### PR TITLE
docs: add "When to choose this" section to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,6 +44,12 @@ Authorization: Bearer <jwt>
 - **プラグイン可能なアーキテクチャ** — Module システムでカスタム Collector、ルール、リソースパーサーをファクトリ経由で登録。
 - **DSL ロックインなし** — 認可ロジックは TypeScript。Rego も Cedar ポリシー言語も不要。スケールアウトが必要になれば grpc.authz 経由で OPA や Cedar に差し替え可能 — REST API 契約は同じ。
 
+## いつ選ぶか
+
+- ポリシーを書くのは開発者で、DSL を学習したくない → **これ**
+- ポリシーを非開発者が編集する、または形式検証が必要 → **[Cedar](https://www.cedarpolicy.com/)**
+- 組織全体のポリシー基盤として広範な built-in operator 群が必要 → **[OPA](https://www.openpolicyagent.org/)**
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Authorization: Bearer <jwt>
 - **Pluggable architecture** — Module system for registering custom collectors, rules, and resource parsers via factories.
 - **No DSL lock-in** — Authorization logic is TypeScript. No Rego, no Cedar policy language. If you outgrow this, swap to OPA or Cedar via grpc.authz — the REST API contract is the same.
 
+## When to choose this
+
+- Policy authors are developers, and you don't want to learn a DSL → **this**
+- Policies are edited by non-developers, or you need formal verification → **[Cedar](https://www.cedarpolicy.com/)**
+- You need org-wide policy infrastructure with a large built-in operator surface → **[OPA](https://www.openpolicyagent.org/)**
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a 3-line self-selection guide to both README.md and README.ja.md contrasting auth.policy-verifier with OPA and Cedar.

- Policy authors are developers, don't want a DSL → this
- Non-developer policy authors / formal verification → Cedar
- Org-wide policy infra with large operator surface → OPA

Closes #39

## Test plan

- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)