### PR TITLE
fix: use Node 24 LTS in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############################################
-FROM node:25-alpine AS base
+FROM node:24-alpine AS base
 
 RUN npm install -g corepack --force
 


### PR DESCRIPTION
## Summary
- Replace `node:25-alpine` with `node:24-alpine` in Dockerfile base image
- Node 25 is the current/unstable release line; Node 24 is the active LTS release (codename Krypton)
- Using LTS ensures longer support window and production stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)