### PR TITLE
feat: migrate to @o3co/auth.utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "node dist/server/main.mjs"
   },
   "dependencies": {
-    "@o3co/js.util.log": "^0.5.0",
+    "@o3co/auth.utils": "^0.0.1",
     "@o3co/ts.hocon": "^0.1.2",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@o3co/js.util.log':
-        specifier: ^0.5.0
-        version: 0.5.0(pino@10.3.1)
+      '@o3co/auth.utils':
+        specifier: ^0.0.1
+        version: 0.0.1(express@5.2.1)(pino@10.3.1)
       '@o3co/ts.hocon':
         specifier: ^0.1.2
         version: 0.1.3(zod@4.3.6)
@@ -289,10 +289,14 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@o3co/js.util.log@0.5.0':
-    resolution: {integrity: sha512-e/mdt0jOrPL2gFYb3pE3ykJJnhqUK8BN48zpmE9tmUKNbqrEqKyTSif3kMiimclwFIhtBRi14wg6rCpx4HlkVg==, tarball: https://npm.pkg.github.com/download/@o3co/js.util.log/0.5.0/fa1e3cc37212be47088b8d5d64c3b778dffc140c}
+  '@o3co/auth.utils@0.0.1':
+    resolution: {integrity: sha512-4rU9Rhnn1NzUNDMQra8VXs9Qp5mLBbvU8LrQWNsBhzMGPDAlYF80hXaq1EDlURXQ/IvoPEo8etctMOrrq55WJg==, tarball: https://npm.pkg.github.com/download/@o3co/auth.utils/0.0.1/c5e8b3766bafcb010f5c6aea644188356f7ee452}
     peerDependencies:
-      pino: 10.*
+      express: ^5.0.0
+      pino: ^10.0.0
+    peerDependenciesMeta:
+      pino:
+        optional: true
 
   '@o3co/ts.hocon@0.1.3':
     resolution: {integrity: sha512-8+dVbW+ILHSsGrBuaXVEbY/XOavCscQjqBGUqIZKrzuZjotdtbhcpFvK2pkxPBoQ1XWZHYuQaCh66K34grjegA==, tarball: https://npm.pkg.github.com/download/@o3co/ts.hocon/0.1.3/cad4f61fcb4255fc2e42f168b22d5b71f2ec3e68}
@@ -1336,8 +1340,10 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@o3co/js.util.log@0.5.0(pino@10.3.1)':
+  '@o3co/auth.utils@0.0.1(express@5.2.1)(pino@10.3.1)':
     dependencies:
+      express: 5.2.1
+    optionalDependencies:
       pino: 10.3.1
 
   '@o3co/ts.hocon@0.1.3(zod@4.3.6)':
@@ -1350,7 +1356,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@pinojs/redact@0.4.0': {}
+  '@pinojs/redact@0.4.0':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
@@ -1536,7 +1543,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  atomic-sleep@1.0.0: {}
+  atomic-sleep@1.0.0:
+    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -1919,7 +1927,8 @@ snapshots:
 
   obug@2.1.1: {}
 
-  on-exit-leak-free@2.1.2: {}
+  on-exit-leak-free@2.1.2:
+    optional: true
 
   on-finished@2.4.1:
     dependencies:
@@ -1942,8 +1951,10 @@ snapshots:
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
+    optional: true
 
-  pino-std-serializers@7.1.0: {}
+  pino-std-serializers@7.1.0:
+    optional: true
 
   pino@10.3.1:
     dependencies:
@@ -1958,6 +1969,7 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+    optional: true
 
   postcss@8.5.8:
     dependencies:
@@ -1965,7 +1977,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  process-warning@5.0.0: {}
+  process-warning@5.0.0:
+    optional: true
 
   proxy-addr@2.0.7:
     dependencies:
@@ -1976,7 +1989,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  quick-format-unescaped@4.0.4: {}
+  quick-format-unescaped@4.0.4:
+    optional: true
 
   range-parser@1.2.1: {}
 
@@ -1987,7 +2001,8 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  real-require@0.2.0: {}
+  real-require@0.2.0:
+    optional: true
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -2027,7 +2042,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-stable-stringify@2.5.0: {}
+  safe-stable-stringify@2.5.0:
+    optional: true
 
   safer-buffer@2.1.2: {}
 
@@ -2093,10 +2109,12 @@ snapshots:
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
+    optional: true
 
   source-map-js@1.2.1: {}
 
-  split2@4.2.0: {}
+  split2@4.2.0:
+    optional: true
 
   stackback@0.0.2: {}
 
@@ -2129,6 +2147,7 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+    optional: true
 
   tinybench@2.9.0: {}
 

--- a/src/server/app.mts
+++ b/src/server/app.mts
@@ -14,7 +14,7 @@ import type { AttributeCollector, ResourceParser, RuleCollector } from "#/engine
 import { DotNotationResourceParser } from "#/resource/DotNotationResourceParser.mjs";
 import { ResourceActionPermissionRuleCollector } from "#/rules/ResourceActionPermissionRuleCollector.mjs";
 import { ResourceActionScopeRuleCollector } from "#/rules/ResourceActionScopeRuleCollector.mjs";
-import { createHealthcheckRouter } from "./routes/healthcheck.mjs";
+import { createHealthcheckRouter } from "@o3co/auth.utils/express";
 import { createVerifyRouter } from "./routes/verify.mjs";
 
 // biome-ignore lint/suspicious/noExplicitAny: collector constructors accept varied config shapes

--- a/src/server/main.mts
+++ b/src/server/main.mts
@@ -1,13 +1,18 @@
 /*
  * Standalone entrypoint — creates and starts the policy-verifier server.
  */
+import { createLogger, gracefulShutdown } from "@o3co/auth.utils";
 import { createApp } from "./app.mjs";
+
+const logger = createLogger("policy-verifier");
 
 const PORT = Number(process.env.HTTP_PORT ?? 3000);
 const HOSTNAME = process.env.HTTP_HOSTNAME ?? "0.0.0.0";
 
 const app = await createApp();
 
-app.listen(PORT, HOSTNAME, () => {
-	console.log(`policy-verifier listening on http://${HOSTNAME}:${PORT}`);
+const server = app.listen(PORT, HOSTNAME, () => {
+	logger.info(`listening on http://${HOSTNAME}:${PORT}`);
 });
+
+gracefulShutdown(server);

--- a/src/server/routes/healthcheck.mts
+++ b/src/server/routes/healthcheck.mts
@@ -1,9 +1,0 @@
-import express from "express";
-
-export function createHealthcheckRouter(): express.Router {
-	const router = express.Router();
-	router.get("/healthcheck", (_req, res) => {
-		res.status(200).json({ status: "ok" });
-	});
-	return router;
-}


### PR DESCRIPTION
## Summary
- Replace `@o3co/js.util.log` with `@o3co/auth.utils` for structured logging via `createLogger`
- Replace local `createHealthcheckRouter` with the one from `@o3co/auth.utils/express`
- Add `gracefulShutdown` handler to the server entrypoint for clean SIGTERM/SIGINT handling
- Delete `src/server/routes/healthcheck.mts` (now provided by auth.utils)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm vitest run` — all 132 tests pass (28 test files)
- [ ] Manual: verify healthcheck endpoint responds at `/healthcheck`
- [ ] Manual: verify graceful shutdown on SIGTERM

🤖 Generated with [Claude Code](https://claude.com/claude-code)