### PR TITLE
fix: skip scope rule generation for scopeless JWTs (#27)

### DIFF
--- a/packages/builtins/src/__tests__/rules/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/ResourceActionScopeRuleCollector.test.mts
@@ -2,8 +2,8 @@ import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifi
 import { describe, expect, it } from "vitest";
 import { ResourceActionScopeRuleCollector } from "#/rules/ResourceActionScopeRuleCollector.mjs";
 
-const makeContext = (resourceType: string, action: string): CollectorContext => ({
-	payload: {} satisfies VerifierPayload,
+const makeContext = (resourceType: string, action: string, scope?: string): CollectorContext => ({
+	payload: { ...(scope !== undefined ? { scope } : {}) } satisfies VerifierPayload,
 	resource: { raw: `${resourceType}:1`, resourceType, resourceId: "1" },
 	action,
 });
@@ -12,7 +12,7 @@ describe("ResourceActionScopeRuleCollector", () => {
 	const collector = new ResourceActionScopeRuleCollector();
 
 	it("creates a HasScope rule with action:resourceType", async () => {
-		const rules = await collector.collect(makeContext("document", "read"));
+		const rules = await collector.collect(makeContext("document", "read", "read:document"));
 		expect(rules).toHaveLength(1);
 		expect(rules[0].ruleType).toBe("scope");
 
@@ -22,12 +22,36 @@ describe("ResourceActionScopeRuleCollector", () => {
 
 	it("creates correct scope for nested resource types", async () => {
 		const ctx: CollectorContext = {
-			payload: {} satisfies VerifierPayload,
+			payload: { scope: "update:project_member" } satisfies VerifierPayload,
 			resource: { raw: "project:1.member:2", resourceType: "project_member", resourceId: "2" },
 			action: "update",
 		};
 		const rules = await collector.collect(ctx);
+		expect(rules).toHaveLength(1);
 		const attrs = new Map([["scopes", ["update:project_member"]]]);
 		expect(rules[0].verify(attrs)).toBe(true);
+	});
+
+	it("returns no rules when payload has no scope claim", async () => {
+		const ctx = makeContext("document", "read");
+		// payload has no scope — simulates DID JWT
+		const rules = await collector.collect(ctx);
+		expect(rules).toHaveLength(0);
+	});
+
+	it("returns HasScope rule when payload has scope claim", async () => {
+		const ctx: CollectorContext = {
+			payload: { scope: "read:document" } satisfies VerifierPayload,
+			resource: { raw: "document:1", resourceType: "document", resourceId: "1" },
+			action: "read",
+		};
+		const rules = await collector.collect(ctx);
+		expect(rules).toHaveLength(1);
+		expect(rules[0].ruleType).toBe("scope");
+	});
+
+	it("still generates HasScope rule when scope is empty string", async () => {
+		const rules = await collector.collect(makeContext("document", "read", ""));
+		expect(rules).toHaveLength(1);
 	});
 });

--- a/packages/builtins/src/rules/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/ResourceActionScopeRuleCollector.mts
@@ -1,8 +1,20 @@
 import type { CollectorContext, Rule, RuleCollector } from "@o3co/auth.policy-verifier.core";
 import { HasScope } from "./HasScope.mjs";
 
+/**
+ * Generates a HasScope rule derived from the request action and resource type.
+ *
+ * When the JWT payload has no `scope` claim (e.g. DID-grant tokens), no rules
+ * are generated. The scope rule group is therefore absent from AND-evaluation,
+ * allowing other rule groups to decide independently.
+ *
+ * OAuth JWTs that carry a `scope` claim are validated as before.
+ */
 export class ResourceActionScopeRuleCollector implements RuleCollector {
 	async collect(context: CollectorContext): Promise<Rule[]> {
+		if (context.payload.scope === undefined) {
+			return [];
+		}
 		const scope = `${context.action}:${context.resource.resourceType}`;
 		return [new HasScope(scope)];
 	}

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -267,6 +267,33 @@ describe("POST /verify — Bearer scheme validation (#17)", () => {
 	});
 });
 
+describe("POST /verify — scopeless JWT (DID grant) (#27)", () => {
+	const app = createTestApp();
+
+	it("returns allow for valid token without scope claim", async () => {
+		const token = await signHS256Token({ sub: "did:example:123" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(200);
+		expect(res.body.decision).toBe("allow");
+	});
+
+	it("still denies when scope claim is present but does not match", async () => {
+		const token = await signHS256Token({ sub: "did:example:123", scope: "write:project" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("invalid_scope");
+	});
+});
+
 describe("POST /verify — request body validation (#18)", () => {
 	const app = createTestApp();
 


### PR DESCRIPTION
## Summary

- `ResourceActionScopeRuleCollector` now returns `[]` when `payload.scope === undefined` (e.g. DID-grant JWTs)
- Scope rule group is absent from AND-evaluation, so other rule groups decide independently
- Uses strict `=== undefined` — empty-string scope (malformed token) still triggers enforcement
- Fixes #27

## Related

- o3co/auth.provider#56 (Won't Fix) — `scopeResolver` rejected for DID grant: IdP does AuthN only, scope belongs to policy-verifier

## Test plan

- [x] Unit: scope absent → no rules generated
- [x] Unit: scope present → HasScope rule generated (existing behavior)
- [x] Unit: scope empty string → HasScope rule still generated (not bypassed)
- [x] Unit: nested resource types → `toHaveLength(1)` assertion added
- [x] Integration: scopeless JWT → 200 allow
- [x] Integration: scope present but wrong → 403 deny
- [x] Full test suite: 87 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)