### PR TITLE
docs(builtins): clarify scope as capability ceiling on ResourceActionScopeRuleCollector

### DIFF
--- a/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
@@ -10,8 +10,8 @@ import { HasScope } from "../HasScope.mjs";
  * capability ceiling — not what the session **has been granted**. Whether the
  * operation is ultimately permitted is determined by the full rule pipeline
  * (other collectors, resource-owner policy, etc.). This collector enforces the
- * ceiling only: the requested `{action}:{resourceType}` must be present in
- * the scopes asserted by the token.
+ * ceiling only: it produces a `HasScope` rule for the requested
+ * `{action}:{resourceType}`, which must be satisfied by the token's scopes.
  *
  * ## Behavior for scopeless tokens
  *
@@ -25,8 +25,8 @@ import { HasScope } from "../HasScope.mjs";
  * contributes nothing — prefer collectors that derive rules from identity
  * claims (e.g. DID, `sub`, role) instead.
  *
- * See o3co/auth.provider#56 for background on why the IdP asserts identity,
- * not permissions.
+ * See https://github.com/o3co/auth.provider/issues/56 for background on why
+ * the IdP asserts identity, not permissions.
  */
 export class ResourceActionScopeRuleCollector implements RuleCollector {
 	async collect(context: CollectorContext): Promise<Rule[]> {

--- a/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
@@ -4,11 +4,29 @@ import { HasScope } from "../HasScope.mjs";
 /**
  * Generates a HasScope rule derived from the request action and resource type.
  *
- * When the JWT payload has no `scope` claim (e.g. DID-grant tokens), no rules
- * are generated. The scope rule group is therefore absent from AND-evaluation,
- * allowing other rule groups to decide independently.
+ * ## Scope as capability ceiling
  *
- * OAuth JWTs that carry a `scope` claim are validated as before.
+ * The JWT `scope` claim represents what the session **can request** — a
+ * capability ceiling — not what the session **has been granted**. Whether the
+ * operation is ultimately permitted is determined by the full rule pipeline
+ * (other collectors, resource-owner policy, etc.). This collector enforces the
+ * ceiling only: the requested `{action}:{resourceType}` must be present in
+ * the scopes asserted by the token.
+ *
+ * ## Behavior for scopeless tokens
+ *
+ * Flows where the IdP does not issue a `scope` claim (e.g. DID-grant tokens)
+ * produce scopeless JWTs. For those requests this collector returns no rules,
+ * so the scope rule group is absent from AND-evaluation and other rule groups
+ * decide independently. The collector is therefore safe to include in
+ * pipelines that mix OAuth and DID flows.
+ *
+ * For pipelines that exclusively serve scopeless flows, this collector
+ * contributes nothing — prefer collectors that derive rules from identity
+ * claims (e.g. DID, `sub`, role) instead.
+ *
+ * See o3co/auth.provider#56 for background on why the IdP asserts identity,
+ * not permissions.
  */
 export class ResourceActionScopeRuleCollector implements RuleCollector {
 	async collect(context: CollectorContext): Promise<Rule[]> {


### PR DESCRIPTION
## Summary

Expand the JSDoc on `ResourceActionScopeRuleCollector` to clarify the semantics of the JWT `scope` claim:

- `scope` is a **capability ceiling** — what the session can request — not granted permissions.
- Whether the operation is actually permitted is determined by the full rule-evaluation pipeline (other collectors, resource-owner policy, etc.).
- For scopeless tokens (e.g. DID-grant) the collector returns no rules, so the scope rule group is absent from AND-evaluation. It is safe to include in pipelines that mix OAuth and DID flows. For pipelines that exclusively serve scopeless flows, prefer collectors that derive rules from identity claims.

No runtime behavior change.

## Context

- Closes #26.
- Motivated by the rationale in o3co/auth.provider#56 — the IdP asserts identity, not permissions.
- Deliberate deviation from #26 wording: issue says "this collector should not be used" in DID flows, but the current implementation returns `[]` for scopeless tokens, making it safe in mixed pipelines. The doc reflects this nuance.

## Review input incorporated

Internal multi-agent review (Claude + Codex) flagged:

- I-1 (Important): "consented scope" was too narrow — `HasScope` is indifferent to scope provenance (OAuth consent vs `client_credentials` vs token exchange). Reworded to "the scopes asserted by the token".
- S-2 (Minor): "identity-based collectors (DID, `sub`, role)" implied out-of-the-box availability in this package — those collectors are not shipped in `@o3co/auth.policy-verifier.builtins`. Softened to "prefer collectors that derive rules from identity claims (e.g. DID, `sub`, role)".

## Test plan

- [ ] JSDoc renders without structural issues.
- [ ] No behavior change — existing tests in `packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts` remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)