### PR TITLE
fix: post-monorepo code cleanup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,7 +57,7 @@ curl -X POST http://localhost:3000/verify \
 
 ## 設定
 
-HOCON 設定ファイル（環境変数でオーバーライド可能）。`createApp` を使用する際は `configPath` オプションが必須。
+HOCON 設定ファイル（環境変数でオーバーライド可能）。`AppConfigSchema` で設定をパースし、結果を `createApp` に渡す。
 
 | 変数 | 説明 | デフォルト |
 | --- | --- | --- |
@@ -102,14 +102,16 @@ export class MyRoleCollector implements AttributeCollector {
 ```typescript
 // main.mts
 import { resolve } from 'node:path'
-import { createApp } from '@o3co/auth.policy-verifier.express'
+import { parseFile } from '@o3co/ts.hocon'
+import { validate } from '@o3co/ts.hocon/zod'
+import { AppConfigSchema, createApp } from '@o3co/auth.policy-verifier.express'
 import { MyRoleCollector } from './collectors/MyRoleCollector.mjs'
 
-const app = await createApp({
-  configPath: resolve(import.meta.dirname, '../config/application.conf'),
-  collectors: { MyRoleCollector },
-})
-app.listen(3000)
+const configPath = resolve(import.meta.dirname, '../config/application.conf')
+const config = validate(parseFile(configPath), AppConfigSchema)
+
+const app = await createApp({ config, collectors: { MyRoleCollector } })
+app.listen(config.http.port, config.http.hostname)
 ```
 
 ```hocon

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Response:
 
 ## Configuration
 
-HOCON config file with environment variable overrides. The `configPath` option is required when using `createApp`.
+HOCON config file with environment variable overrides. Parse the config with `AppConfigSchema` and pass the result to `createApp`.
 
 | Variable | Description | Default |
 | --- | --- | --- |
@@ -102,14 +102,16 @@ export class MyRoleCollector implements AttributeCollector {
 ```typescript
 // main.mts
 import { resolve } from 'node:path'
-import { createApp } from '@o3co/auth.policy-verifier.express'
+import { parseFile } from '@o3co/ts.hocon'
+import { validate } from '@o3co/ts.hocon/zod'
+import { AppConfigSchema, createApp } from '@o3co/auth.policy-verifier.express'
 import { MyRoleCollector } from './collectors/MyRoleCollector.mjs'
 
-const app = await createApp({
-  configPath: resolve(import.meta.dirname, '../config/application.conf'),
-  collectors: { MyRoleCollector },
-})
-app.listen(3000)
+const configPath = resolve(import.meta.dirname, '../config/application.conf')
+const config = validate(parseFile(configPath), AppConfigSchema)
+
+const app = await createApp({ config, collectors: { MyRoleCollector } })
+app.listen(config.http.port, config.http.hostname)
 ```
 
 ```hocon

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "files": {
+    "includes": ["**", "!**/dist/**"]
+  },
   "linter": {
     "enabled": true,
     "rules": {

--- a/create-app/package.json
+++ b/create-app/package.json
@@ -6,7 +6,10 @@
 	"bin": {
 		"create-o3co-policy-verifier": "./dist/cli.mjs"
 	},
-	"files": ["dist", "templates"],
+	"files": [
+		"dist",
+		"templates"
+	],
 	"scripts": {
 		"build": "tsc",
 		"prebuild": "node scripts/copy-templates.mjs"

--- a/create-app/templates/standalone/package.json
+++ b/create-app/templates/standalone/package.json
@@ -18,7 +18,9 @@
 		"@o3co/auth.policy-verifier.foundation": "workspace:*",
 		"@o3co/auth.policy-verifier.express": "workspace:*",
 		"@o3co/auth.utils": "^0.0.1",
-		"express": "^5.2.1"
+		"@o3co/ts.hocon": "^0.1.2",
+		"express": "^5.2.1",
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@types/node": "^25.1.0",

--- a/create-app/templates/standalone/src/main.mts
+++ b/create-app/templates/standalone/src/main.mts
@@ -2,10 +2,10 @@
  * Standalone entrypoint — creates and starts the policy-verifier server.
  */
 import { resolve } from "node:path";
-import { parseFile } from "@o3co/ts.hocon";
-import { validate } from "@o3co/ts.hocon/zod";
 import { AppConfigSchema, createApp } from "@o3co/auth.policy-verifier.express";
 import { createLogger, gracefulShutdown } from "@o3co/auth.utils";
+import { parseFile } from "@o3co/ts.hocon";
+import { validate } from "@o3co/ts.hocon/zod";
 
 const logger = createLogger("policy-verifier");
 

--- a/create-app/templates/standalone/src/main.mts
+++ b/create-app/templates/standalone/src/main.mts
@@ -2,19 +2,20 @@
  * Standalone entrypoint — creates and starts the policy-verifier server.
  */
 import { resolve } from "node:path";
+import { parseFile } from "@o3co/ts.hocon";
+import { validate } from "@o3co/ts.hocon/zod";
+import { AppConfigSchema, createApp } from "@o3co/auth.policy-verifier.express";
 import { createLogger, gracefulShutdown } from "@o3co/auth.utils";
-import { createApp } from "@o3co/auth.policy-verifier.express";
 
 const logger = createLogger("policy-verifier");
 
-const PORT = Number(process.env.HTTP_PORT ?? 3000);
-const HOSTNAME = process.env.HTTP_HOSTNAME ?? "0.0.0.0";
-
 const configPath = resolve(import.meta.dirname, "../config/application.conf");
-const app = await createApp({ configPath });
+const config = validate(parseFile(configPath), AppConfigSchema);
 
-const server = app.listen(PORT, HOSTNAME, () => {
-	logger.info(`listening on http://${HOSTNAME}:${PORT}`);
+const app = await createApp({ config });
+
+const server = app.listen(config.http.port, config.http.hostname, () => {
+	logger.info(`listening on http://${config.http.hostname}:${config.http.port}`);
 });
 
 gracefulShutdown(server);

--- a/create-app/templates/standalone/tsconfig.json
+++ b/create-app/templates/standalone/tsconfig.json
@@ -1,9 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "esnext",
-		"lib": [
-			"esnext"
-		],
+		"lib": ["esnext"],
 		"module": "nodenext",
 		"moduleResolution": "nodenext",
 		"declarationMap": true,
@@ -17,11 +15,6 @@
 		"rootDir": "./src",
 		"outDir": "./dist"
 	},
-	"include": [
-		"src/**/*"
-	],
-	"exclude": [
-		"node_modules",
-		"dist"
-	]
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,11 @@
 			"types": "./dist/index.d.mts"
 		}
 	},
-	"files": ["dist", "LICENSE", "README.md"],
+	"files": [
+		"dist",
+		"LICENSE",
+		"README.md"
+	],
 	"scripts": {
 		"build": "tsc",
 		"test": "vitest run"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -27,7 +27,6 @@
 		"@o3co/auth.policy-verifier.core": "workspace:*",
 		"@o3co/auth.policy-verifier.foundation": "workspace:*",
 		"@o3co/auth.utils": "^0.0.1",
-		"@o3co/ts.hocon": "^0.1.2",
 		"jose": "^6.2.2",
 		"zod": "^4.3.6"
 	},

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -11,7 +11,11 @@
 			"types": "./dist/index.d.mts"
 		}
 	},
-	"files": ["dist", "LICENSE", "README.md"],
+	"files": [
+		"dist",
+		"LICENSE",
+		"README.md"
+	],
 	"scripts": {
 		"build": "tsc",
 		"test": "vitest run"

--- a/packages/express/src/__tests__/verify.test.mts
+++ b/packages/express/src/__tests__/verify.test.mts
@@ -1,24 +1,25 @@
-import express from "express";
-import { SignJWT } from "jose";
-import request from "supertest";
-import { describe, expect, it } from "vitest";
-import { AttributePipeline, type ResourceParser, RulePipeline } from "@o3co/auth.policy-verifier.core";
+import {
+	AttributePipeline,
+	type ResourceParser,
+	RulePipeline,
+} from "@o3co/auth.policy-verifier.core";
 import {
 	DotNotationResourceParser,
 	PayloadScopeCollector,
 	RequestContextCollector,
 	ResourceActionScopeRuleCollector,
 } from "@o3co/auth.policy-verifier.foundation";
+import express from "express";
+import { SignJWT } from "jose";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
 import { createVerifyRouter } from "#/routes/verify.mjs";
 
 const JWT_SECRET = "test-secret";
 const secretKey = new TextEncoder().encode(JWT_SECRET);
 
 async function signToken(payload: Record<string, unknown>): Promise<string> {
-	return new SignJWT(payload)
-		.setProtectedHeader({ alg: "HS256" })
-		.setIssuedAt()
-		.sign(secretKey);
+	return new SignJWT(payload).setProtectedHeader({ alg: "HS256" }).setIssuedAt().sign(secretKey);
 }
 
 function createTestApp(resourceParser?: ResourceParser) {

--- a/packages/express/src/app.mts
+++ b/packages/express/src/app.mts
@@ -1,4 +1,3 @@
-import express from "express";
 import {
 	type AttributeCollector,
 	AttributePipeline,
@@ -11,12 +10,13 @@ import {
 	PayloadScopeCollector,
 	PayloadSubjectIdCollector,
 	RequestContextCollector,
-	StaticPermissionCollector,
-	StaticRoleCollector,
 	ResourceActionPermissionRuleCollector,
 	ResourceActionScopeRuleCollector,
+	StaticPermissionCollector,
+	StaticRoleCollector,
 } from "@o3co/auth.policy-verifier.foundation";
 import { createHealthcheckRouter } from "@o3co/auth.utils/express";
+import express from "express";
 import type { AppConfig } from "./config/application.schema.mjs";
 import { createVerifyRouter } from "./routes/verify.mjs";
 

--- a/packages/express/src/app.mts
+++ b/packages/express/src/app.mts
@@ -1,5 +1,3 @@
-import { parseFile } from "@o3co/ts.hocon";
-import { validate } from "@o3co/ts.hocon/zod";
 import express from "express";
 import {
 	type AttributeCollector,
@@ -19,7 +17,7 @@ import {
 	ResourceActionScopeRuleCollector,
 } from "@o3co/auth.policy-verifier.foundation";
 import { createHealthcheckRouter } from "@o3co/auth.utils/express";
-import { AppConfigSchema } from "./config/application.schema.mjs";
+import type { AppConfig } from "./config/application.schema.mjs";
 import { createVerifyRouter } from "./routes/verify.mjs";
 
 // biome-ignore lint/suspicious/noExplicitAny: collector constructors accept varied config shapes
@@ -41,14 +39,14 @@ const BUILTIN_RULE_COLLECTORS: Record<string, RuleCollectorClass> = {
 };
 
 export interface PolicyVerifierOptions {
-	configPath: string;
+	config: AppConfig;
 	collectors?: Record<string, CollectorClass>;
 	ruleCollectors?: Record<string, RuleCollectorClass>;
 	resourceParser?: ResourceParser;
 }
 
 export async function createApp(options: PolicyVerifierOptions): Promise<express.Express> {
-	const config = validate(parseFile(options.configPath), AppConfigSchema);
+	const { config } = options;
 
 	const collectorMap = { ...BUILTIN_COLLECTORS, ...options.collectors };
 	const ruleCollectorMap = { ...BUILTIN_RULE_COLLECTORS, ...options.ruleCollectors };

--- a/packages/express/src/index.mts
+++ b/packages/express/src/index.mts
@@ -1,3 +1,5 @@
+export type { AppConfig } from "./config/application.schema.mjs";
+export { AppConfigSchema } from "./config/application.schema.mjs";
 export type { PolicyVerifierOptions } from "./app.mjs";
 export { createApp } from "./app.mjs";
 export type { VerifyRouterConfig } from "./routes/verify.mjs";

--- a/packages/express/src/index.mts
+++ b/packages/express/src/index.mts
@@ -1,6 +1,6 @@
-export type { AppConfig } from "./config/application.schema.mjs";
-export { AppConfigSchema } from "./config/application.schema.mjs";
 export type { PolicyVerifierOptions } from "./app.mjs";
 export { createApp } from "./app.mjs";
+export type { AppConfig } from "./config/application.schema.mjs";
+export { AppConfigSchema } from "./config/application.schema.mjs";
 export type { VerifyRouterConfig } from "./routes/verify.mjs";
 export { createVerifyRouter } from "./routes/verify.mjs";

--- a/packages/express/src/routes/verify.mts
+++ b/packages/express/src/routes/verify.mts
@@ -1,5 +1,5 @@
 import express from "express";
-import { jwtVerify, decodeJwt } from "jose";
+import { type JWTPayload, decodeJwt, jwtVerify } from "jose";
 import {
 	type AttributePipeline,
 	evaluate,
@@ -32,9 +32,11 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				return;
 			}
 
+			let decoded: JWTPayload;
 			if (config.jwt.validate) {
 				try {
-					await jwtVerify(token, secretKey, { algorithms: ["HS256"] });
+					const result = await jwtVerify(token, secretKey, { algorithms: ["HS256"] });
+					decoded = result.payload;
 				} catch {
 					res.status(401).json({
 						decision: "deny",
@@ -43,18 +45,17 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 					});
 					return;
 				}
-			}
-
-			let decoded: Record<string, unknown>;
-			try {
-				decoded = decodeJwt(token);
-			} catch {
-				res.status(401).json({
-					decision: "deny",
-					code: "invalid_token",
-					message: "Invalid token",
-				});
-				return;
+			} else {
+				try {
+					decoded = decodeJwt(token);
+				} catch {
+					res.status(401).json({
+						decision: "deny",
+						code: "invalid_token",
+						message: "Invalid token",
+					});
+					return;
+				}
 			}
 
 			const payload: VerifierPayload = {

--- a/packages/express/src/routes/verify.mts
+++ b/packages/express/src/routes/verify.mts
@@ -1,5 +1,3 @@
-import express from "express";
-import { type JWTPayload, decodeJwt, jwtVerify } from "jose";
 import {
 	type AttributePipeline,
 	evaluate,
@@ -7,6 +5,8 @@ import {
 	type RulePipeline,
 	type VerifierPayload,
 } from "@o3co/auth.policy-verifier.core";
+import express from "express";
+import { decodeJwt, type JWTPayload, jwtVerify } from "jose";
 
 export interface VerifyRouterConfig {
 	jwt: { secret: string; validate: boolean };

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -11,7 +11,11 @@
 			"types": "./dist/index.d.mts"
 		}
 	},
-	"files": ["dist", "LICENSE", "README.md"],
+	"files": [
+		"dist",
+		"LICENSE",
+		"README.md"
+	],
 	"scripts": {
 		"build": "tsc",
 		"test": "vitest run"

--- a/packages/foundation/src/__tests__/collectors/PayloadScopeCollector.test.mts
+++ b/packages/foundation/src/__tests__/collectors/PayloadScopeCollector.test.mts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { PayloadScopeCollector } from "#/collectors/PayloadScopeCollector.mjs";
 
 const makeContext = (scope?: string): CollectorContext => ({

--- a/packages/foundation/src/__tests__/collectors/PayloadSubjectIdCollector.test.mts
+++ b/packages/foundation/src/__tests__/collectors/PayloadSubjectIdCollector.test.mts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { ATTR_CLIENT_ID, ATTR_USER_ID } from "@o3co/auth.policy-verifier.core";
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { ATTR_CLIENT_ID, ATTR_USER_ID } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { PayloadSubjectIdCollector } from "#/collectors/PayloadSubjectIdCollector.mjs";
 
 describe("PayloadSubjectIdCollector", () => {

--- a/packages/foundation/src/__tests__/collectors/RequestContextCollector.test.mts
+++ b/packages/foundation/src/__tests__/collectors/RequestContextCollector.test.mts
@@ -1,9 +1,9 @@
 // Copyright 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
-import { ATTR_CLIENT_IP } from "@o3co/auth.policy-verifier.core";
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { ATTR_CLIENT_IP } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { RequestContextCollector } from "#/collectors/RequestContextCollector.mjs";
 
 const makeContext = (requestContext?: Record<string, unknown>): CollectorContext => ({

--- a/packages/foundation/src/__tests__/collectors/StaticPermissionCollector.test.mts
+++ b/packages/foundation/src/__tests__/collectors/StaticPermissionCollector.test.mts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { ATTR_PERMISSIONS } from "@o3co/auth.policy-verifier.core";
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { ATTR_PERMISSIONS } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { StaticPermissionCollector } from "#/collectors/StaticPermissionCollector.mjs";
 
 const stubContext: CollectorContext = {

--- a/packages/foundation/src/__tests__/collectors/StaticRoleCollector.test.mts
+++ b/packages/foundation/src/__tests__/collectors/StaticRoleCollector.test.mts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { StaticRoleCollector } from "#/collectors/StaticRoleCollector.mjs";
 
 const stubContext: CollectorContext = {

--- a/packages/foundation/src/__tests__/rules/HasPermission.test.mts
+++ b/packages/foundation/src/__tests__/rules/HasPermission.test.mts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { HasPermission } from "#/rules/HasPermission.mjs";
 
 describe("HasPermission", () => {

--- a/packages/foundation/src/__tests__/rules/HasScope.test.mts
+++ b/packages/foundation/src/__tests__/rules/HasScope.test.mts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { HasScope } from "#/rules/HasScope.mjs";
 
 describe("HasScope", () => {

--- a/packages/foundation/src/__tests__/rules/ResourceActionPermissionRuleCollector.test.mts
+++ b/packages/foundation/src/__tests__/rules/ResourceActionPermissionRuleCollector.test.mts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { ResourceActionPermissionRuleCollector } from "#/rules/ResourceActionPermissionRuleCollector.mjs";
 
 describe("ResourceActionPermissionRuleCollector", () => {

--- a/packages/foundation/src/__tests__/rules/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/foundation/src/__tests__/rules/ResourceActionScopeRuleCollector.test.mts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
 import { ResourceActionScopeRuleCollector } from "#/rules/ResourceActionScopeRuleCollector.mjs";
 
 const makeContext = (resourceType: string, action: string): CollectorContext => ({

--- a/packages/foundation/src/collectors/PayloadScopeCollector.mts
+++ b/packages/foundation/src/collectors/PayloadScopeCollector.mts
@@ -1,5 +1,9 @@
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorContext,
+} from "@o3co/auth.policy-verifier.core";
 import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
-import type { AttributeCollector, Attributes, CollectorContext } from "@o3co/auth.policy-verifier.core";
 
 export class PayloadScopeCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {

--- a/packages/foundation/src/collectors/PayloadSubjectIdCollector.mts
+++ b/packages/foundation/src/collectors/PayloadSubjectIdCollector.mts
@@ -1,5 +1,9 @@
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorContext,
+} from "@o3co/auth.policy-verifier.core";
 import { ATTR_CLIENT_ID, ATTR_USER_ID } from "@o3co/auth.policy-verifier.core";
-import type { AttributeCollector, Attributes, CollectorContext } from "@o3co/auth.policy-verifier.core";
 
 export class PayloadSubjectIdCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {

--- a/packages/foundation/src/collectors/RequestContextCollector.mts
+++ b/packages/foundation/src/collectors/RequestContextCollector.mts
@@ -1,8 +1,12 @@
 // Copyright 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorContext,
+} from "@o3co/auth.policy-verifier.core";
 import { ATTR_CLIENT_IP } from "@o3co/auth.policy-verifier.core";
-import type { AttributeCollector, Attributes, CollectorContext } from "@o3co/auth.policy-verifier.core";
 
 export class RequestContextCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {

--- a/packages/foundation/src/collectors/StaticPermissionCollector.mts
+++ b/packages/foundation/src/collectors/StaticPermissionCollector.mts
@@ -1,5 +1,9 @@
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorContext,
+} from "@o3co/auth.policy-verifier.core";
 import { ATTR_PERMISSIONS } from "@o3co/auth.policy-verifier.core";
-import type { AttributeCollector, Attributes, CollectorContext } from "@o3co/auth.policy-verifier.core";
 
 export class StaticPermissionCollector implements AttributeCollector {
 	private permissions: string[];

--- a/packages/foundation/src/collectors/StaticRoleCollector.mts
+++ b/packages/foundation/src/collectors/StaticRoleCollector.mts
@@ -1,5 +1,10 @@
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorContext,
+	Role,
+} from "@o3co/auth.policy-verifier.core";
 import { ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
-import type { AttributeCollector, Attributes, CollectorContext, Role } from "@o3co/auth.policy-verifier.core";
 
 export class StaticRoleCollector implements AttributeCollector {
 	private roles: Role[];

--- a/packages/foundation/src/index.mts
+++ b/packages/foundation/src/index.mts
@@ -4,10 +4,10 @@ export { PayloadSubjectIdCollector } from "./collectors/PayloadSubjectIdCollecto
 export { RequestContextCollector } from "./collectors/RequestContextCollector.mjs";
 export { StaticPermissionCollector } from "./collectors/StaticPermissionCollector.mjs";
 export { StaticRoleCollector } from "./collectors/StaticRoleCollector.mjs";
+// Resource
+export { DotNotationResourceParser } from "./resource/DotNotationResourceParser.mjs";
 // Rules
 export { HasPermission } from "./rules/HasPermission.mjs";
 export { HasScope } from "./rules/HasScope.mjs";
 export { ResourceActionPermissionRuleCollector } from "./rules/ResourceActionPermissionRuleCollector.mjs";
 export { ResourceActionScopeRuleCollector } from "./rules/ResourceActionScopeRuleCollector.mjs";
-// Resource
-export { DotNotationResourceParser } from "./resource/DotNotationResourceParser.mjs";

--- a/packages/foundation/src/rules/HasPermission.mts
+++ b/packages/foundation/src/rules/HasPermission.mts
@@ -1,5 +1,5 @@
-import { ATTR_PERMISSIONS, ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 import type { Attributes, Role, Rule } from "@o3co/auth.policy-verifier.core";
+import { ATTR_PERMISSIONS, ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 
 export class HasPermission implements Rule {
 	readonly ruleType = "permission";

--- a/packages/foundation/src/rules/HasScope.mts
+++ b/packages/foundation/src/rules/HasScope.mts
@@ -1,5 +1,5 @@
-import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 
 export class HasScope implements Rule {
 	readonly ruleType = "scope";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,9 +97,15 @@ importers:
       '@o3co/auth.utils':
         specifier: ^0.0.1
         version: 0.0.1(express@5.2.1)(pino@10.3.1)
+      '@o3co/ts.hocon':
+        specifier: ^0.1.2
+        version: 0.1.3(zod@4.3.6)
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^25.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       '@o3co/auth.utils':
         specifier: ^0.0.1
         version: 0.0.1(express@5.2.1)(pino@10.3.1)
-      '@o3co/ts.hocon':
-        specifier: ^0.1.2
-        version: 0.1.3(zod@4.3.6)
       jose:
         specifier: ^6.2.2
         version: 6.2.2

--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -18,7 +18,9 @@
 		"@o3co/auth.policy-verifier.foundation": "workspace:*",
 		"@o3co/auth.policy-verifier.express": "workspace:*",
 		"@o3co/auth.utils": "^0.0.1",
-		"express": "^5.2.1"
+		"@o3co/ts.hocon": "^0.1.2",
+		"express": "^5.2.1",
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@types/node": "^25.1.0",

--- a/templates/standalone/src/main.mts
+++ b/templates/standalone/src/main.mts
@@ -2,10 +2,10 @@
  * Standalone entrypoint — creates and starts the policy-verifier server.
  */
 import { resolve } from "node:path";
-import { parseFile } from "@o3co/ts.hocon";
-import { validate } from "@o3co/ts.hocon/zod";
 import { AppConfigSchema, createApp } from "@o3co/auth.policy-verifier.express";
 import { createLogger, gracefulShutdown } from "@o3co/auth.utils";
+import { parseFile } from "@o3co/ts.hocon";
+import { validate } from "@o3co/ts.hocon/zod";
 
 const logger = createLogger("policy-verifier");
 

--- a/templates/standalone/src/main.mts
+++ b/templates/standalone/src/main.mts
@@ -2,19 +2,20 @@
  * Standalone entrypoint — creates and starts the policy-verifier server.
  */
 import { resolve } from "node:path";
+import { parseFile } from "@o3co/ts.hocon";
+import { validate } from "@o3co/ts.hocon/zod";
+import { AppConfigSchema, createApp } from "@o3co/auth.policy-verifier.express";
 import { createLogger, gracefulShutdown } from "@o3co/auth.utils";
-import { createApp } from "@o3co/auth.policy-verifier.express";
 
 const logger = createLogger("policy-verifier");
 
-const PORT = Number(process.env.HTTP_PORT ?? 3000);
-const HOSTNAME = process.env.HTTP_HOSTNAME ?? "0.0.0.0";
-
 const configPath = resolve(import.meta.dirname, "../config/application.conf");
-const app = await createApp({ configPath });
+const config = validate(parseFile(configPath), AppConfigSchema);
 
-const server = app.listen(PORT, HOSTNAME, () => {
-	logger.info(`listening on http://${HOSTNAME}:${PORT}`);
+const app = await createApp({ config });
+
+const server = app.listen(config.http.port, config.http.hostname, () => {
+	logger.info(`listening on http://${config.http.hostname}:${config.http.port}`);
 });
 
 gracefulShutdown(server);


### PR DESCRIPTION
## Summary

- Exclude `dist/` from biome lint (eliminate 100+ false errors from compiled output)
- Move config parsing out of `createApp` into caller — single source of truth via HOCON config
- Eliminate double JWT decode when validation is enabled (use `jwtVerify` result directly)
- Auto-fix import sorting and JSON formatting across all packages

## Interface change

`PolicyVerifierOptions.configPath: string` → `PolicyVerifierOptions.config: AppConfig`

`AppConfigSchema` and `AppConfig` type are now exported from `@o3co/auth.policy-verifier.express`.

## Test plan

- [x] All 66 tests pass (core: 16, foundation: 43, express: 7)
- [x] `pnpm lint` passes with zero errors
- [x] `pnpm build` succeeds across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)