### PR TITLE
fix: cross-platform prebuild, module resolution docs, release idempotency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
       - run: pnpm build
       - run: pnpm test
 
-      - name: Publish packages
-        run: pnpm -r publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+      - name: Publish packages
+        run: pnpm -r publish --access public --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,21 @@
 - Never write production code without a failing test that demands it.
 - If code was written before its test, delete it and start over from the test.
 - When generating implementation plans, every task must include explicit RED → GREEN → REFACTOR steps.
+
+## Module Resolution
+
+Each package uses Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) with a conditional `development` / `default` mapping:
+
+```json
+"imports": {
+  "#/*": {
+    "development": "./src/*",
+    "default": "./dist/*"
+  }
+}
+```
+
+- **Tests (vitest):** Vite 8+ includes `"development|production"` in its default resolve conditions. During `vitest run`, `isProduction=false` causes it to expand to `"development"`, resolving `#/*` to `./src/*`. This is an implicit dependency on Vite's resolver — Node.js does not enable the `development` condition natively.
+- **Published packages:** Consumers resolve `#/*` via the `"default"` condition to `./dist/*`.
+- **Local dev server:** The standalone template uses `NODE_OPTIONS='--conditions=development'` to explicitly activate the condition.
+- **Cross-package references** (e.g., `builtins` importing from `core`) go through `exports`, which always point to `./dist/`. Run `pnpm -r run build` before running tests in downstream packages.

--- a/create-app/templates/standalone/package.json
+++ b/create-app/templates/standalone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@o3co/auth-policy-verifier-standalone",
-	"version": "0.1.0",
+	"version": "0.0.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"packageManager": "pnpm@10.29.3",

--- a/create-app/templates/versions.json
+++ b/create-app/templates/versions.json
@@ -1,5 +1,5 @@
 {
-	"@o3co/auth.policy-verifier.core": "0.1.0",
-	"@o3co/auth.policy-verifier.builtins": "0.1.0",
-	"@o3co/auth.policy-verifier.server": "0.1.0"
+	"@o3co/auth.policy-verifier.core": "0.0.0",
+	"@o3co/auth.policy-verifier.builtins": "0.0.0",
+	"@o3co/auth.policy-verifier.server": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.14",
+		"rimraf": "^6.1.3",
 		"typedoc": "^0.28.19",
 		"typescript": "^5.9.3"
 	}

--- a/packages/builtins/package.json
+++ b/packages/builtins/package.json
@@ -22,11 +22,15 @@
 		"directory": "packages/builtins"
 	},
 	"scripts": {
+		"prebuild": "rm -rf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},
 	"imports": {
-		"#/*": "./src/*"
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
 	},
 	"dependencies": {
 		"@o3co/auth.policy-verifier.core": "workspace:*"

--- a/packages/builtins/package.json
+++ b/packages/builtins/package.json
@@ -22,7 +22,7 @@
 		"directory": "packages/builtins"
 	},
 	"scripts": {
-		"prebuild": "rm -rf dist",
+		"prebuild": "rimraf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,11 +22,15 @@
 		"directory": "packages/core"
 	},
 	"scripts": {
+		"prebuild": "rm -rf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},
 	"imports": {
-		"#/*": "./src/*"
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
 	},
 	"devDependencies": {
 		"@types/node": "^25.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
 		"directory": "packages/core"
 	},
 	"scripts": {
-		"prebuild": "rm -rf dist",
+		"prebuild": "rimraf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,7 @@
 		"directory": "packages/server"
 	},
 	"scripts": {
-		"prebuild": "rm -rf dist",
+		"prebuild": "rimraf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,11 +22,15 @@
 		"directory": "packages/server"
 	},
 	"scripts": {
+		"prebuild": "rm -rf dist",
 		"build": "tsc",
 		"test": "vitest run"
 	},
 	"imports": {
-		"#/*": "./src/*"
+		"#/*": {
+			"development": "./src/*",
+			"default": "./dist/*"
+		}
 	},
 	"dependencies": {
 		"@o3co/auth.policy-verifier.core": "workspace:*",


### PR DESCRIPTION
## Summary
- Replace `rm -rf dist` with `rimraf dist` in prebuild scripts (cross-platform compatibility)
- Add `rimraf` as workspace devDependency
- Document module resolution conventions in AGENTS.md (`development` condition, Vite 8 dependency, cross-package exports)
- Move GitHub Release step before npm publish in release workflow for idempotent re-runs

## Context
Review of Codex commit `4122ca1` ("Fix package import resolution for published builds") surfaced these improvements.

## Test plan
- [x] `pnpm -r run build` — all packages build with `rimraf dist` prebuild
- [x] `pnpm -r run test` — 103 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)