### PR TITLE
refactor(builtins): split RuleCollector into rules/collectors/ + add extension guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -72,7 +72,7 @@ standalone → server   → core
 ```
 
 - **core** — 型定義、`evaluate()`、`AttributePipeline`、`RulePipeline`、Module 基盤。ランタイム依存なし。
-- **builtins** — 組み込み Collector (scope, permission, role, subject ID, request context)、ルール (HasScope, HasPermission)、DotNotation リソースパーサー。server に依存しない。
+- **builtins** — 組み込み Collector (scope, permission, role, subject ID)、ルール (HasScope, HasPermission, 属性比較ルール)、DotNotation リソースパーサー。server に依存しない。カスタム Rule / Collector の書き方は [`docs/extending.ja.md`](docs/extending.ja.md) を参照。
 - **server** — Express HTTP サーバー、`createApp()`、`POST /verify` ルート、JWT 鍵解決、設定スキーマ。builtins に依存しない。
 - **standalone** — コンポジションルート: HOCON 設定読み込み、モジュール選択、サーバー起動。
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ standalone → server   → core
 ```
 
 - **core** — Types, `evaluate()`, `AttributePipeline`, `RulePipeline`, Module infrastructure. No runtime dependencies.
-- **builtins** — Built-in collectors (scope, permission, role, subject ID, request context), rules (HasScope, HasPermission), DotNotation resource parser. Does not depend on server.
+- **builtins** — Built-in collectors (scope, permission, role, subject ID), rules (HasScope, HasPermission, attribute comparison rules), DotNotation resource parser. Does not depend on server. See [`docs/extending.md`](docs/extending.md) for writing custom rules and collectors.
 - **server** — Express HTTP server, `createApp()`, `POST /verify` route, JWT key resolution, config schema. Does not depend on builtins.
 - **standalone** — Composition root: reads HOCON config, selects modules, starts the server.
 

--- a/docs/extending.ja.md
+++ b/docs/extending.ja.md
@@ -60,7 +60,7 @@ export class UserLevelAtLeast implements Rule {
 
   constructor(private readonly config: UserLevelAtLeastConfig) {
     if (typeof config.threshold !== "number" || Number.isNaN(config.threshold)) {
-      throw new Error("UserLevelAtLeast: 'threshold' must be a finite number");
+      throw new Error("UserLevelAtLeast: 'threshold' must be a number and not NaN");
     }
     // 異なる threshold の 2 インスタンスが AND 結合される（OR ではない）ように、
     // threshold を ruleType にエンコードする。

--- a/docs/extending.ja.md
+++ b/docs/extending.ja.md
@@ -81,6 +81,7 @@ export class UserLevelAtLeast implements Rule {
 - コンストラクタで設定を検証する（fail fast）。`verify()` はホットパスのため、設定を再検証しないこと。
 - `verify()` は欠落・非数値属性に対して `false` を返す（safe-deny）。例外は投げない。
 - 既定の `ruleType` に threshold を含めているので、`new UserLevelAtLeast({ threshold: 3 })` と `new UserLevelAtLeast({ threshold: 5 })` は異なるグループを生成し、AND 結合されます。OR 結合させたい場合（例「レベル ≥ 3 または別の基準」）は、両方に同じ `group` 文字列を渡してください。
+- `Infinity` は `Number.isNaN` チェックを通過します（組み込みの `requireNumber` 規約と一致）。しかし `level >= Infinity` は有限の `level` に対して常に `false` になるため、`threshold: Infinity` は静かに常時拒否する Rule を生成します。この挙動が問題になる場合は、設定層でドメイン境界を検証してください。
 
 ## カスタム AttributeCollector の書き方
 

--- a/docs/extending.ja.md
+++ b/docs/extending.ja.md
@@ -1,0 +1,140 @@
+# auth.policy-verifier の拡張
+
+本ガイドは、カスタム `Rule` / `AttributeCollector` の書き方を説明します。[`@o3co/auth.policy-verifier.builtins`](../packages/builtins/README.ja.md) の組み込み実装を補完する位置づけです。
+
+## 位置づけ: builtins は基本セットであり、網羅カタログではない
+
+`@o3co/auth.policy-verifier.builtins` は、一般的なユースケースをカバーする小さな Rule / Collector 群を意図的に提供します: permission / scope チェック、属性の等価 / 包含 / 比較、subject ID 抽出、静的な permission と role。
+
+このパッケージは [OPA](https://www.openpolicyagent.org/) や [Cedar](https://www.cedarpolicy.com/) のような **網羅的な演算子カタログではありません**。それらのシステムは DSL 内でポリシーを書くため、エンジンが提供する演算子の外側に出られず、広範な組み込み演算子面が必要になります。
+
+auth.policy-verifier は異なる立場を取ります。ポリシーは TypeScript コードであり、`Rule` / `AttributeCollector` は小さく安定したインターフェースです。プロジェクト固有のロジックに対してカスタム `Rule` を書くことは一級の操作であり、ワークアラウンドではありません。組み込みで表現できない要件があれば、自分で書いてください。組み込みの拡張を待つ必要はありません。
+
+**カスタム Rule を書くべきとき:**
+
+- 正規表現マッチ、CIDR マッチ、時間ウィンドウ、集合演算、ネストされた属性パスが必要。
+- ポリシーが、汎用ルールからアクセスできない状態（例: DB ルックアップ）に依存する。
+- 組み込みにきれいに対応しない、ドメイン固有の denial code / message を使いたい。
+
+**組み込みを使うべきとき:**
+
+- ロジックが 1〜2 個の属性に対する equal / not-equal / in / not-in / 数値比較で表現できる。
+- プロトタイプ段階で、ドメイン固有の語彙がまだ固まっていない。
+
+組織内の複数プロジェクトで同じカスタム Rule を書くようになったら、共有パッケージに切り出してください（例: `@yourorg/authz.rules.ipcidr`）。`builtins` を拡張させる方向には進めないでください。意図的に基本セットとして保たれています。
+
+## カスタム Rule の書き方
+
+`Rule` は `@o3co/auth.policy-verifier.core` で定義されます:
+
+```ts
+interface Rule {
+  ruleType: string;
+  code: string;
+  message: string;
+  verify(attrs: Attributes): boolean;
+}
+```
+
+- `verify(attrs)` は述語です。通過時に `true`、失敗時に `false` を返します。**safe-deny 規約:** 欠落・型不一致・不正な属性は `false` を返してください。例外を投げない。例外を投げるとポリシー失敗がエラー応答になり、評価状態が漏れます。
+- `ruleType` は評価器が Rule をグループ化するのに使います。同じ `ruleType` の Rule は OR 結合されます（いずれか 1 つ通ればグループ通過）。異なる `ruleType` の Rule はグループ間 AND 結合されます（全グループ通過が必要）。**既定の `ruleType` は、暗黙の衝突を避けるためにルール設定を十分にエンコードしてください。** 例えば `AttrLiteralEqual` は `attr_literal_equal:${a}:${typeof v}:${String(v)}` を使います — `typeof v` セグメントは `v=true` と `v="true"` が同じ `ruleType` に畳み込まれて意図に反して OR 結合されるのを防ぎます。
+- `code` は短く安定した識別子（例: `"no_permission"`、`"attr_not_equal"`）で、下流のプログラム的ハンドリングに適した文字列にしてください。
+- `message` は人間可読な denial メッセージです。有益な情報を載せつつ、機微な属性値は漏らさないこと。
+
+### 実例: `UserLevelAtLeast`
+
+`userLevel` が設定値以上の数値のときに通過する Rule:
+
+```ts
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+
+export interface UserLevelAtLeastConfig {
+  threshold: number;
+  group?: string;
+}
+
+export class UserLevelAtLeast implements Rule {
+  readonly ruleType: string;
+  readonly code = "user_level_too_low";
+  readonly message: string;
+
+  constructor(private readonly config: UserLevelAtLeastConfig) {
+    if (typeof config.threshold !== "number" || Number.isNaN(config.threshold)) {
+      throw new Error("UserLevelAtLeast: 'threshold' must be a finite number");
+    }
+    // 異なる threshold の 2 インスタンスが AND 結合される（OR ではない）ように、
+    // threshold を ruleType にエンコードする。
+    this.ruleType = config.group ?? `user_level_at_least:${String(config.threshold)}`;
+    this.message = `User level must be at least ${String(config.threshold)}.`;
+  }
+
+  verify(attrs: Attributes): boolean {
+    const level = attrs.get("userLevel");
+    if (typeof level !== "number") return false;
+    return level >= this.config.threshold;
+  }
+}
+```
+
+要点:
+
+- コンストラクタで設定を検証する（fail fast）。`verify()` はホットパスのため、設定を再検証しないこと。
+- `verify()` は欠落・非数値属性に対して `false` を返す（safe-deny）。例外は投げない。
+- 既定の `ruleType` に threshold を含めているので、`new UserLevelAtLeast({ threshold: 3 })` と `new UserLevelAtLeast({ threshold: 5 })` は異なるグループを生成し、AND 結合されます。OR 結合させたい場合（例「レベル ≥ 3 または別の基準」）は、両方に同じ `group` 文字列を渡してください。
+
+## カスタム AttributeCollector の書き方
+
+`AttributeCollector` は `@o3co/auth.policy-verifier.core` で定義されます:
+
+```ts
+interface AttributeCollector {
+  collect(context: CollectorContext): Promise<Attributes>;
+}
+```
+
+- 1 つの Collector は **焦点を絞った属性キー群**を生成してください。関係のない抽出をまとめないこと。IP アドレスと User-Agent を抽出するなら Collector を 2 つに分けてください。
+- 属性キーは文字列定数を使うこと。`@o3co/auth.policy-verifier.core` の `ATTR_SCOPES`、`ATTR_PERMISSIONS`、`ATTR_ROLES`、`ATTR_USER_ID`、`ATTR_CLIENT_ID` を参照。プロジェクト固有のキーは独自の定数を定義し、**core のキーを異なるセマンティクスで再利用しないこと**。
+- `AttributePipeline` は全 Collector を並列実行し、結果をマージします: 配列値は連結、スカラ／オブジェクトは後勝ち。この挙動に合わせて設計し、Collector の実行順序には依存しないこと。
+- `CollectorContext.requestContext` は意図的に型付けされていません。エンジンは汎用 `requestContext` Collector を提供しません。`requestContext` の形は consuming project のトランスポート層 / interceptor が定義するものであり、解釈はプロジェクトの責務だからです。必要なフィールドごとに焦点を絞った Collector を書き、形の検証はその Collector 内で行ってください。
+
+### 実例: `ClientIpCollector`
+
+`requestContext` から IP アドレスを属性として抽出する Collector:
+
+```ts
+import type {
+  AttributeCollector,
+  Attributes,
+  CollectorContext,
+} from "@o3co/auth.policy-verifier.core";
+
+// プロジェクト固有の属性キー定数 — プロジェクトローカルで定義する。
+export const ATTR_CLIENT_IP = "clientIp" as const;
+
+export class ClientIpCollector implements AttributeCollector {
+  async collect(context: CollectorContext): Promise<Attributes> {
+    const ip = context.requestContext?.clientIp;
+    if (typeof ip !== "string" || ip.length === 0) {
+      return new Map(); // 何も出力しない — 下流 Rule では属性欠落として safe-deny される
+    }
+    return new Map([[ATTR_CLIENT_IP, ip]]);
+  }
+}
+```
+
+要点:
+
+- 形が不正または値が欠落している場合は空 `Map` を返すこと。キーを `null` / `undefined` に設定しない — 「欠落」と「存在するが falsy」を区別する下流 Rule が壊れやすくなるため。
+- 形の検証は Collector 内で行う。`requestContext` は `Record<string, unknown>` 型なので、それを消費する Collector が narrowing の適切な場所です。
+
+## RuleCollector を書くタイミング
+
+`RuleCollector` は `CollectorContext` を `Rule[]` に変換するファクトリです。組み込み例として [`packages/builtins/src/rules/collectors/`](../packages/builtins/src/rules/collectors/) の `ResourceActionPermissionRuleCollector` / `ResourceActionScopeRuleCollector` があります。リクエストの resource と action から `HasPermission` / `HasScope` を構築しています。
+
+Rule の構築がリクエスト時のコンテキスト（resource、action、ヘッダ）に依存する場合に、カスタム `RuleCollector` を書いてください。Rule が全リクエストで一定なら、compose 時に `Rule` を直接インスタンス化すれば十分で、Collector は不要です。
+
+## 関連資料
+
+- [`@o3co/auth.policy-verifier.core` README](../packages/core/README.ja.md) — インターフェース、評価器、パイプライン。
+- [`@o3co/auth.policy-verifier.builtins` README](../packages/builtins/README.ja.md) — 組み込み Rule / Collector のリファレンス。
+- [AGENTS.md — Core Vocabulary Scope](../AGENTS.md#core-vocabulary-scope) — `builtins` が汎用 `requestContext` Collector を提供しない理由。

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -81,6 +81,7 @@ Notes:
 - Config is validated at construction time (fail fast). `verify()` is hot-path — it should not re-validate config.
 - `verify()` returns `false` for missing or non-number attributes (safe-deny). It does not throw.
 - The default `ruleType` includes the threshold so `new UserLevelAtLeast({ threshold: 3 })` and `new UserLevelAtLeast({ threshold: 5 })` produce distinct groups and are AND-combined. If you want them OR-combined (e.g. "level ≥ 3 OR some other ladder rung"), pass a shared `group` string to both.
+- `Infinity` passes the `Number.isNaN` check (matching the builtin `requireNumber` convention), but `level >= Infinity` is `false` for every finite level — so `threshold: Infinity` produces a rule that silently always-denies. Validate domain bounds at your configuration layer if this matters.
 
 ## Writing a custom AttributeCollector
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -60,7 +60,7 @@ export class UserLevelAtLeast implements Rule {
 
   constructor(private readonly config: UserLevelAtLeastConfig) {
     if (typeof config.threshold !== "number" || Number.isNaN(config.threshold)) {
-      throw new Error("UserLevelAtLeast: 'threshold' must be a finite number");
+      throw new Error("UserLevelAtLeast: 'threshold' must be a number and not NaN");
     }
     // Encode threshold into ruleType so two UserLevelAtLeast instances with
     // different thresholds are AND-combined (both must pass), not OR-combined.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,140 @@
+# Extending auth.policy-verifier
+
+This guide documents how to write custom `Rule` and `AttributeCollector` implementations. It complements the built-in implementations shipped in [`@o3co/auth.policy-verifier.builtins`](../packages/builtins/README.md).
+
+## Positioning: builtins is a basic set, not an exhaustive catalog
+
+`@o3co/auth.policy-verifier.builtins` ships a deliberately small set of rules and collectors that cover common cases: permission / scope checks, attribute equality / membership / comparison, subject-ID extraction, static permissions and roles.
+
+This package is **not** intended to be an exhaustive operator catalog comparable to [OPA](https://www.openpolicyagent.org/) or [Cedar](https://www.cedarpolicy.com/). Those systems require a broad built-in operator surface because policy authors work inside a DSL — they cannot reach outside the operators the engine provides.
+
+auth.policy-verifier takes a different stance. Policies are TypeScript code, and `Rule` / `AttributeCollector` are small, stable interfaces. Writing a custom `Rule` for project-specific logic is a first-class operation, not a workaround. If your requirement is not expressible with a builtin, write your own — do not wait for the builtin to grow.
+
+**When to write a custom Rule instead of using a builtin:**
+
+- You need regex matching, CIDR matching, time windows, set algebra, or nested-attribute paths.
+- Your policy depends on state that a generic rule cannot access (e.g. a database lookup).
+- You want a domain-specific denial code or message that does not map cleanly onto a builtin.
+
+**When to use a builtin:**
+
+- Your logic is expressible as equal / not-equal / in / not-in / numeric compare over one or two attributes.
+- You are prototyping and have not yet defined domain-specific vocabulary.
+
+If multiple projects in your organization end up writing the same custom rule, extract it into a shared package (e.g. `@yourorg/authz.rules.ipcidr`). Do not pressure `builtins` to grow — it is intentionally a basic set.
+
+## Writing a custom Rule
+
+`Rule` is defined in `@o3co/auth.policy-verifier.core`:
+
+```ts
+interface Rule {
+  ruleType: string;
+  code: string;
+  message: string;
+  verify(attrs: Attributes): boolean;
+}
+```
+
+- `verify(attrs)` is the predicate. Return `true` to pass, `false` to fail. **Safe-deny convention:** missing, wrong-type, or malformed attributes must return `false`, not throw. Throwing turns a policy failure into an error response and leaks evaluation state.
+- `ruleType` is used by the evaluator to group rules. Rules sharing a `ruleType` are OR-combined (any one passing satisfies the group). Rules with different `ruleType`s are AND-combined across groups (all groups must be satisfied). **Default `ruleType`s must encode enough of the rule's configuration to avoid silent collisions.** For example, `AttrLiteralEqual` uses `attr_literal_equal:${a}:${typeof v}:${String(v)}` — the `typeof v` segment prevents `v=true` and `v="true"` from collapsing into the same `ruleType` and being OR-combined against intent.
+- `code` is a short, stable identifier (e.g. `"no_permission"`, `"attr_not_equal"`) suitable for downstream programmatic handling.
+- `message` is a human-readable denial message. Keep it informative but do not leak sensitive attribute values.
+
+### Worked example: `UserLevelAtLeast`
+
+A rule that passes when `userLevel` is a number greater than or equal to a configured threshold:
+
+```ts
+import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+
+export interface UserLevelAtLeastConfig {
+  threshold: number;
+  group?: string;
+}
+
+export class UserLevelAtLeast implements Rule {
+  readonly ruleType: string;
+  readonly code = "user_level_too_low";
+  readonly message: string;
+
+  constructor(private readonly config: UserLevelAtLeastConfig) {
+    if (typeof config.threshold !== "number" || Number.isNaN(config.threshold)) {
+      throw new Error("UserLevelAtLeast: 'threshold' must be a finite number");
+    }
+    // Encode threshold into ruleType so two UserLevelAtLeast instances with
+    // different thresholds are AND-combined (both must pass), not OR-combined.
+    this.ruleType = config.group ?? `user_level_at_least:${String(config.threshold)}`;
+    this.message = `User level must be at least ${String(config.threshold)}.`;
+  }
+
+  verify(attrs: Attributes): boolean {
+    const level = attrs.get("userLevel");
+    if (typeof level !== "number") return false;
+    return level >= this.config.threshold;
+  }
+}
+```
+
+Notes:
+
+- Config is validated at construction time (fail fast). `verify()` is hot-path — it should not re-validate config.
+- `verify()` returns `false` for missing or non-number attributes (safe-deny). It does not throw.
+- The default `ruleType` includes the threshold so `new UserLevelAtLeast({ threshold: 3 })` and `new UserLevelAtLeast({ threshold: 5 })` produce distinct groups and are AND-combined. If you want them OR-combined (e.g. "level ≥ 3 OR some other ladder rung"), pass a shared `group` string to both.
+
+## Writing a custom AttributeCollector
+
+`AttributeCollector` is defined in `@o3co/auth.policy-verifier.core`:
+
+```ts
+interface AttributeCollector {
+  collect(context: CollectorContext): Promise<Attributes>;
+}
+```
+
+- One collector should produce a **focused set of attribute keys**. Do not bundle unrelated extractions. If you are extracting IP address and user agent, write two collectors.
+- Prefer string constants for attribute keys. See `ATTR_SCOPES`, `ATTR_PERMISSIONS`, `ATTR_ROLES`, `ATTR_USER_ID`, `ATTR_CLIENT_ID` in `@o3co/auth.policy-verifier.core`. For project-specific keys, define your own constants and **do not reuse core keys with different semantics**.
+- The `AttributePipeline` runs all collectors in parallel and merges their results: array values are concatenated, scalar/object values follow last-writer-wins. Design accordingly — do not rely on collector ordering.
+- `CollectorContext.requestContext` is intentionally unshaped. The engine does not ship a generic `requestContext` collector because its shape is defined by each consuming project's transport or interceptor. Write a focused collector per field you need to promote; validate shapes inside that collector.
+
+### Worked example: `ClientIpCollector`
+
+A collector that extracts the client IP from `requestContext` into an attribute:
+
+```ts
+import type {
+  AttributeCollector,
+  Attributes,
+  CollectorContext,
+} from "@o3co/auth.policy-verifier.core";
+
+// Project-specific attribute key constant — keep it local to your project.
+export const ATTR_CLIENT_IP = "clientIp" as const;
+
+export class ClientIpCollector implements AttributeCollector {
+  async collect(context: CollectorContext): Promise<Attributes> {
+    const ip = context.requestContext?.clientIp;
+    if (typeof ip !== "string" || ip.length === 0) {
+      return new Map(); // emit nothing — downstream rules see missing attribute and safe-deny
+    }
+    return new Map([[ATTR_CLIENT_IP, ip]]);
+  }
+}
+```
+
+Notes:
+
+- When the shape is wrong or the value is missing, emit an empty `Map`. Do not set the key to `null` or `undefined` — downstream rules distinguishing "missing" vs "present-and-falsy" would be brittle.
+- Validate the shape inside the collector. The type of `requestContext` is `Record<string, unknown>`; a collector that consumes it is the right place to narrow.
+
+## RuleCollector: when to write one
+
+`RuleCollector` is the factory that turns a `CollectorContext` into a `Rule[]`. Built-in examples are `ResourceActionPermissionRuleCollector` and `ResourceActionScopeRuleCollector` under [`packages/builtins/src/rules/collectors/`](../packages/builtins/src/rules/collectors/). They construct a `HasPermission` / `HasScope` rule from the request's resource and action.
+
+Write a custom `RuleCollector` when your rule construction depends on request-time context (resource, action, headers). If your rule is constant across all requests, instantiate the `Rule` directly at composition time instead — no collector needed.
+
+## Further reading
+
+- [`@o3co/auth.policy-verifier.core` README](../packages/core/README.md) — interfaces, evaluator, pipelines.
+- [`@o3co/auth.policy-verifier.builtins` README](../packages/builtins/README.md) — reference for built-in rules and collectors.
+- [AGENTS.md — Core Vocabulary Scope](../AGENTS.md#core-vocabulary-scope) — rationale for why `builtins` does not ship a generic `requestContext` collector.

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -211,5 +211,6 @@ import { builtinCollectorsModule } from "@o3co/auth.policy-verifier.builtins";
 
 ## 関連
 
-- [`@o3co/auth.policy-verifier.core`](../core/README.md) — コアインターフェースと attribute 定数
-- [auth.policy-verifier ルート README](../../README.md) — 完全なセットアップと設定のリファレンス
+- [拡張ガイド (`docs/extending.ja.md`)](../../docs/extending.ja.md) — カスタム `Rule` / `AttributeCollector` の書き方と、`builtins` が基本セットとして位置づけられている理由
+- [`@o3co/auth.policy-verifier.core`](../core/README.ja.md) — コアインターフェースと attribute 定数
+- [auth.policy-verifier ルート README](../../README.ja.md) — 完全なセットアップと設定のリファレンス

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -211,5 +211,6 @@ import { builtinCollectorsModule } from "@o3co/auth.policy-verifier.builtins";
 
 ## See Also
 
+- [Extension guide (`docs/extending.md`)](../../docs/extending.md) — how to write custom `Rule` and `AttributeCollector` implementations; positioning of `builtins` as a basic set
 - [`@o3co/auth.policy-verifier.core`](../core/README.md) — core interfaces and attribute constants
 - [auth.policy-verifier root README](../../README.md) — full setup and configuration reference

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionPermissionRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionPermissionRuleCollector.test.mts
@@ -1,6 +1,6 @@
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
-import { ResourceActionPermissionRuleCollector } from "#/rules/ResourceActionPermissionRuleCollector.mjs";
+import { ResourceActionPermissionRuleCollector } from "#/rules/collectors/ResourceActionPermissionRuleCollector.mjs";
 
 describe("ResourceActionPermissionRuleCollector", () => {
 	const collector = new ResourceActionPermissionRuleCollector();

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
@@ -1,6 +1,6 @@
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
-import { ResourceActionScopeRuleCollector } from "#/rules/ResourceActionScopeRuleCollector.mjs";
+import { ResourceActionScopeRuleCollector } from "#/rules/collectors/ResourceActionScopeRuleCollector.mjs";
 
 const makeContext = (resourceType: string, action: string, scope?: string): CollectorContext => ({
 	payload: { ...(scope !== undefined ? { scope } : {}) } satisfies VerifierPayload,

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -22,5 +22,6 @@ export { AttrPairEqual, type AttrPairEqualConfig } from "./rules/AttrPairEqual.m
 export { AttrPairNotEqual, type AttrPairNotEqualConfig } from "./rules/AttrPairNotEqual.mjs";
 export { HasPermission } from "./rules/HasPermission.mjs";
 export { HasScope } from "./rules/HasScope.mjs";
+// Rule Collectors
 export { ResourceActionPermissionRuleCollector } from "./rules/collectors/ResourceActionPermissionRuleCollector.mjs";
 export { ResourceActionScopeRuleCollector } from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -20,8 +20,7 @@ export { AttrMatchRule, type AttrMatchRuleConfig } from "./rules/AttrMatchRule.m
 export { AttrPairCompare, type AttrPairCompareConfig } from "./rules/AttrPairCompare.mjs";
 export { AttrPairEqual, type AttrPairEqualConfig } from "./rules/AttrPairEqual.mjs";
 export { AttrPairNotEqual, type AttrPairNotEqualConfig } from "./rules/AttrPairNotEqual.mjs";
-export { HasPermission } from "./rules/HasPermission.mjs";
-export { HasScope } from "./rules/HasScope.mjs";
-// Rule Collectors
 export { ResourceActionPermissionRuleCollector } from "./rules/collectors/ResourceActionPermissionRuleCollector.mjs";
 export { ResourceActionScopeRuleCollector } from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";
+export { HasPermission } from "./rules/HasPermission.mjs";
+export { HasScope } from "./rules/HasScope.mjs";

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -22,5 +22,5 @@ export { AttrPairEqual, type AttrPairEqualConfig } from "./rules/AttrPairEqual.m
 export { AttrPairNotEqual, type AttrPairNotEqualConfig } from "./rules/AttrPairNotEqual.mjs";
 export { HasPermission } from "./rules/HasPermission.mjs";
 export { HasScope } from "./rules/HasScope.mjs";
-export { ResourceActionPermissionRuleCollector } from "./rules/ResourceActionPermissionRuleCollector.mjs";
-export { ResourceActionScopeRuleCollector } from "./rules/ResourceActionScopeRuleCollector.mjs";
+export { ResourceActionPermissionRuleCollector } from "./rules/collectors/ResourceActionPermissionRuleCollector.mjs";
+export { ResourceActionScopeRuleCollector } from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";

--- a/packages/builtins/src/module.mts
+++ b/packages/builtins/src/module.mts
@@ -4,8 +4,8 @@ import { PayloadSubjectIdCollector } from "./collectors/PayloadSubjectIdCollecto
 import { StaticPermissionCollector } from "./collectors/StaticPermissionCollector.mjs";
 import { StaticRoleCollector } from "./collectors/StaticRoleCollector.mjs";
 import { DotNotationResourceParser } from "./resource/DotNotationResourceParser.mjs";
-import { ResourceActionPermissionRuleCollector } from "./rules/ResourceActionPermissionRuleCollector.mjs";
-import { ResourceActionScopeRuleCollector } from "./rules/ResourceActionScopeRuleCollector.mjs";
+import { ResourceActionPermissionRuleCollector } from "./rules/collectors/ResourceActionPermissionRuleCollector.mjs";
+import { ResourceActionScopeRuleCollector } from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";
 
 export const builtinCollectorsModule: Module = {
 	name: "builtin-collectors",

--- a/packages/builtins/src/rules/collectors/ResourceActionPermissionRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionPermissionRuleCollector.mts
@@ -1,5 +1,5 @@
 import type { CollectorContext, Rule, RuleCollector } from "@o3co/auth.policy-verifier.core";
-import { HasPermission } from "./HasPermission.mjs";
+import { HasPermission } from "../HasPermission.mjs";
 
 export class ResourceActionPermissionRuleCollector implements RuleCollector {
 	async collect(context: CollectorContext): Promise<Rule[]> {

--- a/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
@@ -1,5 +1,5 @@
 import type { CollectorContext, Rule, RuleCollector } from "@o3co/auth.policy-verifier.core";
-import { HasScope } from "./HasScope.mjs";
+import { HasScope } from "../HasScope.mjs";
 
 /**
  * Generates a HasScope rule derived from the request action and resource type.

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -165,6 +165,6 @@ export const customModule: Module = {
 
 ## 関連
 
-- [ルート README](../../README.md) — セットアップ全体、設定、サーバー利用方法
-- [`@o3co/auth.policy-verifier.builtins`](../builtins/README.md) — 組み込みコレクター、ルール、リソースパーサー
-- [`@o3co/auth.policy-verifier.server`](../server/README.md) — Express HTTP サーバーと `createApp`
+- [ルート README](../../README.ja.md) — セットアップ全体、設定、サーバー利用方法
+- [`@o3co/auth.policy-verifier.builtins`](../builtins/README.ja.md) — 組み込みコレクター、ルール、リソースパーサー
+- [`@o3co/auth.policy-verifier.server`](../server/README.ja.md) — Express HTTP サーバーと `createApp`

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -161,6 +161,8 @@ export const customModule: Module = {
 
 `customModule` をスタンドアロンエントリーポイントの `createApp` に渡してください。完全なセットアップ例はルートの README を参照してください。
 
+カスタム `Rule` の書き方、`ruleType` のグルーピング規約、独自ロジックを書くべきときと [`@o3co/auth.policy-verifier.builtins`](../builtins/README.ja.md) を使うべきときの判断基準などを含む完全な拡張ガイドは [`docs/extending.ja.md`](../../docs/extending.ja.md) を参照してください。
+
 ## 関連
 
 - [ルート README](../../README.md) — セットアップ全体、設定、サーバー利用方法

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -161,6 +161,8 @@ export const customModule: Module = {
 
 Pass `customModule` to `createApp` in the standalone entrypoint. See the root README for the full wiring example.
 
+For the full extension guide — including how to author custom `Rule` implementations, `ruleType` grouping semantics, and guidance on when to write custom logic vs. use [`@o3co/auth.policy-verifier.builtins`](../builtins/README.md) — see [`docs/extending.md`](../../docs/extending.md).
+
 ## See Also
 
 - [Root README](../../README.md) — full setup, configuration, and server usage

--- a/packages/server/README.ja.md
+++ b/packages/server/README.ja.md
@@ -182,6 +182,6 @@ const app = await createApp({
 
 ## 関連
 
-- [`@o3co/auth.policy-verifier.core`](../core/README.md) — 型定義、`evaluate`、`AttributePipeline`、`RulePipeline`、Module インフラ
-- [`@o3co/auth.policy-verifier.builtins`](../builtins/README.md) — 組み込みコレクターとパーサー
-- [auth.policy-verifier ルート README](../../README.md) — アーキテクチャ概要・設定リファレンス・Docker
+- [`@o3co/auth.policy-verifier.core`](../core/README.ja.md) — 型定義、`evaluate`、`AttributePipeline`、`RulePipeline`、Module インフラ
+- [`@o3co/auth.policy-verifier.builtins`](../builtins/README.ja.md) — 組み込みコレクターとパーサー
+- [auth.policy-verifier ルート README](../../README.ja.md) — アーキテクチャ概要・設定リファレンス・Docker


### PR DESCRIPTION
## Summary

- Move the two `RuleCollector` implementations (and their tests) from `packages/builtins/src/rules/` into a new `packages/builtins/src/rules/collectors/` subdirectory so `Rule` predicates and `RuleCollector` factories are visually separated at the file-system level.
- Add `docs/extending.md` + `docs/extending.ja.md`: a cross-cutting extension guide positioning `@o3co/auth.policy-verifier.builtins` as a basic set (not an exhaustive operator catalog) and documenting custom `Rule` / `AttributeCollector` authoring with worked examples (`UserLevelAtLeast`, `ClientIpCollector`).
- Correct the root README's prior claim that `builtins` ships a "request context" collector (it has never shipped one — contradicted the already-documented stance in `packages/builtins/README.md`). Link the new extension guide from the 6 relevant READMEs.

## What does NOT change

- Public API surface: exported symbol names, types, and the single `"."` export entry in `package.json`.
- Module registry keys (`"ResourceActionScopeRuleCollector"`, `"ResourceActionPermissionRuleCollector"`) — consumers referring to these by string in HOCON/JSON policy configs are unaffected.
- Runtime behavior, `evaluate()` semantics, `Rule` / `AttributeCollector` interfaces.
- Rule source files themselves (`HasPermission`, `HasScope`, `Attr*`, `_sharedValidation`) and `AttributeCollector` files.

## Commits

1. `5c2d139` — refactor(builtins): separate RuleCollector from Rule via rules/collectors/ subdir
2. `9c52356` — docs: add extension guide + correct builtins positioning in READMEs
3. `3c7198f` — docs: fix UserLevelAtLeast example guard message (was "finite number" but guard only rejects NaN)
4. `1eb68e4` — style: sort barrel exports per Biome organizeImports
5. `aba1122` — docs: note Infinity threshold footgun in UserLevelAtLeast example (code review follow-up)

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-04-17-rule-spec-optimization-and-extension-guide-design.md` (in the agentscope workspace)
- Plan: `docs/superpowers/plans/2026-04-17-rule-spec-optimization-and-extension-guide.md` (ditto)

## Test plan

- [x] `pnpm -r run test` — all suites pass (core, builtins 390 tests, server, standalone, integration)
- [x] `pnpm -r run build` — clean across all packages
- [x] `pnpm run lint` — biome check passes
- [x] Multi-agent review (Claude + Codex) — no regressions, minor feedback addressed in `aba1122`
- [x] Public API surface verified unchanged via `.d.ts` inspection

## Related / follow-up

- #35 — Fix link targets in `packages/core/README.ja.md` pointing to English READMEs (pre-existing, out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)