### PR TITLE
feat(builtins): add attribute-based literal/pair comparison rules (#30-family)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "files": {
-    "includes": ["**", "!**/dist/**"]
+    "includes": ["**", "!**/dist", "!create-app/templates"]
   },
   "linter": {
     "enabled": true,

--- a/create-app/package.json
+++ b/create-app/package.json
@@ -4,6 +4,9 @@
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"bin": {
 		"create-o3co-policy-verifier": "./dist/cli.mjs"
 	},

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "pnpm -r run build",
 		"test": "pnpm -r run test",
-		"lint": "biome check packages/ templates/ create-app/",
+		"lint": "biome check packages/ templates/ create-app/ tests/",
 		"docs": "typedoc"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"private": true,
 	"packageManager": "pnpm@10.29.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"scripts": {
 		"build": "pnpm -r run build",
 		"test": "pnpm -r run test",

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -2,6 +2,8 @@
 
 auth.policy-verifier 向けの組み込み attribute collector、rule collector、および resource parser です。
 
+**Runtime:** Node.js 22+。本パッケージは `ruleType` の安定ハッシュ用に `node:crypto` を利用します。browser / edge ランタイム対応は今後の課題として別 issue で追跡します。
+
 ## インストール
 
 ```bash
@@ -105,8 +107,8 @@ new AttrLiteralIn({ a: string, values: (string | number | boolean)[], group?: st
 ```
 
 - `code`: `"attr_not_in_set"`。
-- 既定の `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — `hashPrefix` は `values` をソートして文字列化した内容に対する SHA-256 の先頭 8 桁（例: `attr_literal_in:role:string:2:a1b2c3d4`）。同じ `a` と内容上等価な `values`（順序非依存）を持つ 2 つのインスタンスは同じ `ruleType` を持ち、評価器で OR 結合されます。
-- `values` は非空かつ同種の配列（`string[]`、`number[]`、`boolean[]` のいずれか）でなければなりません。`attrs.get(a)` が集合に含まれるときに通過します。
+- 既定の `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — `count` は重複除去後の要素数、`hashPrefix` は重複除去かつソート済みの `values` を文字列化した内容に対する SHA-256 の先頭 8 桁。同じ `a` と内容上等価な `values`（順序・重複を無視）を持つ 2 つのインスタンスは同じ `ruleType` を持ち、評価器で OR 結合されます。
+- `values` は非空かつ同種の配列（`string[]`、`number[]`、`boolean[]` のいずれか）でなければなりません。`attrs.get(a)` が集合に含まれるときに通過します。`values` 内の重複要素は Rule の挙動に影響しません（内部では `Set` として扱われます）。
 
 ### AttrLiteralNotIn
 
@@ -115,8 +117,8 @@ new AttrLiteralNotIn({ a: string, values: (string | number | boolean)[], group?:
 ```
 
 - `code`: `"attr_in_set"`。
-- 既定の `ruleType`: `` `attr_literal_not_in:${a}:${type}:${count}:${hashPrefix}` `` — `AttrLiteralIn` と同じ安定ハッシュ方式。
-- `values` は非空かつ同種の配列。`attrs.get(a)` が集合に含まれないときに通過します。
+- 既定の `ruleType`: `` `attr_literal_not_in:${a}:${type}:${count}:${hashPrefix}` `` — `AttrLiteralIn` と同じ、重複除去済みの安定ハッシュ方式。
+- `values` は非空かつ同種の配列。`attrs.get(a)` が集合に含まれないときに通過します。`values` 内の重複要素は Rule の挙動に影響しません。
 
 ### AttrLiteralCompare
 

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -54,6 +54,8 @@ new HasScope(scope: string)
 
 ### AttrMatchRule
 
+**非推奨。** 代わりに [`AttrPairEqual`](#attrpairequal) を使用してください。`AttrMatchRule` は `AttrPairEqual` の非推奨エイリアスであり、将来のメジャーバージョンで削除されます。型 `AttrMatchRuleConfig` は `AttrPairEqualConfig` と同じ構造に解決されます。
+
 ```ts
 new AttrMatchRule({ a: string, b: string, group?: string })
 ```
@@ -62,6 +64,103 @@ new AttrMatchRule({ a: string, b: string, group?: string })
 - `attrs.get(a)` と `attrs.get(b)` がいずれも非空文字列かつ等しいときに `true` を返します。それ以外はすべて `false`（fail closed）。
 - 純粋な述語です。`CollectorContext` を参照しません。比較対象の値はプロジェクト側の上流 `AttributeCollector` が attrs に格納し、プロジェクト側の `RuleCollector` でこの Rule を構築します。
 - `ruleType` の既定値は `"attr_match:${a}:${b}"` です。評価器は `ruleType` 内で OR、`ruleType` 間で AND を取るので、この既定値により異なる2つの比較は AND（両方必要）として扱われます。2つの比較を OR 結合したい場合（例「DID または email で一致」）は、両方の Rule に同じ `group` を指定してください。その `group` 値が `ruleType` として使われます。
+
+## Attribute Comparison Rules
+
+属性比較 Rule 群は 2 軸のマトリクスで構成されます: **family**（Literal または Pair）と **operator**（Equal、NotEqual、In、NotIn、Compare）。
+
+- **Literal** Rule は、単一の名前付き属性を、コンストラクタで与えられた静的な値（または値集合）と比較します。
+- **Pair** Rule は、評価時に `Attributes` から解決される 2 つの名前付き属性を互いに比較します。
+- `In` / `NotIn` のバリアントは Literal family のみ提供します。集合に対する Pair 比較は有限リストへ自然に一般化できないため、`AttrPairIn` / `AttrPairNotIn` は意図的に存在しません。
+
+| Family  | Equal              | NotEqual              | In              | NotIn              | Compare              |
+| ------- | ------------------ | --------------------- | --------------- | ------------------ | -------------------- |
+| Literal | `AttrLiteralEqual` | `AttrLiteralNotEqual` | `AttrLiteralIn` | `AttrLiteralNotIn` | `AttrLiteralCompare` |
+| Pair    | `AttrPairEqual`    | `AttrPairNotEqual`    | —               | —                  | `AttrPairCompare`    |
+
+### AttrLiteralEqual
+
+```ts
+new AttrLiteralEqual({ a: string, v: string | number | boolean, group?: string })
+```
+
+- `code`: `"attr_not_equal"`。
+- 既定の `ruleType`: `` `attr_literal_equal:${a}:${String(v)}` ``。
+- `attrs.get(a)` が `v` と同じ型で厳密等価のときに通過します。型の強制変換は行いません。
+
+### AttrLiteralNotEqual
+
+```ts
+new AttrLiteralNotEqual({ a: string, v: string | number | boolean, group?: string })
+```
+
+- `code`: `"attr_equal"`。
+- 既定の `ruleType`: `` `attr_literal_not_equal:${a}:${String(v)}` ``。
+- `attrs.get(a)` が `v` と同じ型で厳密等価でないときに通過します。欠落または型不一致は `false`（safe-deny）を返します。
+
+### AttrLiteralIn
+
+```ts
+new AttrLiteralIn({ a: string, values: (string | number | boolean)[], group?: string })
+```
+
+- `code`: `"attr_not_in_set"`。
+- 既定の `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — `hashPrefix` は `values` をソートして文字列化した内容に対する SHA-256 の先頭 8 桁（例: `attr_literal_in:role:string:2:a1b2c3d4`）。同じ `a` と内容上等価な `values`（順序非依存）を持つ 2 つのインスタンスは同じ `ruleType` を持ち、評価器で OR 結合されます。
+- `values` は非空かつ同種の配列（`string[]`、`number[]`、`boolean[]` のいずれか）でなければなりません。`attrs.get(a)` が集合に含まれるときに通過します。
+
+### AttrLiteralNotIn
+
+```ts
+new AttrLiteralNotIn({ a: string, values: (string | number | boolean)[], group?: string })
+```
+
+- `code`: `"attr_in_set"`。
+- 既定の `ruleType`: `` `attr_literal_not_in:${a}:${type}:${count}:${hashPrefix}` `` — `AttrLiteralIn` と同じ安定ハッシュ方式。
+- `values` は非空かつ同種の配列。`attrs.get(a)` が集合に含まれないときに通過します。
+
+### AttrLiteralCompare
+
+```ts
+new AttrLiteralCompare({ a: string, op: "lt" | "le" | "gt" | "ge", v: number, group?: string })
+```
+
+- `code`: `"attr_compare_violated"`。
+- 既定の `ruleType`: `` `attr_literal_compare:${a}:${op}:${String(v)}` ``。
+- `attrs.get(a)` が数値であり `a op v` を満たすときに通過します。`v` が NaN の場合はコンストラクタ時点で拒否されます。属性側が NaN の場合は常に `false` を返します。
+
+### AttrPairEqual
+
+```ts
+new AttrPairEqual({ a: string, b: string, group?: string })
+```
+
+- `code`: `"attr_mismatch"`。
+- 既定の `ruleType`: `` `attr_pair_equal:${a}:${b}` ``。
+- `attrs.get(a)` と `attrs.get(b)` がいずれも非空文字列かつ厳密等価のときに通過します。非推奨となった `AttrMatchRule` の後継です。
+
+### AttrPairNotEqual
+
+```ts
+new AttrPairNotEqual({ a: string, b: string, group?: string })
+```
+
+- `code`: `"attr_match"`。
+- 既定の `ruleType`: `` `attr_pair_not_equal:${a}:${b}` ``。
+- `attrs.get(a)` と `attrs.get(b)` がいずれも非空文字列かつ厳密等価でないときに通過します。欠落・空文字列・非文字列はすべて `false`（safe-deny）を返します。
+
+### AttrPairCompare
+
+```ts
+new AttrPairCompare({ a: string, op: "lt" | "le" | "gt" | "ge", b: string, group?: string })
+```
+
+- `code`: `"attr_compare_violated"`。
+- 既定の `ruleType`: `` `attr_pair_compare:${a}:${op}:${b}` ``。
+- `attrs.get(a)` と `attrs.get(b)` がいずれも数値で `a op b` を満たすときに通過します。どちらかが NaN の場合は `false` を返します（JS の比較セマンティクス）。
+
+### グルーピング: 既定は AND、OR にするには `group` を指定
+
+属性比較 Rule はすべて、上記 `AttrMatchRule` と同じグルーピング規則に従います。既定では各 Rule の `ruleType` は識別用パラメータから導出されるため、異なる要件は評価器によって AND 結合されます。2 つの Rule に同じ `group` 文字列を渡すと、両者は同じ `ruleType` を持つようになり、評価器は OR 結合します（どちらか一方が成立すれば要件を満たす）。
 
 ## Rule Collectors
 

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -54,7 +54,7 @@ new HasScope(scope: string)
 
 ### AttrMatchRule
 
-**非推奨。** 代わりに [`AttrPairEqual`](#attrpairequal) を使用してください。`AttrMatchRule` は `AttrPairEqual` の非推奨エイリアスであり、将来のメジャーバージョンで削除されます。型 `AttrMatchRuleConfig` は `AttrPairEqualConfig` と同じ構造に解決されます。
+**非推奨。** 代わりに [`AttrPairEqual`](#attrpairequal) を使用してください。`AttrMatchRule` は `AttrPairEqual` を継承した薄いラッパークラスとして残されており、後方互換のため旧来の `ruleType`（`attr_match:${a}:${b}`）と旧来の `message` 文言を保持します。型 `AttrMatchRuleConfig` は `AttrPairEqualConfig` の型エイリアスです。将来のメジャーバージョンで削除されます。
 
 ```ts
 new AttrMatchRule({ a: string, b: string, group?: string })
@@ -85,7 +85,7 @@ new AttrLiteralEqual({ a: string, v: string | number | boolean, group?: string }
 ```
 
 - `code`: `"attr_not_equal"`。
-- 既定の `ruleType`: `` `attr_literal_equal:${a}:${String(v)}` ``。
+- 既定の `ruleType`: `` `attr_literal_equal:${a}:${typeof v}:${String(v)}` ``。`typeof v` セグメントは、文字列化すると同じになる異型リテラル（例: `true` と `"true"`）が同じ `ruleType` に畳み込まれるのを防ぎます。
 - `attrs.get(a)` が `v` と同じ型で厳密等価のときに通過します。型の強制変換は行いません。
 
 ### AttrLiteralNotEqual
@@ -95,7 +95,7 @@ new AttrLiteralNotEqual({ a: string, v: string | number | boolean, group?: strin
 ```
 
 - `code`: `"attr_equal"`。
-- 既定の `ruleType`: `` `attr_literal_not_equal:${a}:${String(v)}` ``。
+- 既定の `ruleType`: `` `attr_literal_not_equal:${a}:${typeof v}:${String(v)}` ``。`typeof v` セグメントは異型リテラル間の衝突を防ぎます（`AttrLiteralEqual` と同じ理由）。
 - `attrs.get(a)` が `v` と同じ型で厳密等価でないときに通過します。欠落または型不一致は `false`（safe-deny）を返します。
 
 ### AttrLiteralIn

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -54,7 +54,7 @@ new HasScope(scope: string)
 
 ### AttrMatchRule
 
-**Deprecated.** Use [`AttrPairEqual`](#attrpairequal) instead. `AttrMatchRule` is a deprecated alias of `AttrPairEqual` and will be removed in a future major version. The type `AttrMatchRuleConfig` resolves to the same shape as `AttrPairEqualConfig`.
+**Deprecated.** Use [`AttrPairEqual`](#attrpairequal) instead. `AttrMatchRule` is kept as a thin wrapper class that extends `AttrPairEqual` and preserves the legacy `ruleType` (`attr_match:${a}:${b}`) and legacy `message` wording for backward compatibility. The type `AttrMatchRuleConfig` is a type alias of `AttrPairEqualConfig`. It will be removed in a future major version.
 
 ```ts
 new AttrMatchRule({ a: string, b: string, group?: string })
@@ -85,7 +85,7 @@ new AttrLiteralEqual({ a: string, v: string | number | boolean, group?: string }
 ```
 
 - `code`: `"attr_not_equal"`.
-- Default `ruleType`: `` `attr_literal_equal:${a}:${String(v)}` ``.
+- Default `ruleType`: `` `attr_literal_equal:${a}:${typeof v}:${String(v)}` ``. The `typeof v` segment prevents silent collisions between distinct-type literals that stringify the same way (e.g. `true` vs `"true"`).
 - Passes when `attrs.get(a)` is the same type and strictly equal to `v`. No type coercion.
 
 ### AttrLiteralNotEqual
@@ -95,7 +95,7 @@ new AttrLiteralNotEqual({ a: string, v: string | number | boolean, group?: strin
 ```
 
 - `code`: `"attr_equal"`.
-- Default `ruleType`: `` `attr_literal_not_equal:${a}:${String(v)}` ``.
+- Default `ruleType`: `` `attr_literal_not_equal:${a}:${typeof v}:${String(v)}` ``. The `typeof v` segment prevents silent collisions between distinct-type literals (same rationale as `AttrLiteralEqual`).
 - Passes when `attrs.get(a)` is the same type as `v` and strictly not equal to it. Missing or wrong-type attributes return `false` (safe-deny).
 
 ### AttrLiteralIn

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -2,6 +2,8 @@
 
 Built-in attribute collectors, rule collectors, and resource parser for auth.policy-verifier.
 
+**Runtime:** Node.js 22+. This package uses `node:crypto` for stable rule-type hashing; browser / edge runtime support is tracked as future work.
+
 ## Install
 
 ```bash
@@ -105,8 +107,8 @@ new AttrLiteralIn({ a: string, values: (string | number | boolean)[], group?: st
 ```
 
 - `code`: `"attr_not_in_set"`.
-- Default `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — where `hashPrefix` is the first 8 hex characters of a SHA-256 over the sorted, stringified values (e.g. `attr_literal_in:role:string:2:a1b2c3d4`). Two instances with the same `a` and logically equivalent `values` (order-independent) share the same `ruleType` and are OR-combined by the evaluator.
-- `values` must be a non-empty, homogeneous array (`string[]`, `number[]`, or `boolean[]`). Passes when `attrs.get(a)` is in the set.
+- Default `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — where `count` is the post-deduplication element count and `hashPrefix` is the first 8 hex characters of a SHA-256 over the deduplicated, sorted, stringified values. Two instances with the same `a` and logically equivalent `values` (duplicates and order do not matter) share the same `ruleType` and are OR-combined by the evaluator.
+- `values` must be a non-empty, homogeneous array (`string[]`, `number[]`, or `boolean[]`). Passes when `attrs.get(a)` is in the set. Duplicate elements in `values` are ignored (the rule uses `Set` semantics internally).
 
 ### AttrLiteralNotIn
 
@@ -115,8 +117,8 @@ new AttrLiteralNotIn({ a: string, values: (string | number | boolean)[], group?:
 ```
 
 - `code`: `"attr_in_set"`.
-- Default `ruleType`: `` `attr_literal_not_in:${a}:${type}:${count}:${hashPrefix}` `` — same stable hash scheme as `AttrLiteralIn`.
-- `values` must be a non-empty, homogeneous array. Passes when `attrs.get(a)` is NOT in the set.
+- Default `ruleType`: `` `attr_literal_not_in:${a}:${type}:${count}:${hashPrefix}` `` — same stable, deduplication-aware hash scheme as `AttrLiteralIn`.
+- `values` must be a non-empty, homogeneous array. Passes when `attrs.get(a)` is NOT in the set. Duplicate elements in `values` are ignored.
 
 ### AttrLiteralCompare
 

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -54,6 +54,8 @@ new HasScope(scope: string)
 
 ### AttrMatchRule
 
+**Deprecated.** Use [`AttrPairEqual`](#attrpairequal) instead. `AttrMatchRule` is a deprecated alias of `AttrPairEqual` and will be removed in a future major version. The type `AttrMatchRuleConfig` resolves to the same shape as `AttrPairEqualConfig`.
+
 ```ts
 new AttrMatchRule({ a: string, b: string, group?: string })
 ```
@@ -62,6 +64,103 @@ new AttrMatchRule({ a: string, b: string, group?: string })
 - Passes when `attrs.get(a)` and `attrs.get(b)` are both non-empty strings and equal. Any other case returns `false` (fail closed).
 - Pure predicate — does not read `CollectorContext`. Consuming projects provide the two values to compare through upstream `AttributeCollector`s and wire the rule through their own `RuleCollector`.
 - `ruleType` defaults to `"attr_match:${a}:${b}"`. The evaluator ORs rules within a `ruleType` and ANDs across different `ruleType`s, so the default ensures two independent comparisons are AND-combined (required together). Pass `group` explicitly when you want two comparisons to be OR-combined (for example, "identify by DID or by email") — both rules then share the provided `group` as their `ruleType`.
+
+## Attribute Comparison Rules
+
+The attribute comparison rules form a 2 × 5 matrix over two axes: **family** (Literal vs. Pair) and **operator** (Equal, NotEqual, In, NotIn, Compare).
+
+- **Literal** rules compare a single named attribute against a static value (or set of values) supplied at construction time.
+- **Pair** rules compare two named attributes resolved from the `Attributes` map at evaluation time.
+- `In` / `NotIn` variants exist for the Literal family only. A pair-over-set operation does not generalize cleanly to a finite list, so `AttrPairIn` / `AttrPairNotIn` are intentionally absent.
+
+| Family  | Equal              | NotEqual              | In              | NotIn              | Compare              |
+| ------- | ------------------ | --------------------- | --------------- | ------------------ | -------------------- |
+| Literal | `AttrLiteralEqual` | `AttrLiteralNotEqual` | `AttrLiteralIn` | `AttrLiteralNotIn` | `AttrLiteralCompare` |
+| Pair    | `AttrPairEqual`    | `AttrPairNotEqual`    | —               | —                  | `AttrPairCompare`    |
+
+### AttrLiteralEqual
+
+```ts
+new AttrLiteralEqual({ a: string, v: string | number | boolean, group?: string })
+```
+
+- `code`: `"attr_not_equal"`.
+- Default `ruleType`: `` `attr_literal_equal:${a}:${String(v)}` ``.
+- Passes when `attrs.get(a)` is the same type and strictly equal to `v`. No type coercion.
+
+### AttrLiteralNotEqual
+
+```ts
+new AttrLiteralNotEqual({ a: string, v: string | number | boolean, group?: string })
+```
+
+- `code`: `"attr_equal"`.
+- Default `ruleType`: `` `attr_literal_not_equal:${a}:${String(v)}` ``.
+- Passes when `attrs.get(a)` is the same type as `v` and strictly not equal to it. Missing or wrong-type attributes return `false` (safe-deny).
+
+### AttrLiteralIn
+
+```ts
+new AttrLiteralIn({ a: string, values: (string | number | boolean)[], group?: string })
+```
+
+- `code`: `"attr_not_in_set"`.
+- Default `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — where `hashPrefix` is the first 8 hex characters of a SHA-256 over the sorted, stringified values (e.g. `attr_literal_in:role:string:2:a1b2c3d4`). Two instances with the same `a` and logically equivalent `values` (order-independent) share the same `ruleType` and are OR-combined by the evaluator.
+- `values` must be a non-empty, homogeneous array (`string[]`, `number[]`, or `boolean[]`). Passes when `attrs.get(a)` is in the set.
+
+### AttrLiteralNotIn
+
+```ts
+new AttrLiteralNotIn({ a: string, values: (string | number | boolean)[], group?: string })
+```
+
+- `code`: `"attr_in_set"`.
+- Default `ruleType`: `` `attr_literal_not_in:${a}:${type}:${count}:${hashPrefix}` `` — same stable hash scheme as `AttrLiteralIn`.
+- `values` must be a non-empty, homogeneous array. Passes when `attrs.get(a)` is NOT in the set.
+
+### AttrLiteralCompare
+
+```ts
+new AttrLiteralCompare({ a: string, op: "lt" | "le" | "gt" | "ge", v: number, group?: string })
+```
+
+- `code`: `"attr_compare_violated"`.
+- Default `ruleType`: `` `attr_literal_compare:${a}:${op}:${String(v)}` ``.
+- Passes when `attrs.get(a)` is a number satisfying `a op v`. NaN as `v` is rejected at construction time. NaN attributes always return `false`.
+
+### AttrPairEqual
+
+```ts
+new AttrPairEqual({ a: string, b: string, group?: string })
+```
+
+- `code`: `"attr_mismatch"`.
+- Default `ruleType`: `` `attr_pair_equal:${a}:${b}` ``.
+- Passes when both `attrs.get(a)` and `attrs.get(b)` are non-empty strings and strictly equal. This is the successor to the deprecated `AttrMatchRule`.
+
+### AttrPairNotEqual
+
+```ts
+new AttrPairNotEqual({ a: string, b: string, group?: string })
+```
+
+- `code`: `"attr_match"`.
+- Default `ruleType`: `` `attr_pair_not_equal:${a}:${b}` ``.
+- Passes when both `attrs.get(a)` and `attrs.get(b)` are non-empty strings and strictly not equal. Missing, empty, or non-string attributes return `false` (safe-deny).
+
+### AttrPairCompare
+
+```ts
+new AttrPairCompare({ a: string, op: "lt" | "le" | "gt" | "ge", b: string, group?: string })
+```
+
+- `code`: `"attr_compare_violated"`.
+- Default `ruleType`: `` `attr_pair_compare:${a}:${op}:${b}` ``.
+- Passes when both `attrs.get(a)` and `attrs.get(b)` are numbers satisfying `a op b`. NaN on either side returns `false` (JS comparison semantics).
+
+### Grouping: AND by default, `group` for OR
+
+All attribute comparison rules follow the same grouping semantics described for `AttrMatchRule` above. By default, each rule's `ruleType` is derived from its distinguishing parameters so that distinct requirements are AND-combined by the evaluator. Pass the same `group` string to two rules to give them the same `ruleType` — the evaluator then OR-combines them (either condition satisfies the requirement).
 
 ## Rule Collectors
 

--- a/packages/builtins/package.json
+++ b/packages/builtins/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"license": "Apache-2.0",
 	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",
 	"exports": {

--- a/packages/builtins/src/__tests__/rules/AttrLiteralCompare.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralCompare.test.mts
@@ -167,8 +167,7 @@ describe("AttrLiteralCompare", () => {
 
 	it("throws when 'a' is undefined", () => {
 		expect(
-			() =>
-				new AttrLiteralCompare({ a: undefined as unknown as string, op: "gt", v: 0 }),
+			() => new AttrLiteralCompare({ a: undefined as unknown as string, op: "gt", v: 0 }),
 		).toThrow(/AttrLiteralCompare.*'a'.*(non-empty string|got undefined)/);
 	});
 
@@ -179,9 +178,9 @@ describe("AttrLiteralCompare", () => {
 	});
 
 	it("throws when 'a' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrLiteralCompare({ a: 42 as unknown as string, op: "gt", v: 0 }),
-		).toThrow(/AttrLiteralCompare.*'a'.*got number/);
+		expect(() => new AttrLiteralCompare({ a: 42 as unknown as string, op: "gt", v: 0 })).toThrow(
+			/AttrLiteralCompare.*'a'.*got number/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -190,36 +189,31 @@ describe("AttrLiteralCompare", () => {
 
 	it("throws when 'v' is missing (undefined)", () => {
 		expect(
-			() =>
-				new AttrLiteralCompare({ a: "score", op: "gt", v: undefined as unknown as number }),
+			() => new AttrLiteralCompare({ a: "score", op: "gt", v: undefined as unknown as number }),
 		).toThrow(/AttrLiteralCompare.*'v'/);
 	});
 
 	it("throws when 'v' is null", () => {
 		expect(
-			() =>
-				new AttrLiteralCompare({ a: "score", op: "gt", v: null as unknown as number }),
+			() => new AttrLiteralCompare({ a: "score", op: "gt", v: null as unknown as number }),
 		).toThrow(/AttrLiteralCompare.*'v'/);
 	});
 
 	it("throws when 'v' is a string", () => {
 		expect(
-			() =>
-				new AttrLiteralCompare({ a: "score", op: "gt", v: "10" as unknown as number }),
+			() => new AttrLiteralCompare({ a: "score", op: "gt", v: "10" as unknown as number }),
 		).toThrow(/AttrLiteralCompare.*'v'/);
 	});
 
 	it("throws when 'v' is a boolean", () => {
 		expect(
-			() =>
-				new AttrLiteralCompare({ a: "score", op: "gt", v: true as unknown as number }),
+			() => new AttrLiteralCompare({ a: "score", op: "gt", v: true as unknown as number }),
 		).toThrow(/AttrLiteralCompare.*'v'/);
 	});
 
 	it("throws when 'v' is a plain object", () => {
 		expect(
-			() =>
-				new AttrLiteralCompare({ a: "score", op: "gt", v: {} as unknown as number }),
+			() => new AttrLiteralCompare({ a: "score", op: "gt", v: {} as unknown as number }),
 		).toThrow(/AttrLiteralCompare.*'v'/);
 	});
 
@@ -271,9 +265,9 @@ describe("AttrLiteralCompare", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'group' is present but is an empty string", () => {
-		expect(
-			() => new AttrLiteralCompare({ a: "score", op: "gt", v: 0, group: "" }),
-		).toThrow(/AttrLiteralCompare.*'group'.*empty string/);
+		expect(() => new AttrLiteralCompare({ a: "score", op: "gt", v: 0, group: "" })).toThrow(
+			/AttrLiteralCompare.*'group'.*empty string/,
+		);
 	});
 
 	it("throws when 'group' is present but is a non-string (number 42)", () => {

--- a/packages/builtins/src/__tests__/rules/AttrLiteralCompare.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralCompare.test.mts
@@ -1,0 +1,349 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrLiteralCompare } from "#/rules/AttrLiteralCompare.mjs";
+
+describe("AttrLiteralCompare", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: each op at boundary values
+	// ---------------------------------------------------------------------------
+
+	it("op=lt: returns true when attr < v (5 < 10)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "lt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 5]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=lt: returns false when attr === v (10 < 10 is false)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "lt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 10]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=lt: returns false when attr > v (15 < 10 is false)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "lt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 15]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=le: returns true when attr === v (10 <= 10)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "le", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 10]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=le: returns true when attr < v (5 <= 10)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "le", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 5]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=le: returns false when attr > v (15 <= 10 is false)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "le", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 15]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=gt: returns true when attr > v (15 > 10)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 15]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=gt: returns false when attr === v (10 > 10 is false)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 10]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=gt: returns false when attr < v (5 > 10 is false)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 5]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=ge: returns true when attr === v (10 >= 10)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "ge", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 10]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=ge: returns true when attr > v (15 >= 10)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "ge", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 15]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=ge: returns false when attr < v (5 >= 10 is false)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "ge", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", 5]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: attr is not a number
+	// ---------------------------------------------------------------------------
+
+	it("returns false when attr is a string (not a number)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 5 });
+		const attrs: Attributes = new Map<string, unknown>([["score", "10"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr is a boolean (not a number)", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 0 });
+		const attrs: Attributes = new Map<string, unknown>([["score", true]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time: NaN attribute → false for all ops
+	// ---------------------------------------------------------------------------
+
+	it("op=lt: returns false when attr is NaN", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "lt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", NaN]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=le: returns false when attr is NaN", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "le", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", NaN]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=gt: returns false when attr is NaN", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", NaN]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=ge: returns false when attr is NaN", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "ge", v: 10 });
+		const attrs: Attributes = new Map<string, unknown>([["score", NaN]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time: Infinity / -Infinity attributes
+	// ---------------------------------------------------------------------------
+
+	it("op=gt: Infinity > 100 returns true", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 100 });
+		const attrs: Attributes = new Map<string, unknown>([["score", Infinity]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=lt: -Infinity < 0 returns true", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "lt", v: 0 });
+		const attrs: Attributes = new Map<string, unknown>([["score", -Infinity]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=ge: Infinity >= Infinity returns true", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "ge", v: Infinity });
+		const attrs: Attributes = new Map<string, unknown>([["score", Infinity]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: missing / null attr
+	// ---------------------------------------------------------------------------
+
+	it("returns false when the target attribute is missing", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 0 });
+		const attrs: Attributes = new Map<string, unknown>();
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when the target attribute is null", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 0 });
+		const attrs: Attributes = new Map<string, unknown>([["score", null]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({ a: undefined as unknown as string, op: "gt", v: 0 }),
+		).toThrow(/AttrLiteralCompare.*'a'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(() => new AttrLiteralCompare({ a: "", op: "gt", v: 0 })).toThrow(
+			/AttrLiteralCompare.*'a'.*empty string/,
+		);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrLiteralCompare({ a: 42 as unknown as string, op: "gt", v: 0 }),
+		).toThrow(/AttrLiteralCompare.*'a'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'v'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'v' is missing (undefined)", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({ a: "score", op: "gt", v: undefined as unknown as number }),
+		).toThrow(/AttrLiteralCompare.*'v'/);
+	});
+
+	it("throws when 'v' is null", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({ a: "score", op: "gt", v: null as unknown as number }),
+		).toThrow(/AttrLiteralCompare.*'v'/);
+	});
+
+	it("throws when 'v' is a string", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({ a: "score", op: "gt", v: "10" as unknown as number }),
+		).toThrow(/AttrLiteralCompare.*'v'/);
+	});
+
+	it("throws when 'v' is a boolean", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({ a: "score", op: "gt", v: true as unknown as number }),
+		).toThrow(/AttrLiteralCompare.*'v'/);
+	});
+
+	it("throws when 'v' is a plain object", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({ a: "score", op: "gt", v: {} as unknown as number }),
+		).toThrow(/AttrLiteralCompare.*'v'/);
+	});
+
+	it("throws when 'v' is NaN (fail-fast at construction)", () => {
+		expect(() => new AttrLiteralCompare({ a: "score", op: "gt", v: NaN })).toThrow(
+			/AttrLiteralCompare.*'v'.*NaN/,
+		);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'op'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'op' is missing (undefined)", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({
+					a: "score",
+					op: undefined as unknown as "lt",
+					v: 0,
+				}),
+		).toThrow(/AttrLiteralCompare.*'op'/);
+	});
+
+	it("throws when 'op' is not a string (number)", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({
+					a: "score",
+					op: 42 as unknown as "lt",
+					v: 0,
+				}),
+		).toThrow(/AttrLiteralCompare.*'op'/);
+	});
+
+	it("throws when 'op' is an invalid string ('eq')", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({
+					a: "score",
+					op: "eq" as unknown as "lt",
+					v: 0,
+				}),
+		).toThrow(/AttrLiteralCompare.*'op'/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(
+			() => new AttrLiteralCompare({ a: "score", op: "gt", v: 0, group: "" }),
+		).toThrow(/AttrLiteralCompare.*'group'.*empty string/);
+	});
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(
+			() =>
+				new AttrLiteralCompare({
+					a: "score",
+					op: "gt",
+					v: 0,
+					group: 42 as unknown as string,
+				}),
+		).toThrow(/AttrLiteralCompare.*'group'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default derived from a, op, v
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType from a, op, and v", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		expect(rule.ruleType).toBe("attr_literal_compare:score:gt:10");
+	});
+
+	it("derives default ruleType for negative v", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "lt", v: -5 });
+		expect(rule.ruleType).toBe("attr_literal_compare:score:lt:-5");
+	});
+
+	it("derives default ruleType for Infinity v", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "lt", v: Infinity });
+		expect(rule.ruleType).toBe("attr_literal_compare:score:lt:Infinity");
+	});
+
+	it("distinct op or v produce distinct ruleTypes (AND semantics)", () => {
+		const r1 = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		const r2 = new AttrLiteralCompare({ a: "score", op: "ge", v: 10 });
+		const r3 = new AttrLiteralCompare({ a: "score", op: "gt", v: 20 });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+		expect(r1.ruleType).not.toBe(r3.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the default", () => {
+		const r1 = new AttrLiteralCompare({ a: "score", op: "gt", v: 10, group: "score-check" });
+		const r2 = new AttrLiteralCompare({ a: "score", op: "ge", v: 11, group: "score-check" });
+		expect(r1.ruleType).toBe("score-check");
+		expect(r2.ruleType).toBe("score-check");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_compare_violated'", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		expect(rule.code).toBe("attr_compare_violated");
+	});
+
+	it("message contains the attribute name, op, and v", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		expect(rule.message).toContain("score");
+		expect(rule.message).toContain("gt");
+		expect(rule.message).toContain("10");
+	});
+
+	it("message starts with a capital letter", () => {
+		const rule = new AttrLiteralCompare({ a: "score", op: "gt", v: 10 });
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+});

--- a/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
@@ -101,6 +101,13 @@ describe("AttrLiteralEqual", () => {
 		);
 	});
 
+	it("throws when 'v' is NaN", () => {
+		// NaN === NaN is always false, so AttrLiteralEqual({ v: NaN }) would be
+		// an always-deny rule. Must fail-fast at construction rather than ship
+		// a silently-broken predicate.
+		expect(() => new AttrLiteralEqual({ a: "score", v: Number.NaN })).toThrow(/must not be NaN/);
+	});
+
 	// ---------------------------------------------------------------------------
 	// Construction errors: invalid 'group'
 	// ---------------------------------------------------------------------------

--- a/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
@@ -118,27 +118,37 @@ describe("AttrLiteralEqual", () => {
 	});
 
 	// ---------------------------------------------------------------------------
-	// ruleType: default derived from 'a' and 'v'
+	// ruleType: default derived from 'a', 'typeof v', and 'String(v)'
 	// ---------------------------------------------------------------------------
 
-	it("derives default ruleType from a and v for a string literal", () => {
+	it("derives default ruleType including the type segment for a string literal", () => {
 		const rule = new AttrLiteralEqual({ a: "role", v: "admin" });
-		expect(rule.ruleType).toBe("attr_literal_equal:role:admin");
+		expect(rule.ruleType).toBe("attr_literal_equal:role:string:admin");
 	});
 
-	it("derives default ruleType from a and v for a number literal", () => {
+	it("derives default ruleType including the type segment for a number literal", () => {
 		const rule = new AttrLiteralEqual({ a: "age", v: 30 });
-		expect(rule.ruleType).toBe("attr_literal_equal:age:30");
+		expect(rule.ruleType).toBe("attr_literal_equal:age:number:30");
 	});
 
-	it("derives default ruleType from a and v for a boolean literal", () => {
+	it("derives default ruleType including the type segment for a boolean literal", () => {
 		const rule = new AttrLiteralEqual({ a: "verified", v: true });
-		expect(rule.ruleType).toBe("attr_literal_equal:verified:true");
+		expect(rule.ruleType).toBe("attr_literal_equal:verified:boolean:true");
 	});
 
 	it("distinct configs produce distinct default ruleTypes (AND semantics)", () => {
 		const r1 = new AttrLiteralEqual({ a: "role", v: "admin" });
 		const r2 = new AttrLiteralEqual({ a: "role", v: "editor" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	it("distinguishes literals by type in ruleType (e.g. boolean true vs string 'true')", () => {
+		// Regression guard: without the typeof-segment in ruleType, these two
+		// rules would share the same default ruleType and the evaluator would
+		// silently OR them together, weakening authorization. The type tag
+		// keeps them AND-combined as intended.
+		const r1 = new AttrLiteralEqual({ a: "status", v: true });
+		const r2 = new AttrLiteralEqual({ a: "status", v: "true" });
 		expect(r1.ruleType).not.toBe(r2.ruleType);
 	});
 

--- a/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
@@ -1,0 +1,171 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrLiteralEqual } from "#/rules/AttrLiteralEqual.mjs";
+
+describe("AttrLiteralEqual", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: verify() returns true
+	// ---------------------------------------------------------------------------
+
+	it("returns true when attr equals the configured string literal", () => {
+		const rule = new AttrLiteralEqual({ a: "role", v: "admin" });
+		const attrs: Attributes = new Map<string, unknown>([["role", "admin"]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr equals the configured number literal", () => {
+		const rule = new AttrLiteralEqual({ a: "age", v: 30 });
+		const attrs: Attributes = new Map<string, unknown>([["age", 30]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr equals the configured boolean literal", () => {
+		const rule = new AttrLiteralEqual({ a: "verified", v: true });
+		const attrs: Attributes = new Map<string, unknown>([["verified", true]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Type mismatch: no coercion
+	// ---------------------------------------------------------------------------
+
+	it("returns false when number literal v=30 but attr is the string '30' (no coercion)", () => {
+		const rule = new AttrLiteralEqual({ a: "age", v: 30 });
+		const attrs: Attributes = new Map<string, unknown>([["age", "30"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when string literal v='true' but attr is the boolean true (no coercion)", () => {
+		const rule = new AttrLiteralEqual({ a: "verified", v: "true" });
+		const attrs: Attributes = new Map<string, unknown>([["verified", true]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: missing / null attr
+	// ---------------------------------------------------------------------------
+
+	it("returns false when the target attribute is missing", () => {
+		const rule = new AttrLiteralEqual({ a: "role", v: "admin" });
+		const attrs: Attributes = new Map<string, unknown>();
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when the target attribute is null", () => {
+		const rule = new AttrLiteralEqual({ a: "role", v: "admin" });
+		const attrs: Attributes = new Map<string, unknown>([["role", null]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(() => new AttrLiteralEqual({ a: undefined as unknown as string, v: "x" })).toThrow(
+			/AttrLiteralEqual.*'a'.*(non-empty string|got undefined)/,
+		);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(() => new AttrLiteralEqual({ a: "", v: "x" })).toThrow(
+			/AttrLiteralEqual.*'a'.*empty string/,
+		);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(() => new AttrLiteralEqual({ a: 42 as unknown as string, v: "x" })).toThrow(
+			/AttrLiteralEqual.*'a'.*got number/,
+		);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'v'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'v' is null", () => {
+		expect(() => new AttrLiteralEqual({ a: "role", v: null as unknown as string })).toThrow(
+			/AttrLiteralEqual.*'v'.*got null/,
+		);
+	});
+
+	it("throws when 'v' is undefined", () => {
+		expect(() => new AttrLiteralEqual({ a: "role", v: undefined as unknown as string })).toThrow(
+			/AttrLiteralEqual.*'v'.*got undefined/,
+		);
+	});
+
+	it("throws when 'v' is a plain object ({})", () => {
+		expect(() => new AttrLiteralEqual({ a: "role", v: {} as unknown as string })).toThrow(
+			/AttrLiteralEqual.*'v'.*got object/,
+		);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(() => new AttrLiteralEqual({ a: "role", v: "admin", group: "" })).toThrow(
+			/AttrLiteralEqual.*'group'.*empty string/,
+		);
+	});
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(() =>
+			new AttrLiteralEqual({ a: "role", v: "admin", group: 42 as unknown as string }),
+		).toThrow(/AttrLiteralEqual.*'group'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default derived from 'a' and 'v'
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType from a and v for a string literal", () => {
+		const rule = new AttrLiteralEqual({ a: "role", v: "admin" });
+		expect(rule.ruleType).toBe("attr_literal_equal:role:admin");
+	});
+
+	it("derives default ruleType from a and v for a number literal", () => {
+		const rule = new AttrLiteralEqual({ a: "age", v: 30 });
+		expect(rule.ruleType).toBe("attr_literal_equal:age:30");
+	});
+
+	it("derives default ruleType from a and v for a boolean literal", () => {
+		const rule = new AttrLiteralEqual({ a: "verified", v: true });
+		expect(rule.ruleType).toBe("attr_literal_equal:verified:true");
+	});
+
+	it("distinct configs produce distinct default ruleTypes (AND semantics)", () => {
+		const r1 = new AttrLiteralEqual({ a: "role", v: "admin" });
+		const r2 = new AttrLiteralEqual({ a: "role", v: "editor" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the default", () => {
+		const r1 = new AttrLiteralEqual({ a: "role", v: "admin", group: "any-admin-role" });
+		const r2 = new AttrLiteralEqual({ a: "role", v: "superuser", group: "any-admin-role" });
+		expect(r1.ruleType).toBe("any-admin-role");
+		expect(r2.ruleType).toBe("any-admin-role");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_not_equal'", () => {
+		const rule = new AttrLiteralEqual({ a: "role", v: "admin" });
+		expect(rule.code).toBe("attr_not_equal");
+	});
+
+	it("message contains the attribute name and literal value, and starts with a capital letter", () => {
+		const rule = new AttrLiteralEqual({ a: "role", v: "admin" });
+		expect(rule.message).toContain("role");
+		expect(rule.message).toContain("admin");
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+});

--- a/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
@@ -112,8 +112,8 @@ describe("AttrLiteralEqual", () => {
 	});
 
 	it("throws when 'group' is present but is a non-string (number 42)", () => {
-		expect(() =>
-			new AttrLiteralEqual({ a: "role", v: "admin", group: 42 as unknown as string }),
+		expect(
+			() => new AttrLiteralEqual({ a: "role", v: "admin", group: 42 as unknown as string }),
 		).toThrow(/AttrLiteralEqual.*'group'.*got number/);
 	});
 

--- a/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
@@ -78,9 +78,9 @@ describe("AttrLiteralIn", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'a' is undefined", () => {
-		expect(
-			() => new AttrLiteralIn({ a: undefined as unknown as string, values: ["x"] }),
-		).toThrow(/AttrLiteralIn.*'a'.*(non-empty string|got undefined)/);
+		expect(() => new AttrLiteralIn({ a: undefined as unknown as string, values: ["x"] })).toThrow(
+			/AttrLiteralIn.*'a'.*(non-empty string|got undefined)/,
+		);
 	});
 
 	it("throws when 'a' is an empty string", () => {
@@ -90,9 +90,9 @@ describe("AttrLiteralIn", () => {
 	});
 
 	it("throws when 'a' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrLiteralIn({ a: 42 as unknown as string, values: ["x"] }),
-		).toThrow(/AttrLiteralIn.*'a'.*got number/);
+		expect(() => new AttrLiteralIn({ a: 42 as unknown as string, values: ["x"] })).toThrow(
+			/AttrLiteralIn.*'a'.*got number/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -106,41 +106,37 @@ describe("AttrLiteralIn", () => {
 	});
 
 	it("throws when 'values' is not an array (a string)", () => {
-		expect(
-			() => new AttrLiteralIn({ a: "role", values: "admin" as unknown as string[] }),
-		).toThrow(/AttrLiteralIn.*'values'/);
-	});
-
-	it("throws when 'values' is an empty array", () => {
-		expect(() => new AttrLiteralIn({ a: "role", values: [] })).toThrow(
+		expect(() => new AttrLiteralIn({ a: "role", values: "admin" as unknown as string[] })).toThrow(
 			/AttrLiteralIn.*'values'/,
 		);
 	});
 
+	it("throws when 'values' is an empty array", () => {
+		expect(() => new AttrLiteralIn({ a: "role", values: [] })).toThrow(/AttrLiteralIn.*'values'/);
+	});
+
 	it("throws when 'values' contains null", () => {
-		expect(
-			() => new AttrLiteralIn({ a: "role", values: [null as unknown as string] }),
-		).toThrow(/AttrLiteralIn.*'values'/);
+		expect(() => new AttrLiteralIn({ a: "role", values: [null as unknown as string] })).toThrow(
+			/AttrLiteralIn.*'values'/,
+		);
 	});
 
 	it("throws when 'values' contains undefined", () => {
 		expect(
-			() =>
-				new AttrLiteralIn({ a: "role", values: [undefined as unknown as string] }),
+			() => new AttrLiteralIn({ a: "role", values: [undefined as unknown as string] }),
 		).toThrow(/AttrLiteralIn.*'values'/);
 	});
 
 	it("throws when 'values' contains mixed types (string and number)", () => {
-		expect(
-			() => new AttrLiteralIn({ a: "role", values: ["a", 1] as unknown as string[] }),
-		).toThrow(/AttrLiteralIn.*'values'.*mixed/);
+		expect(() => new AttrLiteralIn({ a: "role", values: ["a", 1] as unknown as string[] })).toThrow(
+			/AttrLiteralIn.*'values'.*mixed/,
+		);
 	});
 
 	it("throws when 'values' contains an object element", () => {
-		expect(
-			() =>
-				new AttrLiteralIn({ a: "role", values: [{}] as unknown as string[] }),
-		).toThrow(/AttrLiteralIn.*'values'/);
+		expect(() => new AttrLiteralIn({ a: "role", values: [{}] as unknown as string[] })).toThrow(
+			/AttrLiteralIn.*'values'/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -148,15 +144,14 @@ describe("AttrLiteralIn", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'group' is present but is an empty string", () => {
-		expect(
-			() => new AttrLiteralIn({ a: "role", values: ["admin"], group: "" }),
-		).toThrow(/AttrLiteralIn.*'group'.*empty string/);
+		expect(() => new AttrLiteralIn({ a: "role", values: ["admin"], group: "" })).toThrow(
+			/AttrLiteralIn.*'group'.*empty string/,
+		);
 	});
 
 	it("throws when 'group' is present but is a non-string (number 42)", () => {
 		expect(
-			() =>
-				new AttrLiteralIn({ a: "role", values: ["admin"], group: 42 as unknown as string }),
+			() => new AttrLiteralIn({ a: "role", values: ["admin"], group: 42 as unknown as string }),
 		).toThrow(/AttrLiteralIn.*'group'.*got number/);
 	});
 

--- a/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
@@ -139,6 +139,14 @@ describe("AttrLiteralIn", () => {
 		);
 	});
 
+	it("throws when 'values' contains NaN", () => {
+		// A NaN element could never match any numeric attribute (NaN !== NaN)
+		// and would silently be a dead element in the set. Must fail-fast.
+		expect(() => new AttrLiteralIn({ a: "score", values: [1, Number.NaN, 3] })).toThrow(
+			/AttrLiteralIn.*must not contain NaN/,
+		);
+	});
+
 	// ---------------------------------------------------------------------------
 	// Construction errors: invalid 'group'
 	// ---------------------------------------------------------------------------

--- a/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
@@ -1,0 +1,222 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrLiteralIn } from "#/rules/AttrLiteralIn.mjs";
+
+describe("AttrLiteralIn", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: attr in set → true
+	// ---------------------------------------------------------------------------
+
+	it("returns true when attr is a string in the configured values set", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin", "editor", "viewer"] });
+		const attrs: Attributes = new Map<string, unknown>([["role", "editor"]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr is a number in the configured values set", () => {
+		const rule = new AttrLiteralIn({ a: "level", values: [1, 2, 3] });
+		const attrs: Attributes = new Map<string, unknown>([["level", 2]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr is a boolean in the configured values set", () => {
+		const rule = new AttrLiteralIn({ a: "active", values: [true] });
+		const attrs: Attributes = new Map<string, unknown>([["active", true]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Happy path: attr not in set → false
+	// ---------------------------------------------------------------------------
+
+	it("returns false when attr is a string not in the configured values set", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin", "editor"] });
+		const attrs: Attributes = new Map<string, unknown>([["role", "viewer"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr is a number not in the configured values set", () => {
+		const rule = new AttrLiteralIn({ a: "level", values: [1, 2, 3] });
+		const attrs: Attributes = new Map<string, unknown>([["level", 5]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Type mismatch: values type != attr type → safe-deny (no throw)
+	// ---------------------------------------------------------------------------
+
+	it("returns false when values are strings but attr is a number (type mismatch)", () => {
+		const rule = new AttrLiteralIn({ a: "x", values: ["a", "b"] });
+		const attrs: Attributes = new Map<string, unknown>([["x", 42]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when values are numbers but attr is a string (type mismatch)", () => {
+		const rule = new AttrLiteralIn({ a: "x", values: [1, 2, 3] });
+		const attrs: Attributes = new Map<string, unknown>([["x", "1"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: missing / null attr
+	// ---------------------------------------------------------------------------
+
+	it("returns false when the target attribute is missing", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin"] });
+		const attrs: Attributes = new Map<string, unknown>();
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when the target attribute is null", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin"] });
+		const attrs: Attributes = new Map<string, unknown>([["role", null]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(
+			() => new AttrLiteralIn({ a: undefined as unknown as string, values: ["x"] }),
+		).toThrow(/AttrLiteralIn.*'a'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(() => new AttrLiteralIn({ a: "", values: ["x"] })).toThrow(
+			/AttrLiteralIn.*'a'.*empty string/,
+		);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrLiteralIn({ a: 42 as unknown as string, values: ["x"] }),
+		).toThrow(/AttrLiteralIn.*'a'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'values'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'values' is missing (undefined)", () => {
+		expect(
+			() => new AttrLiteralIn({ a: "role", values: undefined as unknown as string[] }),
+		).toThrow(/AttrLiteralIn.*'values'/);
+	});
+
+	it("throws when 'values' is not an array (a string)", () => {
+		expect(
+			() => new AttrLiteralIn({ a: "role", values: "admin" as unknown as string[] }),
+		).toThrow(/AttrLiteralIn.*'values'/);
+	});
+
+	it("throws when 'values' is an empty array", () => {
+		expect(() => new AttrLiteralIn({ a: "role", values: [] })).toThrow(
+			/AttrLiteralIn.*'values'/,
+		);
+	});
+
+	it("throws when 'values' contains null", () => {
+		expect(
+			() => new AttrLiteralIn({ a: "role", values: [null as unknown as string] }),
+		).toThrow(/AttrLiteralIn.*'values'/);
+	});
+
+	it("throws when 'values' contains undefined", () => {
+		expect(
+			() =>
+				new AttrLiteralIn({ a: "role", values: [undefined as unknown as string] }),
+		).toThrow(/AttrLiteralIn.*'values'/);
+	});
+
+	it("throws when 'values' contains mixed types (string and number)", () => {
+		expect(
+			() => new AttrLiteralIn({ a: "role", values: ["a", 1] as unknown as string[] }),
+		).toThrow(/AttrLiteralIn.*'values'.*mixed/);
+	});
+
+	it("throws when 'values' contains an object element", () => {
+		expect(
+			() =>
+				new AttrLiteralIn({ a: "role", values: [{}] as unknown as string[] }),
+		).toThrow(/AttrLiteralIn.*'values'/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(
+			() => new AttrLiteralIn({ a: "role", values: ["admin"], group: "" }),
+		).toThrow(/AttrLiteralIn.*'group'.*empty string/);
+	});
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(
+			() =>
+				new AttrLiteralIn({ a: "role", values: ["admin"], group: 42 as unknown as string }),
+		).toThrow(/AttrLiteralIn.*'group'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default includes valuesKey
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType containing the attribute name and valuesKey", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin", "editor"] });
+		expect(rule.ruleType).toMatch(/^attr_literal_in:role:string:2:[0-9a-f]{8}$/);
+	});
+
+	it("two instances with same 'a' but different values produce different ruleTypes", () => {
+		const r1 = new AttrLiteralIn({ a: "role", values: ["admin"] });
+		const r2 = new AttrLiteralIn({ a: "role", values: ["editor"] });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	it("two instances with same 'a' and identical values (same order) produce same ruleType", () => {
+		const r1 = new AttrLiteralIn({ a: "role", values: ["admin", "editor"] });
+		const r2 = new AttrLiteralIn({ a: "role", values: ["admin", "editor"] });
+		expect(r1.ruleType).toBe(r2.ruleType);
+	});
+
+	it("two instances with same 'a' and same values in different order produce same ruleType (content-based sort)", () => {
+		const r1 = new AttrLiteralIn({ a: "role", values: ["admin", "editor"] });
+		const r2 = new AttrLiteralIn({ a: "role", values: ["editor", "admin"] });
+		expect(r1.ruleType).toBe(r2.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the valuesKey-based default", () => {
+		const r1 = new AttrLiteralIn({ a: "role", values: ["admin"], group: "any-role" });
+		const r2 = new AttrLiteralIn({ a: "role", values: ["editor"], group: "any-role" });
+		expect(r1.ruleType).toBe("any-role");
+		expect(r2.ruleType).toBe("any-role");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_not_in_set'", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin"] });
+		expect(rule.code).toBe("attr_not_in_set");
+	});
+
+	it("message contains the attribute name, the 'must be one of' phrase, and lists all values", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin", "editor"] });
+		expect(rule.message).toContain("role");
+		expect(rule.message).toContain("must be one of");
+		expect(rule.message).toContain("admin");
+		expect(rule.message).toContain("editor");
+	});
+
+	it("message starts with a capital letter", () => {
+		const rule = new AttrLiteralIn({ a: "role", values: ["admin"] });
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+});

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
@@ -140,27 +140,34 @@ describe("AttrLiteralNotEqual", () => {
 	});
 
 	// ---------------------------------------------------------------------------
-	// ruleType: default derived from 'a' and 'v'
+	// ruleType: default derived from 'a', 'typeof v', and 'String(v)'
 	// ---------------------------------------------------------------------------
 
-	it("derives default ruleType from a and v for a string literal", () => {
+	it("derives default ruleType including the type segment for a string literal", () => {
 		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
-		expect(rule.ruleType).toBe("attr_literal_not_equal:role:admin");
+		expect(rule.ruleType).toBe("attr_literal_not_equal:role:string:admin");
 	});
 
-	it("derives default ruleType from a and v for a number literal", () => {
+	it("derives default ruleType including the type segment for a number literal", () => {
 		const rule = new AttrLiteralNotEqual({ a: "age", v: 30 });
-		expect(rule.ruleType).toBe("attr_literal_not_equal:age:30");
+		expect(rule.ruleType).toBe("attr_literal_not_equal:age:number:30");
 	});
 
-	it("derives default ruleType from a and v for a boolean literal", () => {
+	it("derives default ruleType including the type segment for a boolean literal", () => {
 		const rule = new AttrLiteralNotEqual({ a: "verified", v: true });
-		expect(rule.ruleType).toBe("attr_literal_not_equal:verified:true");
+		expect(rule.ruleType).toBe("attr_literal_not_equal:verified:boolean:true");
 	});
 
 	it("distinct configs produce distinct default ruleTypes (AND semantics)", () => {
 		const r1 = new AttrLiteralNotEqual({ a: "role", v: "admin" });
 		const r2 = new AttrLiteralNotEqual({ a: "role", v: "editor" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	it("distinguishes literals by type in ruleType (e.g. number 1 vs string '1')", () => {
+		// Regression guard: see AttrLiteralEqual test for the same rationale.
+		const r1 = new AttrLiteralNotEqual({ a: "flag", v: 1 });
+		const r2 = new AttrLiteralNotEqual({ a: "flag", v: "1" });
 		expect(r1.ruleType).not.toBe(r2.ruleType);
 	});
 

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
@@ -84,9 +84,9 @@ describe("AttrLiteralNotEqual", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'a' is undefined", () => {
-		expect(
-			() => new AttrLiteralNotEqual({ a: undefined as unknown as string, v: "x" }),
-		).toThrow(/AttrLiteralNotEqual.*'a'.*(non-empty string|got undefined)/);
+		expect(() => new AttrLiteralNotEqual({ a: undefined as unknown as string, v: "x" })).toThrow(
+			/AttrLiteralNotEqual.*'a'.*(non-empty string|got undefined)/,
+		);
 	});
 
 	it("throws when 'a' is an empty string", () => {
@@ -96,9 +96,9 @@ describe("AttrLiteralNotEqual", () => {
 	});
 
 	it("throws when 'a' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrLiteralNotEqual({ a: 42 as unknown as string, v: "x" }),
-		).toThrow(/AttrLiteralNotEqual.*'a'.*got number/);
+		expect(() => new AttrLiteralNotEqual({ a: 42 as unknown as string, v: "x" })).toThrow(
+			/AttrLiteralNotEqual.*'a'.*got number/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -106,21 +106,21 @@ describe("AttrLiteralNotEqual", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'v' is null", () => {
-		expect(
-			() => new AttrLiteralNotEqual({ a: "role", v: null as unknown as string }),
-		).toThrow(/AttrLiteralNotEqual.*'v'.*got null/);
+		expect(() => new AttrLiteralNotEqual({ a: "role", v: null as unknown as string })).toThrow(
+			/AttrLiteralNotEqual.*'v'.*got null/,
+		);
 	});
 
 	it("throws when 'v' is undefined", () => {
-		expect(
-			() => new AttrLiteralNotEqual({ a: "role", v: undefined as unknown as string }),
-		).toThrow(/AttrLiteralNotEqual.*'v'.*got undefined/);
+		expect(() => new AttrLiteralNotEqual({ a: "role", v: undefined as unknown as string })).toThrow(
+			/AttrLiteralNotEqual.*'v'.*got undefined/,
+		);
 	});
 
 	it("throws when 'v' is a plain object ({})", () => {
-		expect(
-			() => new AttrLiteralNotEqual({ a: "role", v: {} as unknown as string }),
-		).toThrow(/AttrLiteralNotEqual.*'v'.*got object/);
+		expect(() => new AttrLiteralNotEqual({ a: "role", v: {} as unknown as string })).toThrow(
+			/AttrLiteralNotEqual.*'v'.*got object/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -135,8 +135,7 @@ describe("AttrLiteralNotEqual", () => {
 
 	it("throws when 'group' is present but is a non-string (number 42)", () => {
 		expect(
-			() =>
-				new AttrLiteralNotEqual({ a: "role", v: "admin", group: 42 as unknown as string }),
+			() => new AttrLiteralNotEqual({ a: "role", v: "admin", group: 42 as unknown as string }),
 		).toThrow(/AttrLiteralNotEqual.*'group'.*got number/);
 	});
 

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
@@ -1,0 +1,199 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrLiteralNotEqual } from "#/rules/AttrLiteralNotEqual.mjs";
+
+describe("AttrLiteralNotEqual", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: verify() returns true (attr present, type matches, not equal)
+	// ---------------------------------------------------------------------------
+
+	it("returns true when attr is a different string than the configured literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		const attrs: Attributes = new Map<string, unknown>([["role", "editor"]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr is a different number than the configured literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "age", v: 30 });
+		const attrs: Attributes = new Map<string, unknown>([["age", 25]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr is a different boolean than the configured literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "verified", v: true });
+		const attrs: Attributes = new Map<string, unknown>([["verified", false]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// verify() returns false when attr equals the literal
+	// ---------------------------------------------------------------------------
+
+	it("returns false when attr equals the configured string literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		const attrs: Attributes = new Map<string, unknown>([["role", "admin"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr equals the configured number literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "age", v: 30 });
+		const attrs: Attributes = new Map<string, unknown>([["age", 30]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr equals the configured boolean literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "verified", v: false });
+		const attrs: Attributes = new Map<string, unknown>([["verified", false]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Type mismatch: safe-deny (no coercion)
+	// ---------------------------------------------------------------------------
+
+	it("returns false when number literal v=30 but attr is the string '30' (no coercion)", () => {
+		const rule = new AttrLiteralNotEqual({ a: "age", v: 30 });
+		const attrs: Attributes = new Map<string, unknown>([["age", "30"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when string literal v='true' but attr is the boolean true (no coercion)", () => {
+		const rule = new AttrLiteralNotEqual({ a: "verified", v: "true" });
+		const attrs: Attributes = new Map<string, unknown>([["verified", true]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: missing / null attr
+	// ---------------------------------------------------------------------------
+
+	it("returns false when the target attribute is missing", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		const attrs: Attributes = new Map<string, unknown>();
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when the target attribute is null", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		const attrs: Attributes = new Map<string, unknown>([["role", null]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(
+			() => new AttrLiteralNotEqual({ a: undefined as unknown as string, v: "x" }),
+		).toThrow(/AttrLiteralNotEqual.*'a'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(() => new AttrLiteralNotEqual({ a: "", v: "x" })).toThrow(
+			/AttrLiteralNotEqual.*'a'.*empty string/,
+		);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrLiteralNotEqual({ a: 42 as unknown as string, v: "x" }),
+		).toThrow(/AttrLiteralNotEqual.*'a'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'v'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'v' is null", () => {
+		expect(
+			() => new AttrLiteralNotEqual({ a: "role", v: null as unknown as string }),
+		).toThrow(/AttrLiteralNotEqual.*'v'.*got null/);
+	});
+
+	it("throws when 'v' is undefined", () => {
+		expect(
+			() => new AttrLiteralNotEqual({ a: "role", v: undefined as unknown as string }),
+		).toThrow(/AttrLiteralNotEqual.*'v'.*got undefined/);
+	});
+
+	it("throws when 'v' is a plain object ({})", () => {
+		expect(
+			() => new AttrLiteralNotEqual({ a: "role", v: {} as unknown as string }),
+		).toThrow(/AttrLiteralNotEqual.*'v'.*got object/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(() => new AttrLiteralNotEqual({ a: "role", v: "admin", group: "" })).toThrow(
+			/AttrLiteralNotEqual.*'group'.*empty string/,
+		);
+	});
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(
+			() =>
+				new AttrLiteralNotEqual({ a: "role", v: "admin", group: 42 as unknown as string }),
+		).toThrow(/AttrLiteralNotEqual.*'group'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default derived from 'a' and 'v'
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType from a and v for a string literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		expect(rule.ruleType).toBe("attr_literal_not_equal:role:admin");
+	});
+
+	it("derives default ruleType from a and v for a number literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "age", v: 30 });
+		expect(rule.ruleType).toBe("attr_literal_not_equal:age:30");
+	});
+
+	it("derives default ruleType from a and v for a boolean literal", () => {
+		const rule = new AttrLiteralNotEqual({ a: "verified", v: true });
+		expect(rule.ruleType).toBe("attr_literal_not_equal:verified:true");
+	});
+
+	it("distinct configs produce distinct default ruleTypes (AND semantics)", () => {
+		const r1 = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		const r2 = new AttrLiteralNotEqual({ a: "role", v: "editor" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the default", () => {
+		const r1 = new AttrLiteralNotEqual({ a: "role", v: "banned", group: "not-banned" });
+		const r2 = new AttrLiteralNotEqual({ a: "role", v: "blocked", group: "not-banned" });
+		expect(r1.ruleType).toBe("not-banned");
+		expect(r2.ruleType).toBe("not-banned");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_equal'", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		expect(rule.code).toBe("attr_equal");
+	});
+
+	it("message contains the attribute name and literal value, and starts with a capital letter", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		expect(rule.message).toContain("role");
+		expect(rule.message).toContain("admin");
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+
+	it("message contains 'must not equal'", () => {
+		const rule = new AttrLiteralNotEqual({ a: "role", v: "admin" });
+		expect(rule.message).toContain("must not equal");
+	});
+});

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
@@ -123,6 +123,13 @@ describe("AttrLiteralNotEqual", () => {
 		);
 	});
 
+	it("throws when 'v' is NaN", () => {
+		// x !== NaN is always true, so AttrLiteralNotEqual({ v: NaN }) would be
+		// an always-allow rule against any numeric attribute — silently
+		// weakening authorization. Must fail-fast at construction.
+		expect(() => new AttrLiteralNotEqual({ a: "score", v: Number.NaN })).toThrow(/must not be NaN/);
+	});
+
 	// ---------------------------------------------------------------------------
 	// Construction errors: invalid 'group'
 	// ---------------------------------------------------------------------------

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
@@ -1,0 +1,232 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrLiteralNotIn } from "#/rules/AttrLiteralNotIn.mjs";
+
+describe("AttrLiteralNotIn", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: attr not in set → true
+	// ---------------------------------------------------------------------------
+
+	it("returns true when attr is a string NOT in the configured values set", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin", "editor"] });
+		const attrs: Attributes = new Map<string, unknown>([["role", "viewer"]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr is a number NOT in the configured values set", () => {
+		const rule = new AttrLiteralNotIn({ a: "level", values: [1, 2, 3] });
+		const attrs: Attributes = new Map<string, unknown>([["level", 5]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("returns true when attr is a boolean NOT in the configured values set", () => {
+		const rule = new AttrLiteralNotIn({ a: "active", values: [false] });
+		const attrs: Attributes = new Map<string, unknown>([["active", true]]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Happy path: attr in set → false
+	// ---------------------------------------------------------------------------
+
+	it("returns false when attr is a string IN the configured values set", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin", "editor"] });
+		const attrs: Attributes = new Map<string, unknown>([["role", "admin"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr is a number IN the configured values set", () => {
+		const rule = new AttrLiteralNotIn({ a: "level", values: [1, 2, 3] });
+		const attrs: Attributes = new Map<string, unknown>([["level", 2]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr is a boolean IN the configured values set", () => {
+		const rule = new AttrLiteralNotIn({ a: "active", values: [true] });
+		const attrs: Attributes = new Map<string, unknown>([["active", true]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Type mismatch: safe-deny (no coercion)
+	// ---------------------------------------------------------------------------
+
+	it("returns false when values are strings but attr is a number (type mismatch)", () => {
+		const rule = new AttrLiteralNotIn({ a: "x", values: ["a", "b"] });
+		const attrs: Attributes = new Map<string, unknown>([["x", 42]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when values are numbers but attr is a string (type mismatch)", () => {
+		const rule = new AttrLiteralNotIn({ a: "x", values: [1, 2, 3] });
+		const attrs: Attributes = new Map<string, unknown>([["x", "1"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: missing / null attr
+	// ---------------------------------------------------------------------------
+
+	it("returns false when the target attribute is missing", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin"] });
+		const attrs: Attributes = new Map<string, unknown>();
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when the target attribute is null", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin"] });
+		const attrs: Attributes = new Map<string, unknown>([["role", null]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(
+			() => new AttrLiteralNotIn({ a: undefined as unknown as string, values: ["x"] }),
+		).toThrow(/AttrLiteralNotIn.*'a'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(() => new AttrLiteralNotIn({ a: "", values: ["x"] })).toThrow(
+			/AttrLiteralNotIn.*'a'.*empty string/,
+		);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrLiteralNotIn({ a: 42 as unknown as string, values: ["x"] }),
+		).toThrow(/AttrLiteralNotIn.*'a'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'values'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'values' is missing (undefined)", () => {
+		expect(
+			() => new AttrLiteralNotIn({ a: "role", values: undefined as unknown as string[] }),
+		).toThrow(/AttrLiteralNotIn.*'values'/);
+	});
+
+	it("throws when 'values' is not an array (a string)", () => {
+		expect(
+			() => new AttrLiteralNotIn({ a: "role", values: "admin" as unknown as string[] }),
+		).toThrow(/AttrLiteralNotIn.*'values'/);
+	});
+
+	it("throws when 'values' is an empty array", () => {
+		expect(() => new AttrLiteralNotIn({ a: "role", values: [] })).toThrow(
+			/AttrLiteralNotIn.*'values'/,
+		);
+	});
+
+	it("throws when 'values' contains null", () => {
+		expect(
+			() => new AttrLiteralNotIn({ a: "role", values: [null as unknown as string] }),
+		).toThrow(/AttrLiteralNotIn.*'values'/);
+	});
+
+	it("throws when 'values' contains undefined", () => {
+		expect(
+			() =>
+				new AttrLiteralNotIn({ a: "role", values: [undefined as unknown as string] }),
+		).toThrow(/AttrLiteralNotIn.*'values'/);
+	});
+
+	it("throws when 'values' contains mixed types (string and number)", () => {
+		expect(
+			() => new AttrLiteralNotIn({ a: "role", values: ["a", 1] as unknown as string[] }),
+		).toThrow(/AttrLiteralNotIn.*'values'.*mixed/);
+	});
+
+	it("throws when 'values' contains an object element", () => {
+		expect(
+			() =>
+				new AttrLiteralNotIn({ a: "role", values: [{}] as unknown as string[] }),
+		).toThrow(/AttrLiteralNotIn.*'values'/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(
+			() => new AttrLiteralNotIn({ a: "role", values: ["admin"], group: "" }),
+		).toThrow(/AttrLiteralNotIn.*'group'.*empty string/);
+	});
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(
+			() =>
+				new AttrLiteralNotIn({ a: "role", values: ["admin"], group: 42 as unknown as string }),
+		).toThrow(/AttrLiteralNotIn.*'group'.*got number/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default includes valuesKey
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType containing the attribute name and valuesKey", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin", "editor"] });
+		expect(rule.ruleType).toMatch(/^attr_literal_not_in:role:string:2:[0-9a-f]{8}$/);
+	});
+
+	it("two instances with same 'a' but different values produce different ruleTypes", () => {
+		const r1 = new AttrLiteralNotIn({ a: "role", values: ["admin"] });
+		const r2 = new AttrLiteralNotIn({ a: "role", values: ["editor"] });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	it("two instances with same 'a' and identical values (same order) produce same ruleType", () => {
+		const r1 = new AttrLiteralNotIn({ a: "role", values: ["admin", "editor"] });
+		const r2 = new AttrLiteralNotIn({ a: "role", values: ["admin", "editor"] });
+		expect(r1.ruleType).toBe(r2.ruleType);
+	});
+
+	it("two instances with same 'a' and same values in different order produce same ruleType (content-based sort)", () => {
+		const r1 = new AttrLiteralNotIn({ a: "role", values: ["admin", "editor"] });
+		const r2 = new AttrLiteralNotIn({ a: "role", values: ["editor", "admin"] });
+		expect(r1.ruleType).toBe(r2.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the valuesKey-based default", () => {
+		const r1 = new AttrLiteralNotIn({ a: "role", values: ["admin"], group: "not-admin-set" });
+		const r2 = new AttrLiteralNotIn({ a: "role", values: ["editor"], group: "not-admin-set" });
+		expect(r1.ruleType).toBe("not-admin-set");
+		expect(r2.ruleType).toBe("not-admin-set");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_in_set'", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin"] });
+		expect(rule.code).toBe("attr_in_set");
+	});
+
+	it("message contains the attribute name and lists all values", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin", "editor"] });
+		expect(rule.message).toContain("role");
+		expect(rule.message).toContain("admin");
+		expect(rule.message).toContain("editor");
+	});
+
+	it("message contains 'must not be one of'", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin"] });
+		expect(rule.message).toContain("must not be one of");
+	});
+
+	it("message starts with a capital letter", () => {
+		const rule = new AttrLiteralNotIn({ a: "role", values: ["admin"] });
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+});

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
@@ -96,9 +96,9 @@ describe("AttrLiteralNotIn", () => {
 	});
 
 	it("throws when 'a' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrLiteralNotIn({ a: 42 as unknown as string, values: ["x"] }),
-		).toThrow(/AttrLiteralNotIn.*'a'.*got number/);
+		expect(() => new AttrLiteralNotIn({ a: 42 as unknown as string, values: ["x"] })).toThrow(
+			/AttrLiteralNotIn.*'a'.*got number/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -124,15 +124,14 @@ describe("AttrLiteralNotIn", () => {
 	});
 
 	it("throws when 'values' contains null", () => {
-		expect(
-			() => new AttrLiteralNotIn({ a: "role", values: [null as unknown as string] }),
-		).toThrow(/AttrLiteralNotIn.*'values'/);
+		expect(() => new AttrLiteralNotIn({ a: "role", values: [null as unknown as string] })).toThrow(
+			/AttrLiteralNotIn.*'values'/,
+		);
 	});
 
 	it("throws when 'values' contains undefined", () => {
 		expect(
-			() =>
-				new AttrLiteralNotIn({ a: "role", values: [undefined as unknown as string] }),
+			() => new AttrLiteralNotIn({ a: "role", values: [undefined as unknown as string] }),
 		).toThrow(/AttrLiteralNotIn.*'values'/);
 	});
 
@@ -143,10 +142,9 @@ describe("AttrLiteralNotIn", () => {
 	});
 
 	it("throws when 'values' contains an object element", () => {
-		expect(
-			() =>
-				new AttrLiteralNotIn({ a: "role", values: [{}] as unknown as string[] }),
-		).toThrow(/AttrLiteralNotIn.*'values'/);
+		expect(() => new AttrLiteralNotIn({ a: "role", values: [{}] as unknown as string[] })).toThrow(
+			/AttrLiteralNotIn.*'values'/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -154,15 +152,14 @@ describe("AttrLiteralNotIn", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'group' is present but is an empty string", () => {
-		expect(
-			() => new AttrLiteralNotIn({ a: "role", values: ["admin"], group: "" }),
-		).toThrow(/AttrLiteralNotIn.*'group'.*empty string/);
+		expect(() => new AttrLiteralNotIn({ a: "role", values: ["admin"], group: "" })).toThrow(
+			/AttrLiteralNotIn.*'group'.*empty string/,
+		);
 	});
 
 	it("throws when 'group' is present but is a non-string (number 42)", () => {
 		expect(
-			() =>
-				new AttrLiteralNotIn({ a: "role", values: ["admin"], group: 42 as unknown as string }),
+			() => new AttrLiteralNotIn({ a: "role", values: ["admin"], group: 42 as unknown as string }),
 		).toThrow(/AttrLiteralNotIn.*'group'.*got number/);
 	});
 

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
@@ -147,6 +147,14 @@ describe("AttrLiteralNotIn", () => {
 		);
 	});
 
+	it("throws when 'values' contains NaN", () => {
+		// A NaN element could never match any numeric attribute (NaN !== NaN),
+		// so including it in a "deny these" list is a silent policy mistake.
+		expect(() => new AttrLiteralNotIn({ a: "score", values: [1, Number.NaN, 3] })).toThrow(
+			/AttrLiteralNotIn.*must not contain NaN/,
+		);
+	});
+
 	// ---------------------------------------------------------------------------
 	// Construction errors: invalid 'group'
 	// ---------------------------------------------------------------------------

--- a/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
@@ -58,6 +58,15 @@ describe("AttrMatchRule", () => {
 		expect(r1.ruleType).toContain("sub");
 	});
 
+	it("preserves the legacy ruleType prefix 'attr_match:' for backward compatibility", () => {
+		// AttrMatchRule is a deprecated wrapper around AttrPairEqual. To keep
+		// downstream consumers (e.g. dplaas.auth) working without code changes
+		// across this release, the default ruleType must remain `attr_match:{a}:{b}`
+		// rather than adopting AttrPairEqual's `attr_pair_equal:...` form.
+		const r = new AttrMatchRule({ a: "userId", b: "sub" });
+		expect(r.ruleType).toBe("attr_match:userId:sub");
+	});
+
 	it("uses the provided group override when set, to enable explicit grouping", () => {
 		// When callers want two comparisons to be OR'd together (e.g. match by
 		// either DID or email), they opt in by passing the same `group`.
@@ -71,12 +80,12 @@ describe("AttrMatchRule", () => {
 		expect(rule.code).toBe("attr_mismatch");
 	});
 
-	it("message describes the contract (both attrs must be equal)", () => {
-		// AttrMatchRule is now a deprecated alias of AttrPairEqual. The exact
-		// wording ("non-empty" phrasing etc.) is not part of the stable contract —
-		// only the presence of the attribute names and an "equal" phrase is.
+	it("message describes the contract (both attrs must be non-empty strings and equal)", () => {
+		// The message should make the rule's contract explicit, not just say "do not match",
+		// because verify() fails closed on missing, non-string, and empty inputs too.
 		expect(rule.message).toContain("x");
 		expect(rule.message).toContain("y");
+		expect(rule.message).toMatch(/non-empty/i);
 		expect(rule.message).toMatch(/equal/i);
 		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
 	});

--- a/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
@@ -71,12 +71,12 @@ describe("AttrMatchRule", () => {
 		expect(rule.code).toBe("attr_mismatch");
 	});
 
-	it("message describes the contract (both attrs must be non-empty strings and equal)", () => {
-		// The message should make the rule's contract explicit, not just say "do not match",
-		// because verify() fails closed on missing, non-string, and empty inputs too.
+	it("message describes the contract (both attrs must be equal)", () => {
+		// AttrMatchRule is now a deprecated alias of AttrPairEqual. The exact
+		// wording ("non-empty" phrasing etc.) is not part of the stable contract —
+		// only the presence of the attribute names and an "equal" phrase is.
 		expect(rule.message).toContain("x");
 		expect(rule.message).toContain("y");
-		expect(rule.message).toMatch(/non-empty/i);
 		expect(rule.message).toMatch(/equal/i);
 		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
 	});

--- a/packages/builtins/src/__tests__/rules/AttrPairCompare.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairCompare.test.mts
@@ -1,0 +1,404 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrPairCompare } from "#/rules/AttrPairCompare.mjs";
+
+describe("AttrPairCompare", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: each op at boundary values
+	// ---------------------------------------------------------------------------
+
+	it("op=lt: returns true when attr(a) < attr(b) (5 < 10)", () => {
+		const rule = new AttrPairCompare({ a: "low", op: "lt", b: "high" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["low", 5],
+			["high", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=lt: returns false when attr(a) === attr(b) (10 < 10 is false)", () => {
+		const rule = new AttrPairCompare({ a: "low", op: "lt", b: "high" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["low", 10],
+			["high", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=lt: returns false when attr(a) > attr(b) (15 < 10 is false)", () => {
+		const rule = new AttrPairCompare({ a: "low", op: "lt", b: "high" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["low", 15],
+			["high", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=le: returns true when attr(a) === attr(b) (10 <= 10)", () => {
+		const rule = new AttrPairCompare({ a: "low", op: "le", b: "high" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["low", 10],
+			["high", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=le: returns true when attr(a) < attr(b) (5 <= 10)", () => {
+		const rule = new AttrPairCompare({ a: "low", op: "le", b: "high" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["low", 5],
+			["high", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=le: returns false when attr(a) > attr(b) (15 <= 10 is false)", () => {
+		const rule = new AttrPairCompare({ a: "low", op: "le", b: "high" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["low", 15],
+			["high", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=gt: returns true when attr(a) > attr(b) (15 > 10)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 15],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=gt: returns false when attr(a) === attr(b) (10 > 10 is false)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 10],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=gt: returns false when attr(a) < attr(b) (5 > 10 is false)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 5],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=ge: returns true when attr(a) === attr(b) (10 >= 10)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "ge", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 10],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=ge: returns true when attr(a) > attr(b) (15 >= 10)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "ge", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 15],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=ge: returns false when attr(a) < attr(b) (5 >= 10 is false)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "ge", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 5],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: attr is not a number
+	// ---------------------------------------------------------------------------
+
+	it("returns false when attr(a) is a string (not a number)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", "10"],
+			["threshold", 5],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr(b) is a string (not a number)", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 10],
+			["threshold", "5"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time safe-deny: missing attr
+	// ---------------------------------------------------------------------------
+
+	it("returns false when attr(a) is missing", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([["threshold", 5]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr(b) is missing", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([["score", 10]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time: NaN attribute → false for all ops
+	// ---------------------------------------------------------------------------
+
+	it("op=lt: returns false when attr(a) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "lt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", NaN],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=le: returns false when attr(a) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "le", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", NaN],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=gt: returns false when attr(a) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", NaN],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=ge: returns false when attr(a) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "ge", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", NaN],
+			["threshold", 10],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=lt: returns false when attr(b) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "lt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 5],
+			["threshold", NaN],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=le: returns false when attr(b) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "le", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 5],
+			["threshold", NaN],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=gt: returns false when attr(b) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 15],
+			["threshold", NaN],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("op=ge: returns false when attr(b) is NaN", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "ge", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", 15],
+			["threshold", NaN],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Evaluation-time: Infinity / -Infinity attributes
+	// ---------------------------------------------------------------------------
+
+	it("op=gt: Infinity > 100 returns true", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", Infinity],
+			["threshold", 100],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=lt: -Infinity < 0 returns true", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "lt", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", -Infinity],
+			["threshold", 0],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("op=ge: Infinity >= Infinity returns true", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "ge", b: "threshold" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["score", Infinity],
+			["threshold", Infinity],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(
+			() =>
+				new AttrPairCompare({ a: undefined as unknown as string, op: "gt", b: "threshold" }),
+		).toThrow(/AttrPairCompare.*'a'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrPairCompare({ a: 42 as unknown as string, op: "gt", b: "threshold" }),
+		).toThrow(/AttrPairCompare.*'a'.*got number/);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(
+			() => new AttrPairCompare({ a: "", op: "gt", b: "threshold" }),
+		).toThrow(/AttrPairCompare.*'a'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'b'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'b' is undefined", () => {
+		expect(
+			() =>
+				new AttrPairCompare({ a: "score", op: "gt", b: undefined as unknown as string }),
+		).toThrow(/AttrPairCompare.*'b'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'b' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrPairCompare({ a: "score", op: "gt", b: 42 as unknown as string }),
+		).toThrow(/AttrPairCompare.*'b'.*got number/);
+	});
+
+	it("throws when 'b' is an empty string", () => {
+		expect(
+			() => new AttrPairCompare({ a: "score", op: "gt", b: "" }),
+		).toThrow(/AttrPairCompare.*'b'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'op'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'op' is missing (undefined)", () => {
+		expect(
+			() =>
+				new AttrPairCompare({ a: "score", op: undefined as unknown as "lt", b: "threshold" }),
+		).toThrow(/AttrPairCompare.*'op'/);
+	});
+
+	it("throws when 'op' is not a string (number 42)", () => {
+		expect(
+			() =>
+				new AttrPairCompare({ a: "score", op: 42 as unknown as "lt", b: "threshold" }),
+		).toThrow(/AttrPairCompare.*'op'/);
+	});
+
+	it("throws when 'op' is an invalid string ('eq')", () => {
+		expect(
+			() =>
+				new AttrPairCompare({ a: "score", op: "eq" as unknown as "lt", b: "threshold" }),
+		).toThrow(/AttrPairCompare.*'op'/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(
+			() =>
+				new AttrPairCompare({
+					a: "score",
+					op: "gt",
+					b: "threshold",
+					group: 42 as unknown as string,
+				}),
+		).toThrow(/AttrPairCompare.*'group'.*got number/);
+	});
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(
+			() => new AttrPairCompare({ a: "score", op: "gt", b: "threshold", group: "" }),
+		).toThrow(/AttrPairCompare.*'group'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default derived from a, op, b
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType from a, op, and b", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		expect(rule.ruleType).toBe("attr_pair_compare:score:gt:threshold");
+	});
+
+	it("distinct op or b produce distinct ruleTypes (AND semantics)", () => {
+		const r1 = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		const r2 = new AttrPairCompare({ a: "score", op: "ge", b: "threshold" });
+		const r3 = new AttrPairCompare({ a: "score", op: "gt", b: "limit" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+		expect(r1.ruleType).not.toBe(r3.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the default", () => {
+		const r1 = new AttrPairCompare({ a: "score", op: "gt", b: "threshold", group: "score-check" });
+		const r2 = new AttrPairCompare({ a: "score", op: "ge", b: "limit", group: "score-check" });
+		expect(r1.ruleType).toBe("score-check");
+		expect(r2.ruleType).toBe("score-check");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_compare_violated'", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		expect(rule.code).toBe("attr_compare_violated");
+	});
+
+	it("message contains a name, op, and b name", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		expect(rule.message).toContain("score");
+		expect(rule.message).toContain("gt");
+		expect(rule.message).toContain("threshold");
+	});
+
+	it("message starts with a capital letter", () => {
+		const rule = new AttrPairCompare({ a: "score", op: "gt", b: "threshold" });
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+});

--- a/packages/builtins/src/__tests__/rules/AttrPairCompare.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairCompare.test.mts
@@ -266,8 +266,7 @@ describe("AttrPairCompare", () => {
 
 	it("throws when 'a' is undefined", () => {
 		expect(
-			() =>
-				new AttrPairCompare({ a: undefined as unknown as string, op: "gt", b: "threshold" }),
+			() => new AttrPairCompare({ a: undefined as unknown as string, op: "gt", b: "threshold" }),
 		).toThrow(/AttrPairCompare.*'a'.*(non-empty string|got undefined)/);
 	});
 
@@ -278,9 +277,9 @@ describe("AttrPairCompare", () => {
 	});
 
 	it("throws when 'a' is an empty string", () => {
-		expect(
-			() => new AttrPairCompare({ a: "", op: "gt", b: "threshold" }),
-		).toThrow(/AttrPairCompare.*'a'.*empty string/);
+		expect(() => new AttrPairCompare({ a: "", op: "gt", b: "threshold" })).toThrow(
+			/AttrPairCompare.*'a'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -289,21 +288,20 @@ describe("AttrPairCompare", () => {
 
 	it("throws when 'b' is undefined", () => {
 		expect(
-			() =>
-				new AttrPairCompare({ a: "score", op: "gt", b: undefined as unknown as string }),
+			() => new AttrPairCompare({ a: "score", op: "gt", b: undefined as unknown as string }),
 		).toThrow(/AttrPairCompare.*'b'.*(non-empty string|got undefined)/);
 	});
 
 	it("throws when 'b' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrPairCompare({ a: "score", op: "gt", b: 42 as unknown as string }),
-		).toThrow(/AttrPairCompare.*'b'.*got number/);
+		expect(() => new AttrPairCompare({ a: "score", op: "gt", b: 42 as unknown as string })).toThrow(
+			/AttrPairCompare.*'b'.*got number/,
+		);
 	});
 
 	it("throws when 'b' is an empty string", () => {
-		expect(
-			() => new AttrPairCompare({ a: "score", op: "gt", b: "" }),
-		).toThrow(/AttrPairCompare.*'b'.*empty string/);
+		expect(() => new AttrPairCompare({ a: "score", op: "gt", b: "" })).toThrow(
+			/AttrPairCompare.*'b'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -312,22 +310,19 @@ describe("AttrPairCompare", () => {
 
 	it("throws when 'op' is missing (undefined)", () => {
 		expect(
-			() =>
-				new AttrPairCompare({ a: "score", op: undefined as unknown as "lt", b: "threshold" }),
+			() => new AttrPairCompare({ a: "score", op: undefined as unknown as "lt", b: "threshold" }),
 		).toThrow(/AttrPairCompare.*'op'/);
 	});
 
 	it("throws when 'op' is not a string (number 42)", () => {
 		expect(
-			() =>
-				new AttrPairCompare({ a: "score", op: 42 as unknown as "lt", b: "threshold" }),
+			() => new AttrPairCompare({ a: "score", op: 42 as unknown as "lt", b: "threshold" }),
 		).toThrow(/AttrPairCompare.*'op'/);
 	});
 
 	it("throws when 'op' is an invalid string ('eq')", () => {
 		expect(
-			() =>
-				new AttrPairCompare({ a: "score", op: "eq" as unknown as "lt", b: "threshold" }),
+			() => new AttrPairCompare({ a: "score", op: "eq" as unknown as "lt", b: "threshold" }),
 		).toThrow(/AttrPairCompare.*'op'/);
 	});
 
@@ -348,9 +343,9 @@ describe("AttrPairCompare", () => {
 	});
 
 	it("throws when 'group' is present but is an empty string", () => {
-		expect(
-			() => new AttrPairCompare({ a: "score", op: "gt", b: "threshold", group: "" }),
-		).toThrow(/AttrPairCompare.*'group'.*empty string/);
+		expect(() => new AttrPairCompare({ a: "score", op: "gt", b: "threshold", group: "" })).toThrow(
+			/AttrPairCompare.*'group'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------

--- a/packages/builtins/src/__tests__/rules/AttrPairEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairEqual.test.mts
@@ -100,21 +100,21 @@ describe("AttrPairEqual", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'a' is undefined", () => {
-		expect(
-			() => new AttrPairEqual({ a: undefined as unknown as string, b: "owner" }),
-		).toThrow(/AttrPairEqual.*'a'.*(non-empty string|got undefined)/);
+		expect(() => new AttrPairEqual({ a: undefined as unknown as string, b: "owner" })).toThrow(
+			/AttrPairEqual.*'a'.*(non-empty string|got undefined)/,
+		);
 	});
 
 	it("throws when 'a' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrPairEqual({ a: 42 as unknown as string, b: "owner" }),
-		).toThrow(/AttrPairEqual.*'a'.*got number/);
+		expect(() => new AttrPairEqual({ a: 42 as unknown as string, b: "owner" })).toThrow(
+			/AttrPairEqual.*'a'.*got number/,
+		);
 	});
 
 	it("throws when 'a' is an empty string", () => {
-		expect(
-			() => new AttrPairEqual({ a: "", b: "owner" }),
-		).toThrow(/AttrPairEqual.*'a'.*empty string/);
+		expect(() => new AttrPairEqual({ a: "", b: "owner" })).toThrow(
+			/AttrPairEqual.*'a'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -122,21 +122,21 @@ describe("AttrPairEqual", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'b' is undefined", () => {
-		expect(
-			() => new AttrPairEqual({ a: "subject", b: undefined as unknown as string }),
-		).toThrow(/AttrPairEqual.*'b'.*(non-empty string|got undefined)/);
+		expect(() => new AttrPairEqual({ a: "subject", b: undefined as unknown as string })).toThrow(
+			/AttrPairEqual.*'b'.*(non-empty string|got undefined)/,
+		);
 	});
 
 	it("throws when 'b' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrPairEqual({ a: "subject", b: 42 as unknown as string }),
-		).toThrow(/AttrPairEqual.*'b'.*got number/);
+		expect(() => new AttrPairEqual({ a: "subject", b: 42 as unknown as string })).toThrow(
+			/AttrPairEqual.*'b'.*got number/,
+		);
 	});
 
 	it("throws when 'b' is an empty string", () => {
-		expect(
-			() => new AttrPairEqual({ a: "subject", b: "" }),
-		).toThrow(/AttrPairEqual.*'b'.*empty string/);
+		expect(() => new AttrPairEqual({ a: "subject", b: "" })).toThrow(
+			/AttrPairEqual.*'b'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -150,9 +150,9 @@ describe("AttrPairEqual", () => {
 	});
 
 	it("throws when 'group' is present but is an empty string", () => {
-		expect(
-			() => new AttrPairEqual({ a: "subject", b: "owner", group: "" }),
-		).toThrow(/AttrPairEqual.*'group'.*empty string/);
+		expect(() => new AttrPairEqual({ a: "subject", b: "owner", group: "" })).toThrow(
+			/AttrPairEqual.*'group'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------

--- a/packages/builtins/src/__tests__/rules/AttrPairEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairEqual.test.mts
@@ -1,0 +1,204 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrPairEqual } from "#/rules/AttrPairEqual.mjs";
+
+describe("AttrPairEqual", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: verify() returns true
+	// ---------------------------------------------------------------------------
+
+	it("returns true when both attrs are equal non-empty strings", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", "alice"],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// verify() returns false
+	// ---------------------------------------------------------------------------
+
+	it("returns false when the two strings are different", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", "bob"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is an empty string", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", ""],
+			["owner", "alice"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is an empty string", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", ""],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is a number (non-string)", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", 42],
+			["owner", "alice"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is a number (non-string)", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", 42],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is missing", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([["owner", "alice"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is missing", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([["subject", "alice"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is null", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", null],
+			["owner", "alice"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is null", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", null],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(
+			() => new AttrPairEqual({ a: undefined as unknown as string, b: "owner" }),
+		).toThrow(/AttrPairEqual.*'a'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrPairEqual({ a: 42 as unknown as string, b: "owner" }),
+		).toThrow(/AttrPairEqual.*'a'.*got number/);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(
+			() => new AttrPairEqual({ a: "", b: "owner" }),
+		).toThrow(/AttrPairEqual.*'a'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'b'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'b' is undefined", () => {
+		expect(
+			() => new AttrPairEqual({ a: "subject", b: undefined as unknown as string }),
+		).toThrow(/AttrPairEqual.*'b'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'b' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrPairEqual({ a: "subject", b: 42 as unknown as string }),
+		).toThrow(/AttrPairEqual.*'b'.*got number/);
+	});
+
+	it("throws when 'b' is an empty string", () => {
+		expect(
+			() => new AttrPairEqual({ a: "subject", b: "" }),
+		).toThrow(/AttrPairEqual.*'b'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(
+			() => new AttrPairEqual({ a: "subject", b: "owner", group: 42 as unknown as string }),
+		).toThrow(/AttrPairEqual.*'group'.*got number/);
+	});
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(
+			() => new AttrPairEqual({ a: "subject", b: "owner", group: "" }),
+		).toThrow(/AttrPairEqual.*'group'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default derived from 'a' and 'b'
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType from a and b", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		expect(rule.ruleType).toBe("attr_pair_equal:subject:owner");
+	});
+
+	it("distinct a/b produce distinct default ruleTypes (AND semantics)", () => {
+		const r1 = new AttrPairEqual({ a: "subject", b: "owner" });
+		const r2 = new AttrPairEqual({ a: "subject", b: "tenant" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the default", () => {
+		const r1 = new AttrPairEqual({ a: "subject", b: "owner", group: "identity-check" });
+		const r2 = new AttrPairEqual({ a: "subject", b: "creator", group: "identity-check" });
+		expect(r1.ruleType).toBe("identity-check");
+		expect(r2.ruleType).toBe("identity-check");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_mismatch'", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		expect(rule.code).toBe("attr_mismatch");
+	});
+
+	it("message contains 'a' name, 'b' name, and the phrase 'must equal'", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		expect(rule.message).toContain("subject");
+		expect(rule.message).toContain("owner");
+		expect(rule.message).toContain("must equal");
+	});
+
+	it("message starts with a capital letter", () => {
+		const rule = new AttrPairEqual({ a: "subject", b: "owner" });
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+});

--- a/packages/builtins/src/__tests__/rules/AttrPairNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairNotEqual.test.mts
@@ -100,21 +100,21 @@ describe("AttrPairNotEqual", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'a' is undefined", () => {
-		expect(
-			() => new AttrPairNotEqual({ a: undefined as unknown as string, b: "owner" }),
-		).toThrow(/AttrPairNotEqual.*'a'.*(non-empty string|got undefined)/);
+		expect(() => new AttrPairNotEqual({ a: undefined as unknown as string, b: "owner" })).toThrow(
+			/AttrPairNotEqual.*'a'.*(non-empty string|got undefined)/,
+		);
 	});
 
 	it("throws when 'a' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrPairNotEqual({ a: 42 as unknown as string, b: "owner" }),
-		).toThrow(/AttrPairNotEqual.*'a'.*got number/);
+		expect(() => new AttrPairNotEqual({ a: 42 as unknown as string, b: "owner" })).toThrow(
+			/AttrPairNotEqual.*'a'.*got number/,
+		);
 	});
 
 	it("throws when 'a' is an empty string", () => {
-		expect(
-			() => new AttrPairNotEqual({ a: "", b: "owner" }),
-		).toThrow(/AttrPairNotEqual.*'a'.*empty string/);
+		expect(() => new AttrPairNotEqual({ a: "", b: "owner" })).toThrow(
+			/AttrPairNotEqual.*'a'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -122,21 +122,21 @@ describe("AttrPairNotEqual", () => {
 	// ---------------------------------------------------------------------------
 
 	it("throws when 'b' is undefined", () => {
-		expect(
-			() => new AttrPairNotEqual({ a: "subject", b: undefined as unknown as string }),
-		).toThrow(/AttrPairNotEqual.*'b'.*(non-empty string|got undefined)/);
+		expect(() => new AttrPairNotEqual({ a: "subject", b: undefined as unknown as string })).toThrow(
+			/AttrPairNotEqual.*'b'.*(non-empty string|got undefined)/,
+		);
 	});
 
 	it("throws when 'b' is a non-string (number 42)", () => {
-		expect(
-			() => new AttrPairNotEqual({ a: "subject", b: 42 as unknown as string }),
-		).toThrow(/AttrPairNotEqual.*'b'.*got number/);
+		expect(() => new AttrPairNotEqual({ a: "subject", b: 42 as unknown as string })).toThrow(
+			/AttrPairNotEqual.*'b'.*got number/,
+		);
 	});
 
 	it("throws when 'b' is an empty string", () => {
-		expect(
-			() => new AttrPairNotEqual({ a: "subject", b: "" }),
-		).toThrow(/AttrPairNotEqual.*'b'.*empty string/);
+		expect(() => new AttrPairNotEqual({ a: "subject", b: "" })).toThrow(
+			/AttrPairNotEqual.*'b'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------
@@ -145,15 +145,14 @@ describe("AttrPairNotEqual", () => {
 
 	it("throws when 'group' is present but is a non-string (number 42)", () => {
 		expect(
-			() =>
-				new AttrPairNotEqual({ a: "subject", b: "owner", group: 42 as unknown as string }),
+			() => new AttrPairNotEqual({ a: "subject", b: "owner", group: 42 as unknown as string }),
 		).toThrow(/AttrPairNotEqual.*'group'.*got number/);
 	});
 
 	it("throws when 'group' is present but is an empty string", () => {
-		expect(
-			() => new AttrPairNotEqual({ a: "subject", b: "owner", group: "" }),
-		).toThrow(/AttrPairNotEqual.*'group'.*empty string/);
+		expect(() => new AttrPairNotEqual({ a: "subject", b: "owner", group: "" })).toThrow(
+			/AttrPairNotEqual.*'group'.*empty string/,
+		);
 	});
 
 	// ---------------------------------------------------------------------------

--- a/packages/builtins/src/__tests__/rules/AttrPairNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairNotEqual.test.mts
@@ -1,0 +1,205 @@
+import type { Attributes } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { AttrPairNotEqual } from "#/rules/AttrPairNotEqual.mjs";
+
+describe("AttrPairNotEqual", () => {
+	// ---------------------------------------------------------------------------
+	// Happy path: verify() returns true
+	// ---------------------------------------------------------------------------
+
+	it("returns true when both attrs are non-empty strings and not equal", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", "bob"],
+		]);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	// ---------------------------------------------------------------------------
+	// verify() returns false
+	// ---------------------------------------------------------------------------
+
+	it("returns false when the two strings are equal", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", "alice"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is an empty string", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", ""],
+			["owner", "bob"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is an empty string", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", ""],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is a number (non-string)", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", 42],
+			["owner", "bob"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is a number (non-string)", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", 42],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is missing", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([["owner", "bob"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is missing", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([["subject", "alice"]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'a' is null", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", null],
+			["owner", "bob"],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("returns false when attr 'b' is null", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const attrs: Attributes = new Map<string, unknown>([
+			["subject", "alice"],
+			["owner", null],
+		]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'a'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'a' is undefined", () => {
+		expect(
+			() => new AttrPairNotEqual({ a: undefined as unknown as string, b: "owner" }),
+		).toThrow(/AttrPairNotEqual.*'a'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'a' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrPairNotEqual({ a: 42 as unknown as string, b: "owner" }),
+		).toThrow(/AttrPairNotEqual.*'a'.*got number/);
+	});
+
+	it("throws when 'a' is an empty string", () => {
+		expect(
+			() => new AttrPairNotEqual({ a: "", b: "owner" }),
+		).toThrow(/AttrPairNotEqual.*'a'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'b'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'b' is undefined", () => {
+		expect(
+			() => new AttrPairNotEqual({ a: "subject", b: undefined as unknown as string }),
+		).toThrow(/AttrPairNotEqual.*'b'.*(non-empty string|got undefined)/);
+	});
+
+	it("throws when 'b' is a non-string (number 42)", () => {
+		expect(
+			() => new AttrPairNotEqual({ a: "subject", b: 42 as unknown as string }),
+		).toThrow(/AttrPairNotEqual.*'b'.*got number/);
+	});
+
+	it("throws when 'b' is an empty string", () => {
+		expect(
+			() => new AttrPairNotEqual({ a: "subject", b: "" }),
+		).toThrow(/AttrPairNotEqual.*'b'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// Construction errors: invalid 'group'
+	// ---------------------------------------------------------------------------
+
+	it("throws when 'group' is present but is a non-string (number 42)", () => {
+		expect(
+			() =>
+				new AttrPairNotEqual({ a: "subject", b: "owner", group: 42 as unknown as string }),
+		).toThrow(/AttrPairNotEqual.*'group'.*got number/);
+	});
+
+	it("throws when 'group' is present but is an empty string", () => {
+		expect(
+			() => new AttrPairNotEqual({ a: "subject", b: "owner", group: "" }),
+		).toThrow(/AttrPairNotEqual.*'group'.*empty string/);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: default derived from 'a' and 'b'
+	// ---------------------------------------------------------------------------
+
+	it("derives default ruleType from a and b", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		expect(rule.ruleType).toBe("attr_pair_not_equal:subject:owner");
+	});
+
+	it("distinct a/b produce distinct default ruleTypes (AND semantics)", () => {
+		const r1 = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		const r2 = new AttrPairNotEqual({ a: "subject", b: "tenant" });
+		expect(r1.ruleType).not.toBe(r2.ruleType);
+	});
+
+	// ---------------------------------------------------------------------------
+	// ruleType: group override
+	// ---------------------------------------------------------------------------
+
+	it("uses the provided group string as ruleType, overriding the default", () => {
+		const r1 = new AttrPairNotEqual({ a: "subject", b: "owner", group: "not-self" });
+		const r2 = new AttrPairNotEqual({ a: "subject", b: "creator", group: "not-self" });
+		expect(r1.ruleType).toBe("not-self");
+		expect(r2.ruleType).toBe("not-self");
+	});
+
+	// ---------------------------------------------------------------------------
+	// code and message fields
+	// ---------------------------------------------------------------------------
+
+	it("has code 'attr_match'", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		expect(rule.code).toBe("attr_match");
+	});
+
+	it("message contains 'a' name, 'b' name, and the phrase 'must not equal'", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		expect(rule.message).toContain("subject");
+		expect(rule.message).toContain("owner");
+		expect(rule.message).toContain("must not equal");
+	});
+
+	it("message starts with a capital letter", () => {
+		const rule = new AttrPairNotEqual({ a: "subject", b: "owner" });
+		expect(rule.message[0]).toBe(rule.message[0]?.toUpperCase());
+	});
+});

--- a/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
+++ b/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
@@ -47,6 +47,16 @@ describe("requireAttrName", () => {
 	it("throws with 'null' in message when value is null", () => {
 		expect(() => requireAttrName("MyClass", "a", null)).toThrow(/null/);
 	});
+
+	it("throws when value contains ':' (reserved as ruleType separator)", () => {
+		// Regression guard for an authorization-weakening bug: with ':' allowed,
+		// (a="x:y", b="z") and (a="x", b="y:z") would both produce the same
+		// `attr_pair_equal:x:y:z` default ruleType and be silently OR-combined
+		// by the evaluator. Fail-fast at construction instead.
+		expect(() => requireAttrName("MyClass", "a", "name:space")).toThrow(
+			/must not contain ':'.*got 'name:space'/,
+		);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -282,8 +292,17 @@ describe("computeValuesKey", () => {
 		expect(computeValuesKey(["b", "a"])).toBe(computeValuesKey(["a", "b"]));
 	});
 
-	it("count discrimination: ['a'] !== ['a', 'a'] (count segment changes)", () => {
-		expect(computeValuesKey(["a"])).not.toBe(computeValuesKey(["a", "a"]));
+	it("count discrimination: ['a'] !== ['a', 'b'] (distinct content → distinct key)", () => {
+		expect(computeValuesKey(["a"])).not.toBe(computeValuesKey(["a", "b"]));
+	});
+
+	it("dedup parity: ['a'] === ['a', 'a'] (duplicates do not affect the Set-based rule behavior, so they must not affect ruleType either)", () => {
+		// AttrLiteralIn / AttrLiteralNotIn use `new Set(values)` for verify(),
+		// so duplicate elements have no semantic effect. The ruleType must
+		// mirror that — otherwise two logically-equivalent rules would be
+		// placed in different evaluator groups and be AND-combined, when
+		// the caller intended them to be OR-combined (shared ruleType).
+		expect(computeValuesKey(["a"])).toBe(computeValuesKey(["a", "a"]));
 	});
 
 	it("content discrimination: ['a', 'b'] !== ['a', 'c'] (hash differs)", () => {

--- a/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
+++ b/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
@@ -289,6 +289,17 @@ describe("computeValuesKey", () => {
 		expect(computeValuesKey(["1"])).not.toBe(computeValuesKey([1]));
 	});
 
+	it("separator collision guard: ['a,b', 'c'] !== ['a', 'b,c'] (values containing commas do not collide)", () => {
+		// Regression guard: a naive implementation of the form
+		//   values.map(String).sort().join(",")
+		// would produce the same string "a,b,c" for both inputs and thus the
+		// same ruleType. That would cause the evaluator to OR what the caller
+		// meant as two independent set constraints, weakening authorization.
+		// The canonical form JSON.stringify-es each element before joining,
+		// so quotes/escapes disambiguate the element boundary.
+		expect(computeValuesKey(["a,b", "c"])).not.toBe(computeValuesKey(["a", "b,c"]));
+	});
+
 	it("pure / referentially transparent: two calls with the same input return the same string", () => {
 		const input = ["x", "y", "z"];
 		expect(computeValuesKey(input)).toBe(computeValuesKey(input));

--- a/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
+++ b/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyCompare,
+	COMPARE_OPS,
+	computeValuesKey,
+	requireAttrName,
+	requireCompareOp,
+	requireHomogeneousLiteralArray,
+	requireLiteralValue,
+	requireNumber,
+	requireOptionalGroup,
+} from "#/rules/_sharedValidation.mjs";
+
+// ---------------------------------------------------------------------------
+// requireAttrName
+// ---------------------------------------------------------------------------
+
+describe("requireAttrName", () => {
+	it("returns the input string when value is a valid non-empty string", () => {
+		expect(requireAttrName("MyClass", "a", "role")).toBe("role");
+	});
+
+	it("returns the input string for fieldName 'b'", () => {
+		expect(requireAttrName("MyClass", "b", "score")).toBe("score");
+	});
+
+	it("throws with className and fieldName 'a' in message when value is undefined", () => {
+		expect(() => requireAttrName("MyClass", "a", undefined)).toThrow(
+			/MyClass.*'a'.*non-empty string.*got undefined/,
+		);
+	});
+
+	it("throws with className and fieldName 'b' in message when value is undefined", () => {
+		expect(() => requireAttrName("MyClass", "b", undefined)).toThrow(
+			/MyClass.*'b'.*non-empty string.*got undefined/,
+		);
+	});
+
+	it("throws with 'empty string' in message when value is ''", () => {
+		expect(() => requireAttrName("MyClass", "a", "")).toThrow(/MyClass.*'a'.*got empty string/);
+	});
+
+	it("throws with 'got number' in message when value is 42", () => {
+		expect(() => requireAttrName("MyClass", "a", 42)).toThrow(/MyClass.*'a'.*got number/);
+	});
+
+	it("throws with 'null' in message when value is null", () => {
+		expect(() => requireAttrName("MyClass", "a", null)).toThrow(/null/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requireLiteralValue
+// ---------------------------------------------------------------------------
+
+describe("requireLiteralValue", () => {
+	it("returns the value when it is a string", () => {
+		expect(requireLiteralValue("MyClass", "v", "hello")).toBe("hello");
+	});
+
+	it("returns the value when it is a number", () => {
+		expect(requireLiteralValue("MyClass", "v", 42)).toBe(42);
+	});
+
+	it("returns the value when it is a boolean", () => {
+		expect(requireLiteralValue("MyClass", "v", false)).toBe(false);
+	});
+
+	it("throws with 'null' in message when value is null", () => {
+		expect(() => requireLiteralValue("MyClass", "v", null)).toThrow(/null/);
+	});
+
+	it("throws with 'undefined' in message when value is undefined", () => {
+		expect(() => requireLiteralValue("MyClass", "v", undefined)).toThrow(/undefined/);
+	});
+
+	it("throws with 'object' in message when value is a plain object", () => {
+		expect(() => requireLiteralValue("MyClass", "v", {})).toThrow(/object/);
+	});
+
+	it("throws with 'object' in message when value is an array (typeof [] === 'object')", () => {
+		expect(() => requireLiteralValue("MyClass", "v", [])).toThrow(/object/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requireNumber
+// ---------------------------------------------------------------------------
+
+describe("requireNumber", () => {
+	it("returns 0 (zero)", () => {
+		expect(requireNumber("MyClass", "v", 0)).toBe(0);
+	});
+
+	it("returns -0 (negative zero)", () => {
+		expect(requireNumber("MyClass", "v", -0)).toBe(-0);
+	});
+
+	it("returns a large finite number", () => {
+		expect(requireNumber("MyClass", "v", 1e308)).toBe(1e308);
+	});
+
+	it("returns Infinity without throwing (Infinity is a valid number per spec)", () => {
+		expect(requireNumber("MyClass", "v", Infinity)).toBe(Infinity);
+	});
+
+	it("returns -Infinity without throwing", () => {
+		expect(requireNumber("MyClass", "v", -Infinity)).toBe(-Infinity);
+	});
+
+	it("throws on NaN with message matching /must not be NaN/", () => {
+		expect(() => requireNumber("MyClass", "v", NaN)).toThrow(/must not be NaN/);
+	});
+
+	it("throws on a string '42' with message containing 'got string'", () => {
+		expect(() => requireNumber("MyClass", "v", "42")).toThrow(/got string/);
+	});
+
+	it("throws on null with message containing 'null'", () => {
+		expect(() => requireNumber("MyClass", "v", null)).toThrow(/null/);
+	});
+
+	it("throws on undefined with message containing 'undefined'", () => {
+		expect(() => requireNumber("MyClass", "v", undefined)).toThrow(/undefined/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requireHomogeneousLiteralArray
+// ---------------------------------------------------------------------------
+
+describe("requireHomogeneousLiteralArray", () => {
+	it("returns a non-empty all-string array", () => {
+		const arr = ["a", "b", "c"];
+		expect(requireHomogeneousLiteralArray("MyClass", arr)).toEqual(arr);
+	});
+
+	it("returns a non-empty all-number array", () => {
+		const arr = [1, 2, 3];
+		expect(requireHomogeneousLiteralArray("MyClass", arr)).toEqual(arr);
+	});
+
+	it("returns a non-empty all-boolean array", () => {
+		const arr = [true, false];
+		expect(requireHomogeneousLiteralArray("MyClass", arr)).toEqual(arr);
+	});
+
+	it("throws with 'got string' when value is not an array", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", "abc")).toThrow(/got string/);
+	});
+
+	it("throws with 'undefined' when value is undefined", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", undefined)).toThrow(/undefined/);
+	});
+
+	it("throws with 'null' when value is null", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", null)).toThrow(/null/);
+	});
+
+	it("throws with 'non-empty array' on empty array", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", [])).toThrow(/non-empty array/);
+	});
+
+	it("throws with 'null' when an element is null", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", [null])).toThrow(/null/);
+	});
+
+	it("throws with 'undefined' when an element is undefined", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", [undefined])).toThrow(/undefined/);
+	});
+
+	it("throws with 'object' when an element is an object", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", [{}])).toThrow(/object/);
+	});
+
+	it("throws with mixed types message for ['a', 1] (left-to-right Set insertion order)", () => {
+		expect(() => requireHomogeneousLiteralArray("MyClass", ["a", 1])).toThrow(
+			/mixed types \[string, number\]/,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requireCompareOp
+// ---------------------------------------------------------------------------
+
+describe("requireCompareOp", () => {
+	it("returns 'lt' for valid op 'lt'", () => {
+		expect(requireCompareOp("MyClass", "lt")).toBe("lt");
+	});
+
+	it("returns 'le' for valid op 'le'", () => {
+		expect(requireCompareOp("MyClass", "le")).toBe("le");
+	});
+
+	it("returns 'gt' for valid op 'gt'", () => {
+		expect(requireCompareOp("MyClass", "gt")).toBe("gt");
+	});
+
+	it("returns 'ge' for valid op 'ge'", () => {
+		expect(requireCompareOp("MyClass", "ge")).toBe("ge");
+	});
+
+	it("throws on invalid string 'eq' with message listing valid ops joined by ' | '", () => {
+		expect(() => requireCompareOp("MyClass", "eq")).toThrow(/lt \| le \| gt \| ge/);
+	});
+
+	it("throws on empty string '' with message listing valid ops", () => {
+		expect(() => requireCompareOp("MyClass", "")).toThrow(/lt \| le \| gt \| ge/);
+	});
+
+	it("throws on symbolic string '<' with message listing valid ops", () => {
+		expect(() => requireCompareOp("MyClass", "<")).toThrow(/lt \| le \| gt \| ge/);
+	});
+
+	it("throws on number 42 with message containing the type label", () => {
+		expect(() => requireCompareOp("MyClass", 42)).toThrow(/got number/);
+	});
+
+	it("throws on null with message containing the type label", () => {
+		expect(() => requireCompareOp("MyClass", null)).toThrow(/null/);
+	});
+
+	it("throws on undefined with message containing the type label", () => {
+		expect(() => requireCompareOp("MyClass", undefined)).toThrow(/undefined/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requireOptionalGroup
+// ---------------------------------------------------------------------------
+
+describe("requireOptionalGroup", () => {
+	it("returns undefined when value is undefined", () => {
+		expect(requireOptionalGroup("MyClass", undefined)).toBeUndefined();
+	});
+
+	it("returns the input string when value is a non-empty string", () => {
+		expect(requireOptionalGroup("MyClass", "my-group")).toBe("my-group");
+	});
+
+	it("throws with 'empty string' message on ''", () => {
+		expect(() => requireOptionalGroup("MyClass", "")).toThrow(/empty string/);
+	});
+
+	it("throws with 'got number' message on 42", () => {
+		expect(() => requireOptionalGroup("MyClass", 42)).toThrow(/got number/);
+	});
+
+	it("throws with 'null' in message on null", () => {
+		expect(() => requireOptionalGroup("MyClass", null)).toThrow(/null/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// computeValuesKey
+// ---------------------------------------------------------------------------
+
+describe("computeValuesKey", () => {
+	it("returns a string matching /{type}:{count}:{8-hex-chars}/ format", () => {
+		expect(computeValuesKey(["admin"])).toMatch(/^(string|number|boolean):[0-9]+:[0-9a-f]{8}$/);
+	});
+
+	it("sort determinism: same content in different order produces the same key", () => {
+		expect(computeValuesKey(["b", "a"])).toBe(computeValuesKey(["a", "b"]));
+	});
+
+	it("count discrimination: ['a'] !== ['a', 'a'] (count segment changes)", () => {
+		expect(computeValuesKey(["a"])).not.toBe(computeValuesKey(["a", "a"]));
+	});
+
+	it("content discrimination: ['a', 'b'] !== ['a', 'c'] (hash differs)", () => {
+		expect(computeValuesKey(["a", "b"])).not.toBe(computeValuesKey(["a", "c"]));
+	});
+
+	it("type segment correctness: string array starts with 'string:'", () => {
+		expect(computeValuesKey(["admin"])).toMatch(/^string:/);
+	});
+
+	it("type segment correctness: number array starts with 'number:'", () => {
+		expect(computeValuesKey([1])).toMatch(/^number:/);
+	});
+
+	it("type segment correctness: boolean array starts with 'boolean:'", () => {
+		expect(computeValuesKey([true])).toMatch(/^boolean:/);
+	});
+
+	it("type divergence: computeValuesKey(['1']) !== computeValuesKey([1]) (type segment differs)", () => {
+		expect(computeValuesKey(["1"])).not.toBe(computeValuesKey([1]));
+	});
+
+	it("pure / referentially transparent: two calls with the same input return the same string", () => {
+		const input = ["x", "y", "z"];
+		expect(computeValuesKey(input)).toBe(computeValuesKey(input));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// applyCompare
+// ---------------------------------------------------------------------------
+
+describe("applyCompare", () => {
+	describe("op=lt", () => {
+		it("returns true when left < right (1 < 2)", () => {
+			expect(applyCompare("lt", 1, 2)).toBe(true);
+		});
+
+		it("returns false when left === right (2 < 2 is false)", () => {
+			expect(applyCompare("lt", 2, 2)).toBe(false);
+		});
+
+		it("returns false when left > right (3 < 2 is false)", () => {
+			expect(applyCompare("lt", 3, 2)).toBe(false);
+		});
+
+		it("edge: -Infinity < 0 returns true", () => {
+			expect(applyCompare("lt", -Infinity, 0)).toBe(true);
+		});
+	});
+
+	describe("op=le", () => {
+		it("returns true when left < right (1 <= 2)", () => {
+			expect(applyCompare("le", 1, 2)).toBe(true);
+		});
+
+		it("returns true when left === right (2 <= 2)", () => {
+			expect(applyCompare("le", 2, 2)).toBe(true);
+		});
+
+		it("returns false when left > right (3 <= 2 is false)", () => {
+			expect(applyCompare("le", 3, 2)).toBe(false);
+		});
+
+		it("edge: 0 >= -0 returns true (ge symmetry check; 0 <= -0 also true)", () => {
+			expect(applyCompare("le", 0, -0)).toBe(true);
+		});
+	});
+
+	describe("op=gt", () => {
+		it("returns true when left > right (3 > 2)", () => {
+			expect(applyCompare("gt", 3, 2)).toBe(true);
+		});
+
+		it("returns false when left === right (2 > 2 is false)", () => {
+			expect(applyCompare("gt", 2, 2)).toBe(false);
+		});
+
+		it("returns false when left < right (1 > 2 is false)", () => {
+			expect(applyCompare("gt", 1, 2)).toBe(false);
+		});
+
+		it("edge: Infinity > 1e308 returns true", () => {
+			expect(applyCompare("gt", Infinity, 1e308)).toBe(true);
+		});
+	});
+
+	describe("op=ge", () => {
+		it("returns true when left > right (3 >= 2)", () => {
+			expect(applyCompare("ge", 3, 2)).toBe(true);
+		});
+
+		it("returns true when left === right (2 >= 2)", () => {
+			expect(applyCompare("ge", 2, 2)).toBe(true);
+		});
+
+		it("returns false when left < right (1 >= 2 is false)", () => {
+			expect(applyCompare("ge", 1, 2)).toBe(false);
+		});
+
+		it("edge: 0 >= -0 returns true", () => {
+			expect(applyCompare("ge", 0, -0)).toBe(true);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// COMPARE_OPS
+// ---------------------------------------------------------------------------
+
+describe("COMPARE_OPS", () => {
+	it("exposes exactly 4 values", () => {
+		expect(COMPARE_OPS).toHaveLength(4);
+	});
+
+	it("contains 'lt', 'le', 'gt', 'ge' in order", () => {
+		expect(COMPARE_OPS).toEqual(["lt", "le", "gt", "ge"]);
+	});
+});

--- a/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
+++ b/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
@@ -81,6 +81,14 @@ describe("requireLiteralValue", () => {
 	it("throws with 'object' in message when value is an array (typeof [] === 'object')", () => {
 		expect(() => requireLiteralValue("MyClass", "v", [])).toThrow(/object/);
 	});
+
+	it("throws on NaN (NaN === NaN is false; would invert Equal/NotEqual rules)", () => {
+		// Regression guard for an authorization-weakening bug: with NaN accepted,
+		// AttrLiteralNotEqual({ v: NaN }) would always pass for any numeric
+		// attribute because `x !== NaN` is always true. Must fail-fast in
+		// construction instead.
+		expect(() => requireLiteralValue("MyClass", "v", Number.NaN)).toThrow(/must not be NaN/);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -176,6 +184,15 @@ describe("requireHomogeneousLiteralArray", () => {
 	it("throws with mixed types message for ['a', 1] (left-to-right Set insertion order)", () => {
 		expect(() => requireHomogeneousLiteralArray("MyClass", ["a", 1])).toThrow(
 			/mixed types \[string, number\]/,
+		);
+	});
+
+	it("throws when an element is NaN (would silently mismatch AttrLiteralIn/NotIn)", () => {
+		// Regression guard: AttrLiteralIn uses strict equality against each element;
+		// a NaN element could never match any attribute value because NaN !== NaN.
+		// Must fail-fast at construction rather than ship an always-false element.
+		expect(() => requireHomogeneousLiteralArray("MyClass", [1, Number.NaN, 3])).toThrow(
+			/must not contain NaN/,
 		);
 	});
 });

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -8,7 +8,15 @@ export { builtinCollectorsModule } from "./module.mjs";
 // Resource
 export { DotNotationResourceParser } from "./resource/DotNotationResourceParser.mjs";
 // Rules
+export { AttrLiteralCompare, type AttrLiteralCompareConfig } from "./rules/AttrLiteralCompare.mjs";
+export { AttrLiteralEqual, type AttrLiteralEqualConfig } from "./rules/AttrLiteralEqual.mjs";
+export { AttrLiteralIn, type AttrLiteralInConfig } from "./rules/AttrLiteralIn.mjs";
+export { AttrLiteralNotEqual, type AttrLiteralNotEqualConfig } from "./rules/AttrLiteralNotEqual.mjs";
+export { AttrLiteralNotIn, type AttrLiteralNotInConfig } from "./rules/AttrLiteralNotIn.mjs";
 export { AttrMatchRule, type AttrMatchRuleConfig } from "./rules/AttrMatchRule.mjs";
+export { AttrPairCompare, type AttrPairCompareConfig } from "./rules/AttrPairCompare.mjs";
+export { AttrPairEqual, type AttrPairEqualConfig } from "./rules/AttrPairEqual.mjs";
+export { AttrPairNotEqual, type AttrPairNotEqualConfig } from "./rules/AttrPairNotEqual.mjs";
 export { HasPermission } from "./rules/HasPermission.mjs";
 export { HasScope } from "./rules/HasScope.mjs";
 export { ResourceActionPermissionRuleCollector } from "./rules/ResourceActionPermissionRuleCollector.mjs";

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -11,7 +11,10 @@ export { DotNotationResourceParser } from "./resource/DotNotationResourceParser.
 export { AttrLiteralCompare, type AttrLiteralCompareConfig } from "./rules/AttrLiteralCompare.mjs";
 export { AttrLiteralEqual, type AttrLiteralEqualConfig } from "./rules/AttrLiteralEqual.mjs";
 export { AttrLiteralIn, type AttrLiteralInConfig } from "./rules/AttrLiteralIn.mjs";
-export { AttrLiteralNotEqual, type AttrLiteralNotEqualConfig } from "./rules/AttrLiteralNotEqual.mjs";
+export {
+	AttrLiteralNotEqual,
+	type AttrLiteralNotEqualConfig,
+} from "./rules/AttrLiteralNotEqual.mjs";
 export { AttrLiteralNotIn, type AttrLiteralNotInConfig } from "./rules/AttrLiteralNotIn.mjs";
 export { AttrMatchRule, type AttrMatchRuleConfig } from "./rules/AttrMatchRule.mjs";
 export { AttrPairCompare, type AttrPairCompareConfig } from "./rules/AttrPairCompare.mjs";

--- a/packages/builtins/src/rules/AttrLiteralCompare.mts
+++ b/packages/builtins/src/rules/AttrLiteralCompare.mts
@@ -1,0 +1,53 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	type CompareOp,
+	applyCompare,
+	requireAttrName,
+	requireCompareOp,
+	requireNumber,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrLiteralCompareConfig {
+	a: string;
+	op: CompareOp;
+	v: number;
+	group?: string;
+}
+
+/**
+ * Rule that passes when a named attribute is present, is a number, and
+ * satisfies the configured comparison operator against the configured literal
+ * number `v`. NaN attributes always return false. Missing, null, or non-number
+ * attributes return false (safe-deny). NaN is rejected at construction time.
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a`, `op`, and `v`:
+ *   `attr_literal_compare:{a}:{op}:{String(v)}`
+ *
+ * Pass an explicit `group` string to override the default ruleType entirely.
+ */
+export class AttrLiteralCompare implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_compare_violated";
+	readonly message: string;
+
+	constructor(private readonly config: AttrLiteralCompareConfig) {
+		requireAttrName("AttrLiteralCompare", "a", config.a);
+		requireNumber("AttrLiteralCompare", "v", config.v);
+		requireCompareOp("AttrLiteralCompare", config.op);
+		const group = requireOptionalGroup("AttrLiteralCompare", config.group);
+
+		this.ruleType =
+			group ?? `attr_literal_compare:${config.a}:${config.op}:${String(config.v)}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must be ${config.op} ${String(config.v)}.`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const x = attrs.get(this.config.a);
+		if (typeof x !== "number") return false;
+		return applyCompare(this.config.op, x, this.config.v);
+	}
+}

--- a/packages/builtins/src/rules/AttrLiteralCompare.mts
+++ b/packages/builtins/src/rules/AttrLiteralCompare.mts
@@ -1,7 +1,7 @@
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
-	type CompareOp,
 	applyCompare,
+	type CompareOp,
 	requireAttrName,
 	requireCompareOp,
 	requireNumber,
@@ -40,8 +40,7 @@ export class AttrLiteralCompare implements Rule {
 		requireCompareOp("AttrLiteralCompare", config.op);
 		const group = requireOptionalGroup("AttrLiteralCompare", config.group);
 
-		this.ruleType =
-			group ?? `attr_literal_compare:${config.a}:${config.op}:${String(config.v)}`;
+		this.ruleType = group ?? `attr_literal_compare:${config.a}:${config.op}:${String(config.v)}`;
 		this.message = `Attribute constraint not satisfied: ${config.a} must be ${config.op} ${String(config.v)}.`;
 	}
 

--- a/packages/builtins/src/rules/AttrLiteralEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralEqual.mts
@@ -20,9 +20,15 @@ export interface AttrLiteralEqualConfig {
  * ## Grouping and the default ruleType
  *
  * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
- * across groups. The default `ruleType` is derived from `a` and `v` so that
- * distinct literal requirements are AND-combined by default:
- *   `attr_literal_equal:{a}:{String(v)}`
+ * across groups. The default `ruleType` is derived from `a`, `typeof v`, and
+ * `String(v)` so that distinct literal requirements are AND-combined by default:
+ *   `attr_literal_equal:{a}:{typeof v}:{String(v)}`
+ *
+ * The `typeof v` segment is required because `String(v)` collapses distinct-
+ * type literals that stringify the same way (e.g. `true` vs `"true"`, `1` vs
+ * `"1"`). Without it, two rules on the same attribute with different-type
+ * literals would share a `ruleType` and be OR-combined by the evaluator,
+ * silently weakening authorization.
  *
  * Pass a shared `group` string to two instances to opt into OR semantics
  * (e.g. "role is admin" OR "role is superuser" under one group).
@@ -37,7 +43,8 @@ export class AttrLiteralEqual implements Rule {
 		requireLiteralValue("AttrLiteralEqual", "v", config.v);
 		const group = requireOptionalGroup("AttrLiteralEqual", config.group);
 
-		this.ruleType = group ?? `attr_literal_equal:${config.a}:${String(config.v)}`;
+		this.ruleType =
+			group ?? `attr_literal_equal:${config.a}:${typeof config.v}:${String(config.v)}`;
 		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${String(config.v)}.`;
 	}
 

--- a/packages/builtins/src/rules/AttrLiteralEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralEqual.mts
@@ -1,0 +1,49 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	type LiteralValue,
+	requireAttrName,
+	requireLiteralValue,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrLiteralEqualConfig {
+	a: string;
+	v: LiteralValue;
+	group?: string;
+}
+
+/**
+ * Rule that passes when a named attribute is present and strictly equal to a
+ * configured literal value (string, number, or boolean). No type coercion is
+ * performed: the attribute value must be the same type and value as `v`.
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a` and `v` so that
+ * distinct literal requirements are AND-combined by default:
+ *   `attr_literal_equal:{a}:{String(v)}`
+ *
+ * Pass a shared `group` string to two instances to opt into OR semantics
+ * (e.g. "role is admin" OR "role is superuser" under one group).
+ */
+export class AttrLiteralEqual implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_not_equal";
+	readonly message: string;
+
+	constructor(private readonly config: AttrLiteralEqualConfig) {
+		requireAttrName("AttrLiteralEqual", "a", config.a);
+		requireLiteralValue("AttrLiteralEqual", "v", config.v);
+		const group = requireOptionalGroup("AttrLiteralEqual", config.group);
+
+		this.ruleType = group ?? `attr_literal_equal:${config.a}:${String(config.v)}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${String(config.v)}.`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const x = attrs.get(this.config.a);
+		if (typeof x !== typeof this.config.v) return false;
+		return x === this.config.v;
+	}
+}

--- a/packages/builtins/src/rules/AttrLiteralIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralIn.mts
@@ -1,0 +1,62 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	type LiteralValue,
+	computeValuesKey,
+	requireAttrName,
+	requireHomogeneousLiteralArray,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrLiteralInConfig {
+	a: string;
+	values: LiteralValue[];
+	group?: string;
+}
+
+/**
+ * Rule that passes when a named attribute is present, matches the element type
+ * of the configured values array, and is included in that array. No type
+ * coercion is performed. If the attribute is missing, null, or of the wrong
+ * type the rule returns false (safe-deny).
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a` and a stable
+ * content-hash key over the values array:
+ *   `attr_literal_in:{a}:{valuesKey}`
+ *
+ * Two instances with the same `a` but different `values` will produce distinct
+ * ruleTypes and thus be AND-combined by the evaluator. Two instances with the
+ * same `a` and logically equivalent `values` (regardless of insertion order)
+ * will share a ruleType and be OR-combined.
+ *
+ * Pass an explicit `group` string to override the default ruleType entirely.
+ */
+export class AttrLiteralIn implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_not_in_set";
+	readonly message: string;
+
+	private readonly elementType: string;
+	private readonly valuesSet: Set<LiteralValue>;
+
+	constructor(private readonly config: AttrLiteralInConfig) {
+		requireAttrName("AttrLiteralIn", "a", config.a);
+		const values = requireHomogeneousLiteralArray("AttrLiteralIn", config.values);
+		const group = requireOptionalGroup("AttrLiteralIn", config.group);
+
+		this.elementType = typeof values[0];
+		this.valuesSet = new Set(values);
+
+		const valuesKey = computeValuesKey(values);
+		this.ruleType = group ?? `attr_literal_in:${config.a}:${valuesKey}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must be one of [${values.map(String).join(", ")}].`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const x = attrs.get(this.config.a);
+		if (typeof x !== this.elementType) return false;
+		return this.valuesSet.has(x as LiteralValue);
+	}
+}

--- a/packages/builtins/src/rules/AttrLiteralIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralIn.mts
@@ -1,7 +1,7 @@
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
-	type LiteralValue,
 	computeValuesKey,
+	type LiteralValue,
 	requireAttrName,
 	requireHomogeneousLiteralArray,
 	requireOptionalGroup,

--- a/packages/builtins/src/rules/AttrLiteralNotEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotEqual.mts
@@ -1,0 +1,48 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	type LiteralValue,
+	requireAttrName,
+	requireLiteralValue,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrLiteralNotEqualConfig {
+	a: string;
+	v: LiteralValue;
+	group?: string;
+}
+
+/**
+ * Rule that passes when a named attribute is present, matches the type of the
+ * configured literal value, and is strictly NOT equal to it. No type coercion
+ * is performed. If the attribute is missing, null, or of the wrong type the
+ * rule returns false (safe-deny).
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a` and `v`:
+ *   `attr_literal_not_equal:{a}:{String(v)}`
+ *
+ * Pass a shared `group` string to two instances to opt into OR semantics.
+ */
+export class AttrLiteralNotEqual implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_equal";
+	readonly message: string;
+
+	constructor(private readonly config: AttrLiteralNotEqualConfig) {
+		requireAttrName("AttrLiteralNotEqual", "a", config.a);
+		requireLiteralValue("AttrLiteralNotEqual", "v", config.v);
+		const group = requireOptionalGroup("AttrLiteralNotEqual", config.group);
+
+		this.ruleType = group ?? `attr_literal_not_equal:${config.a}:${String(config.v)}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must not equal ${String(config.v)}.`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const x = attrs.get(this.config.a);
+		if (typeof x !== typeof this.config.v) return false;
+		return x !== this.config.v;
+	}
+}

--- a/packages/builtins/src/rules/AttrLiteralNotEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotEqual.mts
@@ -21,8 +21,14 @@ export interface AttrLiteralNotEqualConfig {
  * ## Grouping and the default ruleType
  *
  * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
- * across groups. The default `ruleType` is derived from `a` and `v`:
- *   `attr_literal_not_equal:{a}:{String(v)}`
+ * across groups. The default `ruleType` is derived from `a`, `typeof v`, and
+ * `String(v)`:
+ *   `attr_literal_not_equal:{a}:{typeof v}:{String(v)}`
+ *
+ * The `typeof v` segment prevents silent `ruleType` collisions between
+ * different-type literals that stringify the same way (e.g. `1` vs `"1"`),
+ * which would otherwise be OR-combined by the evaluator against the intent
+ * of two independent constraints. See AttrLiteralEqual for the same rationale.
  *
  * Pass a shared `group` string to two instances to opt into OR semantics.
  */
@@ -36,7 +42,8 @@ export class AttrLiteralNotEqual implements Rule {
 		requireLiteralValue("AttrLiteralNotEqual", "v", config.v);
 		const group = requireOptionalGroup("AttrLiteralNotEqual", config.group);
 
-		this.ruleType = group ?? `attr_literal_not_equal:${config.a}:${String(config.v)}`;
+		this.ruleType =
+			group ?? `attr_literal_not_equal:${config.a}:${typeof config.v}:${String(config.v)}`;
 		this.message = `Attribute constraint not satisfied: ${config.a} must not equal ${String(config.v)}.`;
 	}
 

--- a/packages/builtins/src/rules/AttrLiteralNotIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotIn.mts
@@ -1,0 +1,57 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	type LiteralValue,
+	computeValuesKey,
+	requireAttrName,
+	requireHomogeneousLiteralArray,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrLiteralNotInConfig {
+	a: string;
+	values: LiteralValue[];
+	group?: string;
+}
+
+/**
+ * Rule that passes when a named attribute is present, matches the element type
+ * of the configured values array, and is NOT included in that array. No type
+ * coercion is performed. If the attribute is missing, null, or of the wrong
+ * type the rule returns false (safe-deny).
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a` and a stable
+ * content-hash key over the values array:
+ *   `attr_literal_not_in:{a}:{valuesKey}`
+ *
+ * Pass an explicit `group` string to override the default ruleType entirely.
+ */
+export class AttrLiteralNotIn implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_in_set";
+	readonly message: string;
+
+	private readonly elementType: string;
+	private readonly valuesSet: Set<LiteralValue>;
+
+	constructor(private readonly config: AttrLiteralNotInConfig) {
+		requireAttrName("AttrLiteralNotIn", "a", config.a);
+		const values = requireHomogeneousLiteralArray("AttrLiteralNotIn", config.values);
+		const group = requireOptionalGroup("AttrLiteralNotIn", config.group);
+
+		this.elementType = typeof values[0];
+		this.valuesSet = new Set(values);
+
+		const valuesKey = computeValuesKey(values);
+		this.ruleType = group ?? `attr_literal_not_in:${config.a}:${valuesKey}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must not be one of [${values.map(String).join(", ")}].`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const x = attrs.get(this.config.a);
+		if (typeof x !== this.elementType) return false;
+		return !this.valuesSet.has(x as LiteralValue);
+	}
+}

--- a/packages/builtins/src/rules/AttrLiteralNotIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotIn.mts
@@ -1,7 +1,7 @@
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
-	type LiteralValue,
 	computeValuesKey,
+	type LiteralValue,
 	requireAttrName,
 	requireHomogeneousLiteralArray,
 	requireOptionalGroup,

--- a/packages/builtins/src/rules/AttrMatchRule.mts
+++ b/packages/builtins/src/rules/AttrMatchRule.mts
@@ -1,53 +1,7 @@
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
-
-export interface AttrMatchRuleConfig {
-	a: string;
-	b: string;
-	/**
-	 * Optional grouping key used as `ruleType`. See the class comment for
-	 * how this interacts with the evaluator's OR-within-group /
-	 * AND-across-groups semantics.
-	 */
-	group?: string;
-}
+import { AttrPairEqual } from "./AttrPairEqual.mjs";
 
 /**
- * Rule that passes when two named attributes are present, are non-empty
- * strings, and are equal. A pure predicate over the attributes map —
- * `verify(attrs)` does not touch `CollectorContext` and does not close
- * over request state.
- *
- * ## Grouping and the default ruleType
- *
- * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
- * across groups. If every `AttrMatchRule` shared one fixed `ruleType`,
- * two instances collected for different comparisons (e.g. subject vs.
- * subscriber AND tenant vs. request-tenant) would be OR'd together and
- * authorization would weaken silently.
- *
- * To default to the safe reading of "each distinct pair of attributes
- * is a separate AND-combined requirement", `ruleType` is derived from
- * `a` and `b` when `group` is not given: `attr_match:{a}:{b}`.
- *
- * When callers actually want two comparisons to be OR-combined
- * (alternative identities, for example), they opt in explicitly by
- * passing the same `group` to both rule instances.
+ * @deprecated Use {@link AttrPairEqual}. Scheduled for removal in a future major version.
  */
-export class AttrMatchRule implements Rule {
-	readonly ruleType: string;
-	readonly code = "attr_mismatch";
-	readonly message: string;
-
-	constructor(private readonly config: AttrMatchRuleConfig) {
-		this.ruleType = config.group ?? `attr_match:${config.a}:${config.b}`;
-		this.message = `Attribute constraint not satisfied: ${config.a} and ${config.b} must both be non-empty strings and equal.`;
-	}
-
-	verify(attrs: Attributes): boolean {
-		const a = attrs.get(this.config.a);
-		const b = attrs.get(this.config.b);
-		if (typeof a !== "string" || a.length === 0) return false;
-		if (typeof b !== "string" || b.length === 0) return false;
-		return a === b;
-	}
-}
+export const AttrMatchRule = AttrPairEqual;
+export type AttrMatchRuleConfig = ConstructorParameters<typeof AttrPairEqual>[0];

--- a/packages/builtins/src/rules/AttrMatchRule.mts
+++ b/packages/builtins/src/rules/AttrMatchRule.mts
@@ -1,7 +1,21 @@
-import { AttrPairEqual } from "./AttrPairEqual.mjs";
+import { AttrPairEqual, type AttrPairEqualConfig } from "./AttrPairEqual.mjs";
+
+export type AttrMatchRuleConfig = AttrPairEqualConfig;
 
 /**
  * @deprecated Use {@link AttrPairEqual}. Scheduled for removal in a future major version.
+ *
+ * Kept as a thin wrapper that preserves the legacy `ruleType` (`attr_match:{a}:{b}`)
+ * and legacy `message` wording. `verify()` semantics are inherited unchanged from
+ * `AttrPairEqual`: both named attributes must be non-empty strings and equal.
  */
-export const AttrMatchRule = AttrPairEqual;
-export type AttrMatchRuleConfig = ConstructorParameters<typeof AttrPairEqual>[0];
+export class AttrMatchRule extends AttrPairEqual {
+	override readonly ruleType: string;
+	override readonly message: string;
+
+	constructor(config: AttrMatchRuleConfig) {
+		super(config);
+		this.ruleType = config.group ?? `attr_match:${config.a}:${config.b}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} and ${config.b} must both be non-empty strings and equal.`;
+	}
+}

--- a/packages/builtins/src/rules/AttrPairCompare.mts
+++ b/packages/builtins/src/rules/AttrPairCompare.mts
@@ -1,7 +1,7 @@
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
-	type CompareOp,
 	applyCompare,
+	type CompareOp,
 	requireAttrName,
 	requireCompareOp,
 	requireOptionalGroup,

--- a/packages/builtins/src/rules/AttrPairCompare.mts
+++ b/packages/builtins/src/rules/AttrPairCompare.mts
@@ -1,0 +1,57 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	type CompareOp,
+	applyCompare,
+	requireAttrName,
+	requireCompareOp,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrPairCompareConfig {
+	a: string;
+	op: CompareOp;
+	b: string;
+	group?: string;
+}
+
+/**
+ * Rule that passes when two named attributes are present, are both numbers,
+ * and satisfy the configured comparison operator. NaN on either side always
+ * returns false (JS native comparison semantics). Missing, null, or non-number
+ * attributes return false (safe-deny).
+ *
+ * Unlike AttrLiteralCompare, the right-hand side comes from the attributes map
+ * at evaluation time rather than from a static config value — so NaN is not
+ * rejected at construction time.
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a`, `op`, and `b`:
+ *   `attr_pair_compare:{a}:{op}:{b}`
+ *
+ * Pass an explicit `group` string to override the default ruleType entirely.
+ */
+export class AttrPairCompare implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_compare_violated";
+	readonly message: string;
+
+	constructor(private readonly config: AttrPairCompareConfig) {
+		requireAttrName("AttrPairCompare", "a", config.a);
+		requireAttrName("AttrPairCompare", "b", config.b);
+		requireCompareOp("AttrPairCompare", config.op);
+		const group = requireOptionalGroup("AttrPairCompare", config.group);
+
+		this.ruleType = group ?? `attr_pair_compare:${config.a}:${config.op}:${config.b}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must be ${config.op} ${config.b}.`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const a = attrs.get(this.config.a);
+		const b = attrs.get(this.config.b);
+		if (typeof a !== "number") return false;
+		if (typeof b !== "number") return false;
+		return applyCompare(this.config.op, a, b);
+	}
+}

--- a/packages/builtins/src/rules/AttrPairEqual.mts
+++ b/packages/builtins/src/rules/AttrPairEqual.mts
@@ -1,8 +1,5 @@
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
-import {
-	requireAttrName,
-	requireOptionalGroup,
-} from "./_sharedValidation.mjs";
+import { requireAttrName, requireOptionalGroup } from "./_sharedValidation.mjs";
 
 export interface AttrPairEqualConfig {
 	a: string;
@@ -41,7 +38,7 @@ export class AttrPairEqual implements Rule {
 		const group = requireOptionalGroup("AttrPairEqual", config.group);
 
 		this.ruleType = group ?? `attr_pair_equal:${config.a}:${config.b}`;
-		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${config.b} (both must be non-empty strings).`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${config.b}.`;
 	}
 
 	verify(attrs: Attributes): boolean {

--- a/packages/builtins/src/rules/AttrPairEqual.mts
+++ b/packages/builtins/src/rules/AttrPairEqual.mts
@@ -41,7 +41,7 @@ export class AttrPairEqual implements Rule {
 		const group = requireOptionalGroup("AttrPairEqual", config.group);
 
 		this.ruleType = group ?? `attr_pair_equal:${config.a}:${config.b}`;
-		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${config.b}.`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${config.b} (both must be non-empty strings).`;
 	}
 
 	verify(attrs: Attributes): boolean {

--- a/packages/builtins/src/rules/AttrPairEqual.mts
+++ b/packages/builtins/src/rules/AttrPairEqual.mts
@@ -1,0 +1,54 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	requireAttrName,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrPairEqualConfig {
+	a: string;
+	b: string;
+	group?: string;
+}
+
+/**
+ * Rule that passes when two named attributes are present, are non-empty
+ * strings, and are strictly equal. No type coercion is performed: both
+ * attribute values must be non-empty strings.
+ *
+ * ## Backward compatibility
+ *
+ * AttrPairEqual deliberately retains the string-only semantic of the legacy
+ * AttrMatchRule. Do not widen verify() to accept numbers or booleans — the
+ * Phase 4 AttrMatchRule alias depends on this invariant.
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a` and `b` so that
+ * distinct pair requirements are AND-combined by default:
+ *   `attr_pair_equal:{a}:{b}`
+ *
+ * Pass a shared `group` string to two instances to opt into OR semantics.
+ */
+export class AttrPairEqual implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_mismatch";
+	readonly message: string;
+
+	constructor(private readonly config: AttrPairEqualConfig) {
+		requireAttrName("AttrPairEqual", "a", config.a);
+		requireAttrName("AttrPairEqual", "b", config.b);
+		const group = requireOptionalGroup("AttrPairEqual", config.group);
+
+		this.ruleType = group ?? `attr_pair_equal:${config.a}:${config.b}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${config.b}.`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const a = attrs.get(this.config.a);
+		const b = attrs.get(this.config.b);
+		if (typeof a !== "string" || a.length === 0) return false;
+		if (typeof b !== "string" || b.length === 0) return false;
+		return a === b;
+	}
+}

--- a/packages/builtins/src/rules/AttrPairNotEqual.mts
+++ b/packages/builtins/src/rules/AttrPairNotEqual.mts
@@ -1,0 +1,53 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import {
+	requireAttrName,
+	requireOptionalGroup,
+} from "./_sharedValidation.mjs";
+
+export interface AttrPairNotEqualConfig {
+	a: string;
+	b: string;
+	group?: string;
+}
+
+/**
+ * Rule that passes when two named attributes are present, are non-empty
+ * strings, and are strictly NOT equal. No type coercion is performed: both
+ * attribute values must be non-empty strings. Missing, null, empty, or
+ * non-string attributes return false (safe-deny).
+ *
+ * ## Denial code
+ *
+ * The denial code is "attr_match": the rule failed because the pair matched
+ * when it was required to differ.
+ *
+ * ## Grouping and the default ruleType
+ *
+ * The evaluator groups rules by `ruleType`, ORs within a group, and ANDs
+ * across groups. The default `ruleType` is derived from `a` and `b`:
+ *   `attr_pair_not_equal:{a}:{b}`
+ *
+ * Pass a shared `group` string to two instances to opt into OR semantics.
+ */
+export class AttrPairNotEqual implements Rule {
+	readonly ruleType: string;
+	readonly code = "attr_match";
+	readonly message: string;
+
+	constructor(private readonly config: AttrPairNotEqualConfig) {
+		requireAttrName("AttrPairNotEqual", "a", config.a);
+		requireAttrName("AttrPairNotEqual", "b", config.b);
+		const group = requireOptionalGroup("AttrPairNotEqual", config.group);
+
+		this.ruleType = group ?? `attr_pair_not_equal:${config.a}:${config.b}`;
+		this.message = `Attribute constraint not satisfied: ${config.a} must not equal ${config.b}.`;
+	}
+
+	verify(attrs: Attributes): boolean {
+		const a = attrs.get(this.config.a);
+		const b = attrs.get(this.config.b);
+		if (typeof a !== "string" || a.length === 0) return false;
+		if (typeof b !== "string" || b.length === 0) return false;
+		return a !== b;
+	}
+}

--- a/packages/builtins/src/rules/AttrPairNotEqual.mts
+++ b/packages/builtins/src/rules/AttrPairNotEqual.mts
@@ -1,8 +1,5 @@
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
-import {
-	requireAttrName,
-	requireOptionalGroup,
-} from "./_sharedValidation.mjs";
+import { requireAttrName, requireOptionalGroup } from "./_sharedValidation.mjs";
 
 export interface AttrPairNotEqualConfig {
 	a: string;

--- a/packages/builtins/src/rules/_sharedValidation.mts
+++ b/packages/builtins/src/rules/_sharedValidation.mts
@@ -1,9 +1,7 @@
+import { createHash } from "node:crypto";
+
 /**
  * Shared validation helpers for attribute-based rule constructors.
- *
- * Full implementations: requireAttrName, requireLiteralValue, requireOptionalGroup
- * Stubs (not yet implemented): requireNumber, requireHomogeneousLiteralArray,
- *   requireCompareOp, computeValuesKey, applyCompare
  */
 
 export type LiteralValue = string | number | boolean;
@@ -75,34 +73,91 @@ export function requireLiteralValue(
 
 /**
  * Validates a numeric comparison value. Rejects NaN; accepts Infinity/-Infinity.
- * STUB — not yet implemented.
+ * @param className - The rule class name, used in error messages.
+ * @param fieldName - The config field name ("v"), used in error messages.
+ * @param value - The raw value to validate.
+ * @returns The validated number.
+ * @throws {Error} If value is not a number, or if value is NaN.
  */
 export function requireNumber(
-	_className: string,
-	_fieldName: "v",
-	_value: unknown,
+	className: string,
+	fieldName: "v",
+	value: unknown,
 ): number {
-	throw new Error("not yet implemented: requireNumber");
+	if (typeof value !== "number") {
+		throw new Error(
+			`${className}: '${fieldName}' must be a number, got ${describeType(value)}`,
+		);
+	}
+	if (Number.isNaN(value)) {
+		throw new Error(`${className}: '${fieldName}' must not be NaN`);
+	}
+	return value;
 }
 
 /**
  * Validates that a value is a non-empty, homogeneous array of LiteralValues
- * (no null/undefined elements).
- * STUB — not yet implemented.
+ * (no null/undefined elements, all elements the same typeof).
+ * @param className - The rule class name, used in error messages.
+ * @param value - The raw value to validate.
+ * @returns The validated LiteralValue array.
+ * @throws {Error} If not an array, empty, contains invalid elements, or has mixed types.
  */
 export function requireHomogeneousLiteralArray(
-	_className: string,
-	_value: unknown,
+	className: string,
+	value: unknown,
 ): LiteralValue[] {
-	throw new Error("not yet implemented: requireHomogeneousLiteralArray");
+	if (!Array.isArray(value)) {
+		throw new Error(
+			`${className}: 'values' must be a non-empty array of string | number | boolean, got ${describeType(value)}`,
+		);
+	}
+	if (value.length === 0) {
+		throw new Error(`${className}: 'values' must be a non-empty array`);
+	}
+	const seenTypes = new Set<string>();
+	for (const element of value) {
+		if (element === null || element === undefined) {
+			throw new Error(
+				`${className}: 'values' elements must be string | number | boolean, got ${describeType(element)}`,
+			);
+		}
+		const t = typeof element;
+		if (t !== "string" && t !== "number" && t !== "boolean") {
+			throw new Error(
+				`${className}: 'values' elements must be string | number | boolean, got ${t}`,
+			);
+		}
+		seenTypes.add(t);
+	}
+	if (seenTypes.size > 1) {
+		const typeList = [...seenTypes].join(", ");
+		throw new Error(
+			`${className}: 'values' must be a homogeneous array of string | number | boolean; got mixed types [${typeList}]`,
+		);
+	}
+	return value as LiteralValue[];
 }
 
 /**
  * Validates that a value is one of the allowed CompareOp strings.
- * STUB — not yet implemented.
+ * @param className - The rule class name, used in error messages.
+ * @param value - The raw value to validate.
+ * @returns The validated CompareOp.
+ * @throws {Error} If value is not a string or not one of the allowed operators.
  */
-export function requireCompareOp(_className: string, _value: unknown): CompareOp {
-	throw new Error("not yet implemented: requireCompareOp");
+export function requireCompareOp(className: string, value: unknown): CompareOp {
+	if (typeof value !== "string") {
+		throw new Error(
+			`${className}: 'op' must be one of ${COMPARE_OPS.join(" | ")}, got ${describeType(value)}`,
+		);
+	}
+	if (!(COMPARE_OPS as readonly string[]).includes(value)) {
+		throw new Error(
+			`${className}: 'op' must be one of ${COMPARE_OPS.join(" | ")}, got '${value}'`,
+		);
+	}
+	return value as CompareOp;
 }
 
 /**
@@ -137,20 +192,27 @@ export function requireOptionalGroup(
 /**
  * Computes a stable cache/dedup key for an array of LiteralValues.
  * Format: {type}:{count}:{hashPrefix} — SHA-256 over sorted String(x).join(",").
- * STUB — not yet implemented.
+ * Caller must guarantee values is a non-empty homogeneous LiteralValue[].
  */
-export function computeValuesKey(_values: LiteralValue[]): string {
-	throw new Error("not yet implemented: computeValuesKey");
+export function computeValuesKey(values: LiteralValue[]): string {
+	const elementType = typeof values[0];
+	const joined = values.map(String).sort().join(",");
+	const hash = createHash("sha256").update(joined).digest("hex").slice(0, 8);
+	return `${elementType}:${values.length}:${hash}`;
 }
 
 /**
- * Applies a numeric comparison operator.
- * STUB — not yet implemented.
+ * Applies a numeric comparison operator between left and right.
  */
-export function applyCompare<T extends number>(
-	_op: CompareOp,
-	_left: T,
-	_right: T,
-): boolean {
-	throw new Error("not yet implemented: applyCompare");
+export function applyCompare<T extends number>(op: CompareOp, left: T, right: T): boolean {
+	switch (op) {
+		case "lt":
+			return left < right;
+		case "le":
+			return left <= right;
+		case "gt":
+			return left > right;
+		case "ge":
+			return left >= right;
+	}
 }

--- a/packages/builtins/src/rules/_sharedValidation.mts
+++ b/packages/builtins/src/rules/_sharedValidation.mts
@@ -29,11 +29,7 @@ export const COMPARE_OPS: readonly CompareOp[] = ["lt", "le", "gt", "ge"];
  * @returns The validated non-empty string.
  * @throws {Error} If value is not a non-empty string.
  */
-export function requireAttrName(
-	className: string,
-	fieldName: "a" | "b",
-	value: unknown,
-): string {
+export function requireAttrName(className: string, fieldName: "a" | "b", value: unknown): string {
 	if (typeof value !== "string") {
 		throw new Error(
 			`${className}: '${fieldName}' must be a non-empty string, got ${describeType(value)}`,
@@ -59,11 +55,7 @@ export function requireLiteralValue(
 	fieldName: "v",
 	value: unknown,
 ): LiteralValue {
-	if (
-		typeof value === "string" ||
-		typeof value === "number" ||
-		typeof value === "boolean"
-	) {
+	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
 		return value;
 	}
 	throw new Error(
@@ -79,15 +71,9 @@ export function requireLiteralValue(
  * @returns The validated number.
  * @throws {Error} If value is not a number, or if value is NaN.
  */
-export function requireNumber(
-	className: string,
-	fieldName: "v",
-	value: unknown,
-): number {
+export function requireNumber(className: string, fieldName: "v", value: unknown): number {
 	if (typeof value !== "number") {
-		throw new Error(
-			`${className}: '${fieldName}' must be a number, got ${describeType(value)}`,
-		);
+		throw new Error(`${className}: '${fieldName}' must be a number, got ${describeType(value)}`);
 	}
 	if (Number.isNaN(value)) {
 		throw new Error(`${className}: '${fieldName}' must not be NaN`);
@@ -103,10 +89,7 @@ export function requireNumber(
  * @returns The validated LiteralValue array.
  * @throws {Error} If not an array, empty, contains invalid elements, or has mixed types.
  */
-export function requireHomogeneousLiteralArray(
-	className: string,
-	value: unknown,
-): LiteralValue[] {
+export function requireHomogeneousLiteralArray(className: string, value: unknown): LiteralValue[] {
 	if (!Array.isArray(value)) {
 		throw new Error(
 			`${className}: 'values' must be a non-empty array of string | number | boolean, got ${describeType(value)}`,
@@ -153,9 +136,7 @@ export function requireCompareOp(className: string, value: unknown): CompareOp {
 		);
 	}
 	if (!(COMPARE_OPS as readonly string[]).includes(value)) {
-		throw new Error(
-			`${className}: 'op' must be one of ${COMPARE_OPS.join(" | ")}, got '${value}'`,
-		);
+		throw new Error(`${className}: 'op' must be one of ${COMPARE_OPS.join(" | ")}, got '${value}'`);
 	}
 	return value as CompareOp;
 }
@@ -169,10 +150,7 @@ export function requireCompareOp(className: string, value: unknown): CompareOp {
  * @returns The validated non-empty string, or undefined.
  * @throws {Error} If value is a non-string or an empty string.
  */
-export function requireOptionalGroup(
-	className: string,
-	value: unknown,
-): string | undefined {
+export function requireOptionalGroup(className: string, value: unknown): string | undefined {
 	if (value === undefined) {
 		return undefined;
 	}

--- a/packages/builtins/src/rules/_sharedValidation.mts
+++ b/packages/builtins/src/rules/_sharedValidation.mts
@@ -1,0 +1,156 @@
+/**
+ * Shared validation helpers for attribute-based rule constructors.
+ *
+ * Full implementations: requireAttrName, requireLiteralValue, requireOptionalGroup
+ * Stubs (not yet implemented): requireNumber, requireHomogeneousLiteralArray,
+ *   requireCompareOp, computeValuesKey, applyCompare
+ */
+
+export type LiteralValue = string | number | boolean;
+
+/**
+ * Returns a human-readable type label for use in error messages.
+ * Distinguishes null and undefined from other types instead of returning
+ * "object" or "undefined" from typeof.
+ */
+function describeType(value: unknown): string {
+	if (value === null) return "null";
+	if (value === undefined) return "undefined";
+	return typeof value;
+}
+
+export type CompareOp = "lt" | "le" | "gt" | "ge";
+
+export const COMPARE_OPS: readonly CompareOp[] = ["lt", "le", "gt", "ge"];
+
+/**
+ * Validates that a config field used as an attribute name is a non-empty string.
+ * @param className - The rule class name, used in error messages.
+ * @param fieldName - The config field name ("a" or "b"), used in error messages.
+ * @param value - The raw value to validate.
+ * @returns The validated non-empty string.
+ * @throws {Error} If value is not a non-empty string.
+ */
+export function requireAttrName(
+	className: string,
+	fieldName: "a" | "b",
+	value: unknown,
+): string {
+	if (typeof value !== "string") {
+		throw new Error(
+			`${className}: '${fieldName}' must be a non-empty string, got ${describeType(value)}`,
+		);
+	}
+	if (value.length === 0) {
+		throw new Error(`${className}: '${fieldName}' must be a non-empty string, got empty string`);
+	}
+	return value;
+}
+
+/**
+ * Validates that a config field used as a literal comparison value is a
+ * string, number, or boolean (i.e. a LiteralValue).
+ * @param className - The rule class name, used in error messages.
+ * @param fieldName - The config field name ("v"), used in error messages.
+ * @param value - The raw value to validate.
+ * @returns The validated LiteralValue.
+ * @throws {Error} If value is null, undefined, or any other type.
+ */
+export function requireLiteralValue(
+	className: string,
+	fieldName: "v",
+	value: unknown,
+): LiteralValue {
+	if (
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	) {
+		return value;
+	}
+	throw new Error(
+		`${className}: '${fieldName}' must be string | number | boolean, got ${describeType(value)}`,
+	);
+}
+
+/**
+ * Validates a numeric comparison value. Rejects NaN; accepts Infinity/-Infinity.
+ * STUB — not yet implemented.
+ */
+export function requireNumber(
+	_className: string,
+	_fieldName: "v",
+	_value: unknown,
+): number {
+	throw new Error("not yet implemented: requireNumber");
+}
+
+/**
+ * Validates that a value is a non-empty, homogeneous array of LiteralValues
+ * (no null/undefined elements).
+ * STUB — not yet implemented.
+ */
+export function requireHomogeneousLiteralArray(
+	_className: string,
+	_value: unknown,
+): LiteralValue[] {
+	throw new Error("not yet implemented: requireHomogeneousLiteralArray");
+}
+
+/**
+ * Validates that a value is one of the allowed CompareOp strings.
+ * STUB — not yet implemented.
+ */
+export function requireCompareOp(_className: string, _value: unknown): CompareOp {
+	throw new Error("not yet implemented: requireCompareOp");
+}
+
+/**
+ * Validates an optional group string. Returns undefined when value is undefined;
+ * throws when value is a non-string or an empty string; otherwise returns the
+ * non-empty string.
+ * @param className - The rule class name, used in error messages.
+ * @param value - The raw value to validate.
+ * @returns The validated non-empty string, or undefined.
+ * @throws {Error} If value is a non-string or an empty string.
+ */
+export function requireOptionalGroup(
+	className: string,
+	value: unknown,
+): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new Error(
+			`${className}: 'group' must be a non-empty string or undefined, got ${describeType(value)}`,
+		);
+	}
+	if (value.length === 0) {
+		throw new Error(
+			`${className}: 'group' must be a non-empty string or undefined, got empty string`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Computes a stable cache/dedup key for an array of LiteralValues.
+ * Format: {type}:{count}:{hashPrefix} — SHA-256 over sorted String(x).join(",").
+ * STUB — not yet implemented.
+ */
+export function computeValuesKey(_values: LiteralValue[]): string {
+	throw new Error("not yet implemented: computeValuesKey");
+}
+
+/**
+ * Applies a numeric comparison operator.
+ * STUB — not yet implemented.
+ */
+export function applyCompare<T extends number>(
+	_op: CompareOp,
+	_left: T,
+	_right: T,
+): boolean {
+	throw new Error("not yet implemented: applyCompare");
+}

--- a/packages/builtins/src/rules/_sharedValidation.mts
+++ b/packages/builtins/src/rules/_sharedValidation.mts
@@ -169,12 +169,19 @@ export function requireOptionalGroup(className: string, value: unknown): string 
 
 /**
  * Computes a stable cache/dedup key for an array of LiteralValues.
- * Format: {type}:{count}:{hashPrefix} — SHA-256 over sorted String(x).join(",").
+ * Format: `{type}:{count}:{hashPrefix}` — SHA-256 over a canonical serialization
+ * of `values`. The canonical form is `values.map(v => JSON.stringify(String(v))).sort().join(",")`,
+ * which quotes and escapes each element before joining so that values containing
+ * commas (or other separator characters) cannot collide across different arrays
+ * (e.g. `["a,b", "c"]` vs `["a", "b,c"]`).
  * Caller must guarantee values is a non-empty homogeneous LiteralValue[].
  */
 export function computeValuesKey(values: LiteralValue[]): string {
 	const elementType = typeof values[0];
-	const joined = values.map(String).sort().join(",");
+	const joined = values
+		.map((v) => JSON.stringify(String(v)))
+		.sort()
+		.join(",");
 	const hash = createHash("sha256").update(joined).digest("hex").slice(0, 8);
 	return `${elementType}:${values.length}:${hash}`;
 }

--- a/packages/builtins/src/rules/_sharedValidation.mts
+++ b/packages/builtins/src/rules/_sharedValidation.mts
@@ -43,19 +43,28 @@ export function requireAttrName(className: string, fieldName: "a" | "b", value: 
 
 /**
  * Validates that a config field used as a literal comparison value is a
- * string, number, or boolean (i.e. a LiteralValue).
+ * string, number, or boolean (i.e. a LiteralValue). NaN is rejected because
+ * its comparison semantics (`NaN !== NaN` is always true, `NaN === NaN` is
+ * always false) would silently invert Equal/NotEqual rules — a NotEqual(v=NaN)
+ * would always pass against any numeric attribute, weakening authorization.
  * @param className - The rule class name, used in error messages.
  * @param fieldName - The config field name ("v"), used in error messages.
  * @param value - The raw value to validate.
  * @returns The validated LiteralValue.
- * @throws {Error} If value is null, undefined, or any other type.
+ * @throws {Error} If value is null, undefined, of any other type, or NaN.
  */
 export function requireLiteralValue(
 	className: string,
 	fieldName: "v",
 	value: unknown,
 ): LiteralValue {
-	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+	if (typeof value === "string" || typeof value === "boolean") {
+		return value;
+	}
+	if (typeof value === "number") {
+		if (Number.isNaN(value)) {
+			throw new Error(`${className}: '${fieldName}' must not be NaN`);
+		}
 		return value;
 	}
 	throw new Error(
@@ -83,11 +92,11 @@ export function requireNumber(className: string, fieldName: "v", value: unknown)
 
 /**
  * Validates that a value is a non-empty, homogeneous array of LiteralValues
- * (no null/undefined elements, all elements the same typeof).
+ * (no null/undefined elements, no NaN elements, all elements the same typeof).
  * @param className - The rule class name, used in error messages.
  * @param value - The raw value to validate.
  * @returns The validated LiteralValue array.
- * @throws {Error} If not an array, empty, contains invalid elements, or has mixed types.
+ * @throws {Error} If not an array, empty, contains invalid elements, has mixed types, or contains NaN.
  */
 export function requireHomogeneousLiteralArray(className: string, value: unknown): LiteralValue[] {
 	if (!Array.isArray(value)) {
@@ -110,6 +119,9 @@ export function requireHomogeneousLiteralArray(className: string, value: unknown
 			throw new Error(
 				`${className}: 'values' elements must be string | number | boolean, got ${t}`,
 			);
+		}
+		if (t === "number" && Number.isNaN(element)) {
+			throw new Error(`${className}: 'values' must not contain NaN`);
 		}
 		seenTypes.add(t);
 	}

--- a/packages/builtins/src/rules/_sharedValidation.mts
+++ b/packages/builtins/src/rules/_sharedValidation.mts
@@ -22,12 +22,17 @@ export type CompareOp = "lt" | "le" | "gt" | "ge";
 export const COMPARE_OPS: readonly CompareOp[] = ["lt", "le", "gt", "ge"];
 
 /**
- * Validates that a config field used as an attribute name is a non-empty string.
+ * Validates that a config field used as an attribute name is a non-empty string
+ * that does not contain the `:` separator character used in derived `ruleType`
+ * strings. Allowing `:` would let distinct configs collide on the same
+ * `ruleType` (e.g. `(a="x:y", b="z")` and `(a="x", b="y:z")` both produce
+ * `attr_pair_equal:x:y:z`), which the evaluator would silently OR together
+ * and weaken authorization.
  * @param className - The rule class name, used in error messages.
  * @param fieldName - The config field name ("a" or "b"), used in error messages.
  * @param value - The raw value to validate.
  * @returns The validated non-empty string.
- * @throws {Error} If value is not a non-empty string.
+ * @throws {Error} If value is not a non-empty string, or contains `:`.
  */
 export function requireAttrName(className: string, fieldName: "a" | "b", value: unknown): string {
 	if (typeof value !== "string") {
@@ -37,6 +42,11 @@ export function requireAttrName(className: string, fieldName: "a" | "b", value: 
 	}
 	if (value.length === 0) {
 		throw new Error(`${className}: '${fieldName}' must be a non-empty string, got empty string`);
+	}
+	if (value.includes(":")) {
+		throw new Error(
+			`${className}: '${fieldName}' must not contain ':' (reserved as ruleType separator), got '${value}'`,
+		);
 	}
 	return value;
 }
@@ -182,20 +192,24 @@ export function requireOptionalGroup(className: string, value: unknown): string 
 /**
  * Computes a stable cache/dedup key for an array of LiteralValues.
  * Format: `{type}:{count}:{hashPrefix}` — SHA-256 over a canonical serialization
- * of `values`. The canonical form is `values.map(v => JSON.stringify(String(v))).sort().join(",")`,
- * which quotes and escapes each element before joining so that values containing
- * commas (or other separator characters) cannot collide across different arrays
- * (e.g. `["a,b", "c"]` vs `["a", "b,c"]`).
+ * of `values`. The canonical form first deduplicates `values` (to mirror the
+ * Set-based semantics of AttrLiteralIn / AttrLiteralNotIn — duplicates do not
+ * change the rule's behavior, so they must not change its `ruleType`), then
+ * applies `JSON.stringify(String(v))` to each remaining element before sorting
+ * and joining with `,`. The per-element quoting prevents separator collisions
+ * across different arrays (e.g. `["a,b", "c"]` vs `["a", "b,c"]`).
+ * The `{count}` segment reflects the post-dedup element count.
  * Caller must guarantee values is a non-empty homogeneous LiteralValue[].
  */
 export function computeValuesKey(values: LiteralValue[]): string {
 	const elementType = typeof values[0];
-	const joined = values
+	const unique = [...new Set(values)];
+	const joined = unique
 		.map((v) => JSON.stringify(String(v)))
 		.sort()
 		.join(",");
 	const hash = createHash("sha256").update(joined).digest("hex").slice(0, 8);
-	return `${elementType}:${values.length}:${hash}`;
+	return `${elementType}:${unique.length}:${hash}`;
 }
 
 /**

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -2,6 +2,8 @@
 
 auth.policy-verifier の型定義・評価エンジン・モジュール基盤。コレクター、ルール、モジュールが実装すべきインターフェースを定義するパッケージです。
 
+**Runtime:** Node.js 22+。本パッケージを含む `auth.policy-verifier` 群は現時点で Node.js 専用です。browser / edge ランタイム対応は今後の課題として別 issue で追跡します。
+
 ## インストール
 
 ```bash

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,6 +2,8 @@
 
 Types, evaluation engine, and module infrastructure for auth.policy-verifier. This package defines the interfaces that collectors, rules, and modules implement.
 
+**Runtime:** Node.js 22+. This package (and the rest of `auth.policy-verifier`) is Node-only today; browser / edge runtime support is tracked as future work.
+
 ## Install
 
 ```bash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"license": "Apache-2.0",
 	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",
 	"exports": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"license": "Apache-2.0",
 	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",
 	"exports": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - "packages/*"
   - "templates/*"
   - "create-app"
+  - "tests/*"

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@o3co/auth.policy-verifier.integration-tests",
-  "version": "0.0.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "test": "vitest run"
-  },
-  "dependencies": {
-    "@o3co/auth.policy-verifier.core": "workspace:*",
-    "@o3co/auth.policy-verifier.builtins": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^25.1.0",
-    "vitest": "^4.1.2"
-  }
+	"name": "@o3co/auth.policy-verifier.integration-tests",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"@o3co/auth.policy-verifier.core": "workspace:*",
+		"@o3co/auth.policy-verifier.builtins": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^25.1.0",
+		"vitest": "^4.1.2"
+	}
 }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@o3co/auth.policy-verifier.integration-tests",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@o3co/auth.policy-verifier.core": "workspace:*",
+    "@o3co/auth.policy-verifier.builtins": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.1.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"scripts": {
 		"test": "vitest run"
 	},

--- a/tests/integration/src/evaluate-with-rules.test.mts
+++ b/tests/integration/src/evaluate-with-rules.test.mts
@@ -1,10 +1,10 @@
+import {
+	AttrLiteralCompare,
+	AttrLiteralEqual,
+	AttrPairNotEqual,
+} from "@o3co/auth.policy-verifier.builtins";
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { evaluate } from "@o3co/auth.policy-verifier.core";
-import {
-  AttrLiteralCompare,
-  AttrLiteralEqual,
-  AttrPairNotEqual,
-} from "@o3co/auth.policy-verifier.builtins";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -24,64 +24,64 @@ import { describe, expect, it } from "vitest";
  */
 
 describe("evaluate with AttrLiteralEqual + AttrPairNotEqual + AttrLiteralCompare", () => {
-  // Rules listed in a fixed order so Scenario C is deterministic.
-  // Order: [ruleEqual, rulePairNotEqual, ruleCompare]
-  const ruleEqual = new AttrLiteralEqual({ a: "role", v: "admin" });
-  const rulePairNotEqual = new AttrPairNotEqual({ a: "userId", b: "ownerId" });
-  const ruleCompare = new AttrLiteralCompare({ a: "level", v: 5, op: "ge" });
+	// Rules listed in a fixed order so Scenario C is deterministic.
+	// Order: [ruleEqual, rulePairNotEqual, ruleCompare]
+	const ruleEqual = new AttrLiteralEqual({ a: "role", v: "admin" });
+	const rulePairNotEqual = new AttrPairNotEqual({ a: "userId", b: "ownerId" });
+	const ruleCompare = new AttrLiteralCompare({ a: "level", v: 5, op: "ge" });
 
-  const rules: Rule[] = [ruleEqual, rulePairNotEqual, ruleCompare];
+	const rules: Rule[] = [ruleEqual, rulePairNotEqual, ruleCompare];
 
-  it("Scenario A: all three rules satisfied → allow", () => {
-    const attrs: Attributes = new Map([
-      ["role", "admin"],
-      ["userId", "u1"],
-      ["ownerId", "u2"],
-      ["level", 5],
-    ]);
+	it("Scenario A: all three rules satisfied → allow", () => {
+		const attrs: Attributes = new Map([
+			["role", "admin"],
+			["userId", "u1"],
+			["ownerId", "u2"],
+			["level", 5],
+		]);
 
-    const result = evaluate(attrs, rules);
+		const result = evaluate(attrs, rules);
 
-    expect(result).toEqual({ decision: "allow" });
-  });
+		expect(result).toEqual({ decision: "allow" });
+	});
 
-  it("Scenario B: AttrPairNotEqual fails (userId === ownerId) → deny with attr_match", () => {
-    // Break AttrPairNotEqual: userId equals ownerId.
-    const attrs: Attributes = new Map([
-      ["role", "admin"],
-      ["userId", "u1"],
-      ["ownerId", "u1"], // same → rule fails
-      ["level", 5],
-    ]);
+	it("Scenario B: AttrPairNotEqual fails (userId === ownerId) → deny with attr_match", () => {
+		// Break AttrPairNotEqual: userId equals ownerId.
+		const attrs: Attributes = new Map([
+			["role", "admin"],
+			["userId", "u1"],
+			["ownerId", "u1"], // same → rule fails
+			["level", 5],
+		]);
 
-    const result = evaluate(attrs, rules);
+		const result = evaluate(attrs, rules);
 
-    expect(result).toEqual({
-      decision: "deny",
-      code: rulePairNotEqual.code,
-      message: rulePairNotEqual.message,
-    });
-  });
+		expect(result).toEqual({
+			decision: "deny",
+			code: rulePairNotEqual.code,
+			message: rulePairNotEqual.message,
+		});
+	});
 
-  it("Scenario C: AttrLiteralEqual and AttrPairNotEqual both fail → deny with first failing group (attr_not_equal)", () => {
-    // Break AttrLiteralEqual: role is not "admin".
-    // Break AttrPairNotEqual: userId equals ownerId.
-    // AttrLiteralCompare still passes.
-    // Evaluator processes groups in insertion order: ruleEqual's group is first,
-    // so the deny reflects ruleEqual's code/message.
-    const attrs: Attributes = new Map([
-      ["role", "user"], // not "admin" → AttrLiteralEqual fails
-      ["userId", "u1"],
-      ["ownerId", "u1"], // same → AttrPairNotEqual fails
-      ["level", 5],
-    ]);
+	it("Scenario C: AttrLiteralEqual and AttrPairNotEqual both fail → deny with first failing group (attr_not_equal)", () => {
+		// Break AttrLiteralEqual: role is not "admin".
+		// Break AttrPairNotEqual: userId equals ownerId.
+		// AttrLiteralCompare still passes.
+		// Evaluator processes groups in insertion order: ruleEqual's group is first,
+		// so the deny reflects ruleEqual's code/message.
+		const attrs: Attributes = new Map([
+			["role", "user"], // not "admin" → AttrLiteralEqual fails
+			["userId", "u1"],
+			["ownerId", "u1"], // same → AttrPairNotEqual fails
+			["level", 5],
+		]);
 
-    const result = evaluate(attrs, rules);
+		const result = evaluate(attrs, rules);
 
-    expect(result).toEqual({
-      decision: "deny",
-      code: ruleEqual.code,
-      message: ruleEqual.message,
-    });
-  });
+		expect(result).toEqual({
+			decision: "deny",
+			code: ruleEqual.code,
+			message: ruleEqual.message,
+		});
+	});
 });

--- a/tests/integration/src/evaluate-with-rules.test.mts
+++ b/tests/integration/src/evaluate-with-rules.test.mts
@@ -1,0 +1,87 @@
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import { evaluate } from "@o3co/auth.policy-verifier.core";
+import {
+  AttrLiteralCompare,
+  AttrLiteralEqual,
+  AttrPairNotEqual,
+} from "@o3co/auth.policy-verifier.builtins";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Engine-level integration scenario: three rules with distinct default ruleTypes
+ * are AND-combined by the evaluator (one group per rule, no shared `group` option).
+ *
+ * Rules under test:
+ *   - AttrLiteralEqual  ({ a: "role",   v: "admin" })   → code "attr_not_equal"
+ *   - AttrPairNotEqual  ({ a: "userId", b: "ownerId" }) → code "attr_match"
+ *   - AttrLiteralCompare({ a: "level",  v: 5, op: "ge" }) → code "attr_compare_violated"
+ *
+ * Base attributes (all rules satisfied):
+ *   role    = "admin"   (equals literal "admin")
+ *   userId  = "u1"      (not equal to ownerId "u2")
+ *   ownerId = "u2"
+ *   level   = 5         (≥ 5)
+ */
+
+describe("evaluate with AttrLiteralEqual + AttrPairNotEqual + AttrLiteralCompare", () => {
+  // Rules listed in a fixed order so Scenario C is deterministic.
+  // Order: [ruleEqual, rulePairNotEqual, ruleCompare]
+  const ruleEqual = new AttrLiteralEqual({ a: "role", v: "admin" });
+  const rulePairNotEqual = new AttrPairNotEqual({ a: "userId", b: "ownerId" });
+  const ruleCompare = new AttrLiteralCompare({ a: "level", v: 5, op: "ge" });
+
+  const rules: Rule[] = [ruleEqual, rulePairNotEqual, ruleCompare];
+
+  it("Scenario A: all three rules satisfied → allow", () => {
+    const attrs: Attributes = new Map([
+      ["role", "admin"],
+      ["userId", "u1"],
+      ["ownerId", "u2"],
+      ["level", 5],
+    ]);
+
+    const result = evaluate(attrs, rules);
+
+    expect(result).toEqual({ decision: "allow" });
+  });
+
+  it("Scenario B: AttrPairNotEqual fails (userId === ownerId) → deny with attr_match", () => {
+    // Break AttrPairNotEqual: userId equals ownerId.
+    const attrs: Attributes = new Map([
+      ["role", "admin"],
+      ["userId", "u1"],
+      ["ownerId", "u1"], // same → rule fails
+      ["level", 5],
+    ]);
+
+    const result = evaluate(attrs, rules);
+
+    expect(result).toEqual({
+      decision: "deny",
+      code: rulePairNotEqual.code,
+      message: rulePairNotEqual.message,
+    });
+  });
+
+  it("Scenario C: AttrLiteralEqual and AttrPairNotEqual both fail → deny with first failing group (attr_not_equal)", () => {
+    // Break AttrLiteralEqual: role is not "admin".
+    // Break AttrPairNotEqual: userId equals ownerId.
+    // AttrLiteralCompare still passes.
+    // Evaluator processes groups in insertion order: ruleEqual's group is first,
+    // so the deny reflects ruleEqual's code/message.
+    const attrs: Attributes = new Map([
+      ["role", "user"], // not "admin" → AttrLiteralEqual fails
+      ["userId", "u1"],
+      ["ownerId", "u1"], // same → AttrPairNotEqual fails
+      ["level", 5],
+    ]);
+
+    const result = evaluate(attrs, rules);
+
+    expect(result).toEqual({
+      decision: "deny",
+      code: ruleEqual.code,
+      message: ruleEqual.message,
+    });
+  });
+});

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules"]
 }

--- a/tests/integration/vitest.config.mts
+++ b/tests/integration/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.mts"],
+  },
+});

--- a/tests/integration/vitest.config.mts
+++ b/tests/integration/vitest.config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    include: ["src/**/*.test.mts"],
-  },
+	test: {
+		include: ["src/**/*.test.mts"],
+	},
 });


### PR DESCRIPTION
## Summary

Adds a closed set of 8 attribute-comparison rule classes to `@o3co/auth.policy-verifier.builtins` (Literal × {Equal, NotEqual, In, NotIn, Compare} and Pair × {Equal, NotEqual, Compare}), plus a thin `AttrMatchRule` deprecation wrapper that preserves the legacy observable surface.

- Design spec and plan: `docs/superpowers/specs/2026-04-17-attr-literal-pair-rules-design.md` + `docs/superpowers/plans/2026-04-17-attr-literal-pair-rules.md` (internal agentscope copy).
- Closes #32 (backlog item tracked externally — do not auto-close; Yoshi will close once released).

## Behavior highlights

- **No coercion** (`===` only, with a `typeof` guard). Missing attrs or type-mismatched attrs return `false` (safe-deny).
- **Construction-time fail-fast** vs **evaluation-time safe-deny** — each rule's constructor throws on invalid config; `verify(attrs)` never throws.
- **`ruleType` semantics**: derived per rule's identity so distinct constraints are AND-combined by default; callers opt into OR-combining by passing a shared `group` string.
- **`AttrMatchRule` stays usable** as a `@deprecated` subclass of `AttrPairEqual` that overrides `ruleType` / `message` to the legacy values (`attr_match:${a}:${b}` + the non-empty-strings wording). This avoids a silent breaking change for downstream consumers that key off the legacy `ruleType`.

## Review trail (pre-PR)

`/multi-agent-review` was run once before pushing. Both reviewers found real issues that were resolved in commit `3d75bca` before this PR was opened:

- (Claude, Critical) `AttrMatchRule` const-alias leaked `attr_pair_equal:...` as runtime `ruleType` → switched to wrapper class preserving `attr_match:...`.
- (Codex, P1) `AttrLiteralEqual` / `AttrLiteralNotEqual` default `ruleType` collapsed distinct-type literals (`true` vs `"true"`) → added `typeof v` segment with regression test.
- (Codex, P2) `computeValuesKey` canonical form could collide on values containing commas → switched to `JSON.stringify(String(v))` per element before join, with regression test.

## Out of scope (deferred)

- TDD RED-phase evidence is bundled into per-phase commits rather than separate RED/GREEN commits (noted by reviewer as a process nit, not blocking).
- No monorepo-wide `typecheck` scripts exist today; the integration-tests package follows that pre-existing pattern.
- Consumer migration (`dplaas.auth`) is a separate follow-up PR after `0.3.0` publishes.

## Test plan

- [x] `pnpm run lint` clean (86 files, 0 errors)
- [x] `pnpm -r run build` clean (5 packages)
- [x] `pnpm --filter @o3co/auth.policy-verifier.builtins test` — 382 tests green (302 original + 76 `_sharedValidation` + 4 regression guards)
- [x] `pnpm --filter @o3co/auth.policy-verifier.integration-tests test` — 3 scenarios green (all-allow, one-deny, two-deny first-fails-wins)
- [x] Core / server / standalone test suites unchanged and green (21 + 32 + 3)
- [ ] Copilot review — wait for bot comments after PR open
- [ ] Consumer smoke check — verify `dplaas.auth/.../SubscriberIdentityCheckRuleCollector.test.mts` still expects `attr_match:${ATTR_SUBJECT_DID}:${ATTR_SUBSCRIBER_DID}` (wrapper preserves this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)