### PR TITLE
fix: update @o3co/auth.utils to ^0.0.2

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@o3co/auth.policy-verifier.core": "workspace:*",
 		"@o3co/auth.policy-verifier.foundation": "workspace:*",
-		"@o3co/auth.utils": "^0.0.1",
+		"@o3co/auth.utils": "^0.0.2",
 		"@o3co/ts.hocon": "^0.1.2",
 		"jose": "^6.2.2",
 		"zod": "^4.3.6"


### PR DESCRIPTION
## Summary
- Update `@o3co/auth.utils` from `^0.0.1` to `^0.0.2`
- 0.0.1 had GitHub Packages tarball URL in npm metadata

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)