### PR TITLE
refactor: remove hoconBoolean, use validate() from ts.hocon/zod

### DIFF
--- a/src/config/application.schema.mts
+++ b/src/config/application.schema.mts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-const hoconBoolean = z.union([z.boolean(), z.stringbool()]);
-
 const collectorSchema = z
 	.object({
 		collector: z.string(),
@@ -17,7 +15,7 @@ export const AppConfigSchema = z.object({
 	oauth: z.object({
 		jwt: z.object({
 			secret: z.string(),
-			validate: hoconBoolean.default(true),
+			validate: z.boolean().default(true),
 		}),
 	}),
 	attribute: z.object({

--- a/src/server/app.mts
+++ b/src/server/app.mts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
-import { parseFileAsync } from "@o3co/ts.hocon";
+import { parseFile } from "@o3co/ts.hocon";
+import { validate } from "@o3co/ts.hocon/zod";
 import express from "express";
 import { PayloadScopeCollector } from "#/collectors/PayloadScopeCollector.mjs";
 import { PayloadSubjectIdCollector } from "#/collectors/PayloadSubjectIdCollector.mjs";
@@ -40,8 +41,7 @@ export interface PolicyVerifierOptions {
 
 export async function createApp(options?: PolicyVerifierOptions): Promise<express.Express> {
 	const confPath = resolve(import.meta.dirname, "../../config/application.conf");
-	const hocon = await parseFileAsync(confPath);
-	const config = AppConfigSchema.parse(hocon.toObject());
+	const config = validate(parseFile(confPath), AppConfigSchema);
 
 	const collectorMap = { ...BUILTIN_COLLECTORS, ...options?.collectors };
 	const ruleCollectorMap = { ...BUILTIN_RULE_COLLECTORS, ...options?.ruleCollectors };


### PR DESCRIPTION
## Summary

- Switch config loading from `parseFileAsync` + `schema.parse()` to `parseFile` + `validate()` from ts.hocon/zod
- Remove `hoconBoolean` workaround — `validate()` handles boolean coercion automatically
- Replace `z.union([z.boolean(), z.stringbool()])` with `z.boolean()`

Closes #2

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 26 files, 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)