### PR TITLE
feat(builtins): add AttrMatchRule — generic equality predicate over attributes

### DIFF
--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -55,12 +55,13 @@ new HasScope(scope: string)
 ### AttrMatchRule
 
 ```ts
-new AttrMatchRule({ a: string, b: string })
+new AttrMatchRule({ a: string, b: string, group?: string })
 ```
 
-- `ruleType`: `"attr_match"`、`code`: `"attr_mismatch"`。
+- `code`: `"attr_mismatch"`。
 - `attrs.get(a)` と `attrs.get(b)` がいずれも非空文字列かつ等しいときに `true` を返します。それ以外はすべて `false`（fail closed）。
 - 純粋な述語です。`CollectorContext` を参照しません。比較対象の値はプロジェクト側の上流 `AttributeCollector` が attrs に格納し、プロジェクト側の `RuleCollector` でこの Rule を構築します。
+- `ruleType` の既定値は `"attr_match:${a}:${b}"` です。評価器は `ruleType` 内で OR、`ruleType` 間で AND を取るので、この既定値により異なる2つの比較は AND（両方必要）として扱われます。2つの比較を OR 結合したい場合（例「DID または email で一致」）は、両方の Rule に同じ `group` を指定してください。その `group` 値が `ruleType` として使われます。
 
 ## Rule Collectors
 

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -52,6 +52,16 @@ new HasScope(scope: string)
 - `ATTR_SCOPES` 内のプレフィックスなし scope 文字列（例: `"resource"`）は、比較前に `"read:resource"` へ正規化されます。
 - 正規化後に大文字・小文字を区別しない完全一致で比較します。
 
+### AttrMatchRule
+
+```ts
+new AttrMatchRule({ a: string, b: string })
+```
+
+- `ruleType`: `"attr_match"`、`code`: `"attr_mismatch"`。
+- `attrs.get(a)` と `attrs.get(b)` がいずれも非空文字列かつ等しいときに `true` を返します。それ以外はすべて `false`（fail closed）。
+- 純粋な述語です。`CollectorContext` を参照しません。比較対象の値はプロジェクト側の上流 `AttributeCollector` が attrs に格納し、プロジェクト側の `RuleCollector` でこの Rule を構築します。
+
 ## Rule Collectors
 
 | 名前 | 導出する permission / scope | 返り値 |

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -55,12 +55,13 @@ new HasScope(scope: string)
 ### AttrMatchRule
 
 ```ts
-new AttrMatchRule({ a: string, b: string })
+new AttrMatchRule({ a: string, b: string, group?: string })
 ```
 
-- `ruleType`: `"attr_match"`, `code`: `"attr_mismatch"`.
-- Passes when both `attrs.get(a)` and `attrs.get(b)` are non-empty strings and equal. Any other case returns `false` (fail closed).
+- `code`: `"attr_mismatch"`.
+- Passes when `attrs.get(a)` and `attrs.get(b)` are both non-empty strings and equal. Any other case returns `false` (fail closed).
 - Pure predicate — does not read `CollectorContext`. Consuming projects provide the two values to compare through upstream `AttributeCollector`s and wire the rule through their own `RuleCollector`.
+- `ruleType` defaults to `"attr_match:${a}:${b}"`. The evaluator ORs rules within a `ruleType` and ANDs across different `ruleType`s, so the default ensures two independent comparisons are AND-combined (required together). Pass `group` explicitly when you want two comparisons to be OR-combined (for example, "identify by DID or by email") — both rules then share the provided `group` as their `ruleType`.
 
 ## Rule Collectors
 

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -52,6 +52,16 @@ new HasScope(scope: string)
 - A bare scope string `"resource"` in `ATTR_SCOPES` is normalized to `"read:resource"` before comparison.
 - Matching is case-insensitive exact match after normalization.
 
+### AttrMatchRule
+
+```ts
+new AttrMatchRule({ a: string, b: string })
+```
+
+- `ruleType`: `"attr_match"`, `code`: `"attr_mismatch"`.
+- Passes when both `attrs.get(a)` and `attrs.get(b)` are non-empty strings and equal. Any other case returns `false` (fail closed).
+- Pure predicate — does not read `CollectorContext`. Consuming projects provide the two values to compare through upstream `AttributeCollector`s and wire the rule through their own `RuleCollector`.
+
 ## Rule Collectors
 
 | Name | Derives permission/scope | Returns |

--- a/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
@@ -71,9 +71,13 @@ describe("AttrMatchRule", () => {
 		expect(rule.code).toBe("attr_mismatch");
 	});
 
-	it("message mentions both attribute keys and starts with a capital letter", () => {
+	it("message describes the contract (both attrs must be non-empty strings and equal)", () => {
+		// The message should make the rule's contract explicit, not just say "do not match",
+		// because verify() fails closed on missing, non-string, and empty inputs too.
 		expect(rule.message).toContain("x");
 		expect(rule.message).toContain("y");
+		expect(rule.message).toMatch(/non-empty/i);
+		expect(rule.message).toMatch(/equal/i);
 		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
 	});
 });

--- a/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
@@ -47,13 +47,33 @@ describe("AttrMatchRule", () => {
 		expect(rule.verify(attrs)).toBe(false);
 	});
 
-	it("has ruleType 'attr_match' and code 'attr_mismatch'", () => {
-		expect(rule.ruleType).toBe("attr_match");
+	it("derives ruleType from the pair of attribute keys by default", () => {
+		// Distinct pairs must produce distinct ruleType values. Otherwise
+		// evaluate() would OR them together within a single group, which
+		// weakens "require both comparisons to pass" intent.
+		const r1 = new AttrMatchRule({ a: "userId", b: "sub" });
+		const r2 = new AttrMatchRule({ a: "orgId", b: "org" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+		expect(r1.ruleType).toContain("userId");
+		expect(r1.ruleType).toContain("sub");
+	});
+
+	it("uses the provided group override when set, to enable explicit grouping", () => {
+		// When callers want two comparisons to be OR'd together (e.g. match by
+		// either DID or email), they opt in by passing the same `group`.
+		const r1 = new AttrMatchRule({ a: "x", b: "y", group: "identity" });
+		const r2 = new AttrMatchRule({ a: "e", b: "f", group: "identity" });
+		expect(r1.ruleType).toBe("identity");
+		expect(r2.ruleType).toBe("identity");
+	});
+
+	it("has code 'attr_mismatch'", () => {
 		expect(rule.code).toBe("attr_mismatch");
 	});
 
-	it("message mentions both attribute keys", () => {
+	it("message mentions both attribute keys and starts with a capital letter", () => {
 		expect(rule.message).toContain("x");
 		expect(rule.message).toContain("y");
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
 	});
 });

--- a/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
@@ -1,0 +1,59 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrMatchRule } from "#/rules/AttrMatchRule.mjs";
+
+describe("AttrMatchRule", () => {
+	const rule = new AttrMatchRule({ a: "x", b: "y" });
+
+	it("returns true when both attrs are non-empty strings and equal", () => {
+		const attrs: Attributes = new Map([
+			["x", "same"],
+			["y", "same"],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns false when the two attrs differ", () => {
+		const attrs: Attributes = new Map([
+			["x", "foo"],
+			["y", "bar"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when the first attr is missing", () => {
+		const attrs: Attributes = new Map([["y", "same"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when the second attr is missing", () => {
+		const attrs: Attributes = new Map([["x", "same"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when either attr is a non-string value", () => {
+		const attrs: Attributes = new Map<string, unknown>([
+			["x", 42],
+			["y", 42],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when either attr is an empty string", () => {
+		const attrs: Attributes = new Map([
+			["x", ""],
+			["y", ""],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("has ruleType 'attr_match' and code 'attr_mismatch'", () => {
+		expect(rule.ruleType).toBe("attr_match");
+		expect(rule.code).toBe("attr_mismatch");
+	});
+
+	it("message mentions both attribute keys", () => {
+		expect(rule.message).toContain("x");
+		expect(rule.message).toContain("y");
+	});
+});

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -8,6 +8,7 @@ export { builtinCollectorsModule } from "./module.mjs";
 // Resource
 export { DotNotationResourceParser } from "./resource/DotNotationResourceParser.mjs";
 // Rules
+export { AttrMatchRule, type AttrMatchRuleConfig } from "./rules/AttrMatchRule.mjs";
 export { HasPermission } from "./rules/HasPermission.mjs";
 export { HasScope } from "./rules/HasScope.mjs";
 export { ResourceActionPermissionRuleCollector } from "./rules/ResourceActionPermissionRuleCollector.mjs";

--- a/packages/builtins/src/rules/AttrMatchRule.mts
+++ b/packages/builtins/src/rules/AttrMatchRule.mts
@@ -3,31 +3,51 @@ import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 export interface AttrMatchRuleConfig {
 	a: string;
 	b: string;
+	/**
+	 * Optional grouping key used as `ruleType`. See the class comment for
+	 * how this interacts with the evaluator's OR-within-group /
+	 * AND-across-groups semantics.
+	 */
+	group?: string;
 }
 
 /**
  * Rule that passes when two named attributes are present, are non-empty
  * strings, and are equal. A pure predicate over the attributes map —
- * callers provide both attribute keys via configuration, and the rule
- * neither reads nor closes over `CollectorContext`.
+ * `verify(attrs)` does not touch `CollectorContext` and does not close
+ * over request state.
  *
- * Typical use: a consuming project's `RuleCollector` collects the two
- * values to compare through its own `AttributeCollector`s (for example,
- * a JWT-subject collector and a request-context-field collector) and
- * produces an `AttrMatchRule` parameterised with their keys.
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. If every `AttrMatchRule` shared one fixed `ruleType`,
+ * two instances collected for different comparisons (e.g. subject vs.
+ * subscriber AND tenant vs. request-tenant) would be OR'd together and
+ * authorization would weaken silently.
+ *
+ * To default to the safe reading of "each distinct pair of attributes
+ * is a separate AND-combined requirement", `ruleType` is derived from
+ * `a` and `b` when `group` is not given: `attr_match:{a}:{b}`.
+ *
+ * When callers actually want two comparisons to be OR-combined
+ * (alternative identities, for example), they opt in explicitly by
+ * passing the same `group` to both rule instances.
  */
 export class AttrMatchRule implements Rule {
-	readonly ruleType = "attr_match";
+	readonly ruleType: string;
 	readonly code = "attr_mismatch";
 	readonly message: string;
 
 	constructor(private readonly config: AttrMatchRuleConfig) {
-		this.message = `attributes ${config.a} and ${config.b} do not match`;
+		this.ruleType = config.group ?? `attr_match:${config.a}:${config.b}`;
+		this.message = `Attributes ${config.a} and ${config.b} do not match.`;
 	}
 
 	verify(attrs: Attributes): boolean {
 		const a = attrs.get(this.config.a);
 		const b = attrs.get(this.config.b);
-		return typeof a === "string" && a.length > 0 && typeof b === "string" && a === b;
+		if (typeof a !== "string" || a.length === 0) return false;
+		if (typeof b !== "string" || b.length === 0) return false;
+		return a === b;
 	}
 }

--- a/packages/builtins/src/rules/AttrMatchRule.mts
+++ b/packages/builtins/src/rules/AttrMatchRule.mts
@@ -40,7 +40,7 @@ export class AttrMatchRule implements Rule {
 
 	constructor(private readonly config: AttrMatchRuleConfig) {
 		this.ruleType = config.group ?? `attr_match:${config.a}:${config.b}`;
-		this.message = `Attributes ${config.a} and ${config.b} do not match.`;
+		this.message = `Attribute constraint not satisfied: ${config.a} and ${config.b} must both be non-empty strings and equal.`;
 	}
 
 	verify(attrs: Attributes): boolean {

--- a/packages/builtins/src/rules/AttrMatchRule.mts
+++ b/packages/builtins/src/rules/AttrMatchRule.mts
@@ -1,0 +1,33 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+
+export interface AttrMatchRuleConfig {
+	a: string;
+	b: string;
+}
+
+/**
+ * Rule that passes when two named attributes are present, are non-empty
+ * strings, and are equal. A pure predicate over the attributes map —
+ * callers provide both attribute keys via configuration, and the rule
+ * neither reads nor closes over `CollectorContext`.
+ *
+ * Typical use: a consuming project's `RuleCollector` collects the two
+ * values to compare through its own `AttributeCollector`s (for example,
+ * a JWT-subject collector and a request-context-field collector) and
+ * produces an `AttrMatchRule` parameterised with their keys.
+ */
+export class AttrMatchRule implements Rule {
+	readonly ruleType = "attr_match";
+	readonly code = "attr_mismatch";
+	readonly message: string;
+
+	constructor(private readonly config: AttrMatchRuleConfig) {
+		this.message = `attributes ${config.a} and ${config.b} do not match`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const a = attrs.get(this.config.a);
+		const b = attrs.get(this.config.b);
+		return typeof a === "string" && a.length > 0 && typeof b === "string" && a === b;
+	}
+}


### PR DESCRIPTION
Closes #30

## Summary

Add a small, framework-neutral Rule that passes when two named attributes are non-empty strings and equal. It is a pure predicate over the attributes map; it does not touch `CollectorContext` and does not close over request state.

The motivation is to give every consuming project a shared primitive for "compare two attrs for equality" instead of each project rolling its own. dplaas.auth will use this to replace its privately-owned SubjectFieldMatchRule.

## API

```ts
import { AttrMatchRule, type AttrMatchRuleConfig } from "@o3co/auth.policy-verifier.builtins";

const rule = new AttrMatchRule({ a: "userId", b: "subscriberDid" });
rule.verify(attrs); // true iff attrs.get("userId") and attrs.get("subscriberDid") are both non-empty strings and equal
```

- `code`: `"attr_mismatch"`.
- Fails closed: missing attrs, non-string values, empty strings, and type mismatches all yield `false`.
- `ruleType` defaults to `"attr_match:${a}:${b}"`. Because the evaluator ORs rules within a `ruleType` and ANDs across `ruleType`s, distinct attribute pairs naturally end up in distinct groups — two AttrMatchRule instances for different comparisons are AND-combined (both required).
- Pass `group` on the config to opt into OR-combining multiple comparisons (e.g. "identify by DID _or_ by email"); both instances then share the provided `group` as their `ruleType`.
- `message` surfaces the full contract ("both be non-empty strings and equal"), since `verify()` fails closed on missing, non-string, and empty inputs, not only on inequality.

## Why not register in `builtinCollectorsModule`?

`AttrMatchRule` is a `Rule`, not a `RuleCollector`. It does not decide when to fire; it just decides when to pass. Consuming projects wire it through their own `RuleCollector` (dispatching on resource/action, or whatever criteria they care about) and choose both attribute keys at construction time.

## Verification

- [x] `pnpm run lint` clean
- [x] `pnpm run build` — all packages build
- [x] `pnpm test` — 113 passing (core 21, builtins 57 including 10 new, server 32, standalone 3)

## Related

- dplaasio/auth#3 / dplaasio/auth#4 — dplaas policy-verifier will consume this in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)