### PR TITLE
docs: rename grpc.authz references to protobuf.interceptors

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 マイクロサービス認可のための属性ベースアクセス制御 (ABAC) エンジン。JWT + リソース + アクションを受け取り、Collector 駆動のルールを評価して allow/deny を返す。ポリシー DSL 不要 — 認可ロジックは TypeScript で組み立てる。
 
-- OPA や Cedar にドロップイン置き換え可能 — [grpc.authz](https://github.com/o3co/grpc.authz) は3つすべてをバックエンドとしてサポート
+- OPA や Cedar にドロップイン置き換え可能 — [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) は共通の `VerifierEndpoint` インターフェース経由で本サービス、OPA、Cedar Agent のいずれにもルーティング可能
 - HTTP サイドカーとして動作 — エンジンの差し替えはコード変更ではなく設定変更で完了
 - JWT 検証アルゴリズム設定可能 — HS256, RS256, ES256, EdDSA。JWKS または公開鍵直接指定に対応。
 
@@ -42,7 +42,7 @@ Authorization: Bearer <jwt>
 - **JWT 検証アルゴリズム設定可能** — HS256（共有シークレット）、RS256/ES256/EdDSA（JWKS URI または公開鍵直接指定）。[auth.provider](https://github.com/o3co/auth.provider) の JWT 設定と対称設計。
 - **JWKS サポート** — `jwksUri` を auth.provider の `/.well-known/jwks.json` に向ければ鍵ローテーションに自動対応。
 - **プラグイン可能なアーキテクチャ** — Module システムでカスタム Collector、ルール、リソースパーサーをファクトリ経由で登録。
-- **DSL ロックインなし** — 認可ロジックは TypeScript。Rego も Cedar ポリシー言語も不要。スケールアウトが必要になれば grpc.authz 経由で OPA や Cedar に差し替え可能 — REST API 契約は同じ。
+- **DSL ロックインなし** — 認可ロジックは TypeScript。Rego も Cedar ポリシー言語も不要。スケールアウトが必要になれば [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) 経由で OPA や Cedar に差し替え可能 — interceptor がバックエンドを抽象化する。
 
 ## いつ選ぶか
 
@@ -200,7 +200,7 @@ docker run -e OAUTH_JWT_SECRET=secret my-verifier
 
 - [auth.provider](https://github.com/o3co/auth.provider) — DID 認証対応 OAuth 2.0 プロバイダー
 - [auth.proxy](https://github.com/o3co/auth.proxy) — トークン検証リバースプロキシ
-- [grpc.authz](https://github.com/o3co/grpc.authz) — gRPC 認可ミドルウェア (認可判定にこのサービスを呼び出す)
+- [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) — gRPC / ConnectRPC 向け protobuf method option 認可 interceptor (認可判定にこのサービスを呼び出す)
 - [auth](https://github.com/o3co/auth) — アーキテクチャドキュメントと E2E テスト
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Attribute-based access control (ABAC) engine for microservice authorization. Receives a JWT + resource + action, evaluates collector-driven rules, and returns allow/deny. No policy DSL — authorization logic is composed in TypeScript.
 
-- Drop-in replaceable with OPA or Cedar — [grpc.authz](https://github.com/o3co/grpc.authz) supports all three as backends
+- Drop-in replaceable with OPA or Cedar — [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) can route to this service, OPA, or Cedar Agent via a common `VerifierEndpoint` interface
 - Runs as an HTTP sidecar — swapping engines is a config change, not a code change
 - Configurable JWT verification — HS256, RS256, ES256, EdDSA with JWKS or direct public key
 
@@ -47,7 +47,7 @@ Authorization: Bearer <jwt>
 - **Configurable JWT verification** — HS256 (shared secret), RS256/ES256/EdDSA (JWKS URI or direct public key). Symmetric design with [auth.provider](https://github.com/o3co/auth.provider)'s JWT config.
 - **JWKS support** — Point `jwksUri` at auth.provider's `/.well-known/jwks.json` for automatic key rotation.
 - **Pluggable architecture** — Module system for registering custom collectors, rules, and resource parsers via factories.
-- **No DSL lock-in** — Authorization logic is TypeScript. No Rego, no Cedar policy language. If you outgrow this, swap to OPA or Cedar via grpc.authz — the REST API contract is the same.
+- **No DSL lock-in** — Authorization logic is TypeScript. No Rego, no Cedar policy language. If you outgrow this, swap to OPA or Cedar via [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) — the interceptor abstracts over the backend.
 
 ## When to choose this
 
@@ -205,7 +205,7 @@ docker run -e OAUTH_JWT_SECRET=secret my-verifier
 
 - [auth.provider](https://github.com/o3co/auth.provider) — OAuth 2.0 provider with DID authentication
 - [auth.proxy](https://github.com/o3co/auth.proxy) — Token validation reverse proxy
-- [grpc.authz](https://github.com/o3co/grpc.authz) — gRPC authorization middleware (calls this service for authorization decisions)
+- [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) — protobuf method option authorization interceptors for gRPC / ConnectRPC (calls this service for authorization decisions)
 - [auth](https://github.com/o3co/auth) — Architecture docs and E2E tests
 
 ## License


### PR DESCRIPTION
## Summary

- The `o3co/grpc.authz` repository has been renamed to `o3co/protobuf.interceptors` to reflect its broader scope (gRPC + ConnectRPC interceptors that resolve policy from protobuf method options).
- Update all README references (both EN and JP) accordingly, and refine the wording to match the new scope — the interceptor abstracts over the verifier backend (this service, OPA, Cedar Agent) via a common `VerifierEndpoint` interface.

## Changes

- `README.md`: 3 call-sites updated (hero bullet, "No DSL lock-in" bullet, Related projects list).
- `README.ja.md`: same 3 call-sites, translated.

## Test plan

- [ ] Links resolve to `https://github.com/o3co/protobuf.interceptors`.
- [ ] No remaining `grpc.authz` references in READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)