### PR TITLE
feat: update collectors to read sub/azp/scope standard claims

### DIFF
--- a/src/collectors/PayloadScopeCollector.mts
+++ b/src/collectors/PayloadScopeCollector.mts
@@ -3,8 +3,8 @@ import type { AttributeCollector, Attributes, CollectorContext } from "#/engine/
 
 export class PayloadScopeCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {
-		const scope = context.payload.scope ?? "";
-		const scopes = scope ? scope.split(" ").filter(Boolean) : [];
+		const scope = context.payload.scope;
+		const scopes = typeof scope === "string" && scope ? scope.split(" ").filter(Boolean) : [];
 		return new Map([[ATTR_SCOPES, scopes]]);
 	}
 }

--- a/src/collectors/PayloadScopeCollector.mts
+++ b/src/collectors/PayloadScopeCollector.mts
@@ -3,7 +3,8 @@ import type { AttributeCollector, Attributes, CollectorContext } from "#/engine/
 
 export class PayloadScopeCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {
-		const scopes = context.payload.scopes ?? [];
-		return new Map([[ATTR_SCOPES, Array.isArray(scopes) ? scopes : [scopes]]]);
+		const scope = context.payload.scope ?? "";
+		const scopes = scope ? scope.split(" ").filter(Boolean) : [];
+		return new Map([[ATTR_SCOPES, scopes]]);
 	}
 }

--- a/src/collectors/PayloadSubjectIdCollector.mts
+++ b/src/collectors/PayloadSubjectIdCollector.mts
@@ -4,11 +4,11 @@ import type { AttributeCollector, Attributes, CollectorContext } from "#/engine/
 export class PayloadSubjectIdCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {
 		const attrs: Attributes = new Map();
-		if (context.payload.user?.id) {
-			attrs.set(ATTR_USER_ID, context.payload.user.id);
+		if (context.payload.sub) {
+			attrs.set(ATTR_USER_ID, context.payload.sub);
 		}
-		if (context.payload.client?.id) {
-			attrs.set(ATTR_CLIENT_ID, context.payload.client.id);
+		if (context.payload.azp) {
+			attrs.set(ATTR_CLIENT_ID, context.payload.azp);
 		}
 		return attrs;
 	}

--- a/src/collectors/__tests__/PayloadScopeCollector.test.mts
+++ b/src/collectors/__tests__/PayloadScopeCollector.test.mts
@@ -3,8 +3,8 @@ import { ATTR_SCOPES } from "#/engine/keys.mjs";
 import type { CollectorContext, VerifierPayload } from "#/engine/types.mjs";
 import { PayloadScopeCollector } from "../PayloadScopeCollector.mjs";
 
-const makeContext = (scopes: string[]): CollectorContext => ({
-	payload: { scopes } satisfies VerifierPayload,
+const makeContext = (scope?: string): CollectorContext => ({
+	payload: { scope } satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
 });
@@ -13,11 +13,11 @@ describe("PayloadScopeCollector", () => {
 	const collector = new PayloadScopeCollector();
 
 	it("extracts scopes from payload", async () => {
-		const attrs = await collector.collect(makeContext(["read:user", "write:doc"]));
+		const attrs = await collector.collect(makeContext("read:user write:doc"));
 		expect(attrs.get(ATTR_SCOPES)).toEqual(["read:user", "write:doc"]);
 	});
 
-	it("returns empty array when scopes missing", async () => {
+	it("returns empty array when scope missing", async () => {
 		const ctx: CollectorContext = {
 			payload: {} satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },

--- a/src/collectors/__tests__/PayloadSubjectIdCollector.test.mts
+++ b/src/collectors/__tests__/PayloadSubjectIdCollector.test.mts
@@ -6,9 +6,9 @@ import { PayloadSubjectIdCollector } from "../PayloadSubjectIdCollector.mjs";
 describe("PayloadSubjectIdCollector", () => {
 	const collector = new PayloadSubjectIdCollector();
 
-	it("extracts userId from payload.user.id", async () => {
+	it("extracts userId from payload.sub", async () => {
 		const ctx: CollectorContext = {
-			payload: { user: { id: "u1" }, scopes: [] } satisfies VerifierPayload,
+			payload: { sub: "u1" } satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 			action: "read",
 		};
@@ -16,9 +16,9 @@ describe("PayloadSubjectIdCollector", () => {
 		expect(attrs.get(ATTR_USER_ID)).toBe("u1");
 	});
 
-	it("extracts clientId from payload.client.id", async () => {
+	it("extracts clientId from payload.azp", async () => {
 		const ctx: CollectorContext = {
-			payload: { client: { id: "c1" }, scopes: [] } satisfies VerifierPayload,
+			payload: { azp: "c1" } satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 			action: "read",
 		};
@@ -26,9 +26,9 @@ describe("PayloadSubjectIdCollector", () => {
 		expect(attrs.get(ATTR_CLIENT_ID)).toBe("c1");
 	});
 
-	it("returns empty map when neither user nor client present", async () => {
+	it("returns empty map when neither sub nor azp present", async () => {
 		const ctx: CollectorContext = {
-			payload: { scopes: [] } satisfies VerifierPayload,
+			payload: {} satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 			action: "read",
 		};

--- a/src/collectors/__tests__/StaticPermissionCollector.test.mts
+++ b/src/collectors/__tests__/StaticPermissionCollector.test.mts
@@ -4,7 +4,7 @@ import type { CollectorContext, VerifierPayload } from "#/engine/types.mjs";
 import { StaticPermissionCollector } from "../StaticPermissionCollector.mjs";
 
 const stubContext: CollectorContext = {
-	payload: { scopes: [] } satisfies VerifierPayload,
+	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
 };

--- a/src/collectors/__tests__/StaticRoleCollector.test.mts
+++ b/src/collectors/__tests__/StaticRoleCollector.test.mts
@@ -4,7 +4,7 @@ import type { CollectorContext, VerifierPayload } from "#/engine/types.mjs";
 import { StaticRoleCollector } from "../StaticRoleCollector.mjs";
 
 const stubContext: CollectorContext = {
-	payload: { scopes: [] } satisfies VerifierPayload,
+	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
 };

--- a/src/engine/__tests__/AttributePipeline.test.mts
+++ b/src/engine/__tests__/AttributePipeline.test.mts
@@ -8,7 +8,7 @@ import type {
 } from "../types.mjs";
 
 const stubContext: CollectorContext = {
-	payload: { scopes: [] } satisfies VerifierPayload,
+	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
 };

--- a/src/engine/__tests__/RulePipeline.test.mts
+++ b/src/engine/__tests__/RulePipeline.test.mts
@@ -3,7 +3,7 @@ import { RulePipeline } from "../RulePipeline.mjs";
 import type { CollectorContext, Rule, RuleCollector, VerifierPayload } from "../types.mjs";
 
 const stubContext: CollectorContext = {
-	payload: { scopes: [] } satisfies VerifierPayload,
+	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
 };

--- a/src/engine/types.mts
+++ b/src/engine/types.mts
@@ -44,9 +44,9 @@ import type { JwtPayload } from "jsonwebtoken";
 export type { JwtPayload };
 
 export interface VerifierPayload extends JwtPayload {
-	scopes?: string[];
-	user?: { id: string; [key: string]: unknown };
-	client?: { id: string; [key: string]: unknown };
+	sub?: string;
+	azp?: string;
+	scope?: string;
 	token?: string;
 	tokenType?: string;
 }

--- a/src/rules/__tests__/ResourceActionPermissionRuleCollector.test.mts
+++ b/src/rules/__tests__/ResourceActionPermissionRuleCollector.test.mts
@@ -7,7 +7,7 @@ describe("ResourceActionPermissionRuleCollector", () => {
 
 	it("creates a HasPermission rule with resource.perm:action", async () => {
 		const ctx: CollectorContext = {
-			payload: { scopes: [] } satisfies VerifierPayload,
+			payload: {} satisfies VerifierPayload,
 			resource: { raw: "document:12345", resourceType: "document", resourceId: "12345" },
 			action: "read",
 		};
@@ -21,7 +21,7 @@ describe("ResourceActionPermissionRuleCollector", () => {
 
 	it("creates correct permission for nested resources", async () => {
 		const ctx: CollectorContext = {
-			payload: { scopes: [] } satisfies VerifierPayload,
+			payload: {} satisfies VerifierPayload,
 			resource: { raw: "project:1.member", resourceType: "project_member" },
 			action: "update",
 		};

--- a/src/rules/__tests__/ResourceActionScopeRuleCollector.test.mts
+++ b/src/rules/__tests__/ResourceActionScopeRuleCollector.test.mts
@@ -3,7 +3,7 @@ import type { CollectorContext, VerifierPayload } from "#/engine/types.mjs";
 import { ResourceActionScopeRuleCollector } from "../ResourceActionScopeRuleCollector.mjs";
 
 const makeContext = (resourceType: string, action: string): CollectorContext => ({
-	payload: { scopes: [] } satisfies VerifierPayload,
+	payload: {} satisfies VerifierPayload,
 	resource: { raw: `${resourceType}:1`, resourceType, resourceId: "1" },
 	action,
 });
@@ -22,7 +22,7 @@ describe("ResourceActionScopeRuleCollector", () => {
 
 	it("creates correct scope for nested resource types", async () => {
 		const ctx: CollectorContext = {
-			payload: { scopes: [] } satisfies VerifierPayload,
+			payload: {} satisfies VerifierPayload,
 			resource: { raw: "project:1.member:2", resourceType: "project_member", resourceId: "2" },
 			action: "update",
 		};

--- a/src/server/__tests__/verify.test.mts
+++ b/src/server/__tests__/verify.test.mts
@@ -29,7 +29,7 @@ describe("POST /verify", () => {
 	const app = createTestApp();
 
 	it("returns allow for valid token with matching scope", async () => {
-		const token = jwt.sign({ scopes: ["read:project"] }, JWT_SECRET);
+		const token = jwt.sign({ scope: "read:project" }, JWT_SECRET);
 		const res = await request(app)
 			.post("/verify")
 			.set("Authorization", `Bearer ${token}`)
@@ -40,7 +40,7 @@ describe("POST /verify", () => {
 	});
 
 	it("returns deny for valid token without matching scope", async () => {
-		const token = jwt.sign({ scopes: ["write:project"] }, JWT_SECRET);
+		const token = jwt.sign({ scope: "write:project" }, JWT_SECRET);
 		const res = await request(app)
 			.post("/verify")
 			.set("Authorization", `Bearer ${token}`)
@@ -69,7 +69,7 @@ describe("POST /verify", () => {
 	});
 
 	it("returns 401 for expired JWT", async () => {
-		const token = jwt.sign({ scopes: ["read:project"] }, JWT_SECRET, { expiresIn: -1 });
+		const token = jwt.sign({ scope: "read:project" }, JWT_SECRET, { expiresIn: -1 });
 		const res = await request(app)
 			.post("/verify")
 			.set("Authorization", `Bearer ${token}`)


### PR DESCRIPTION
## Summary

Update auth.policy-verifier collectors for JWT claims standardization.

- `PayloadSubjectIdCollector`: reads `sub` / `azp` instead of `user.id` / `client.id`
- `PayloadScopeCollector`: reads `scope` (space-separated string) instead of `scopes` (array)
- `VerifierPayload`: updated type definition

Related: o3co/auth.provider#20 (token format change)

## Test plan

- [x] All collector tests updated and passing
- [x] verify.test.mts uses scope string in mock tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)