### PR TITLE
fix: Node 24 + OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Get pnpm store path
         id: pnpm-store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get pnpm store path
@@ -68,8 +68,6 @@ jobs:
       - name: Publish packages
         if: steps.npm_check.outputs.skip != 'true'
         run: pnpm -r publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Upgrade Node.js 22 → 24 across all workflows (CI + release)
- Node 24 ships npm 11.x+ with native OIDC Trusted Publishing support
- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` secret — OIDC handles npm auth automatically via `id-token: write` permission

## Context
Release workflows were failing with `ENEEDAUTH` because `NPM_TOKEN` secret was not set. With Trusted Publishers configured on npm, OIDC authentication is the correct approach.

## Test plan
- [x] CI should pass with Node 24
- [ ] Release workflow should publish via OIDC (verify on next tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)