### PR TITLE
fix: docs workflow — pnpm run docs, Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
       - run: pnpm install
-      - run: pnpm build
-      - run: pnpm docs
+      - run: pnpm run build
+      - run: pnpm run docs
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/api


### PR DESCRIPTION
## Summary
- Use `pnpm run docs` instead of `pnpm docs` (avoids npm built-in `docs` command that tries to open a browser)
- Upgrade Node.js to 24 (consistent with other workflows)

## Context
Deploy API Docs workflow was failing with `xdg-open: no method available` because `pnpm docs` fell back to npm's built-in `docs` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)