### PR TITLE
docs: add SPDX headers and TSDoc across core/builtins/server

### DIFF
--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { cpSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/create-app/src/cli.mts
+++ b/create-app/src/cli.mts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
 import { main } from "./index.mjs";
 
 main();

--- a/create-app/src/index.mts
+++ b/create-app/src/index.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { cpSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -5,6 +8,11 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = resolve(__dirname, "../templates/standalone");
 
+/**
+ * Reads the embedded `versions.json` produced by the prebuild script. Returns
+ * an empty map if the file is absent (e.g. running from source without
+ * prebuild), so callers must treat "not found" as a separate branch.
+ */
 const getPackageVersions = (): Record<string, string> => {
 	const versionFile = resolve(__dirname, "../templates/versions.json");
 	if (existsSync(versionFile)) {
@@ -13,6 +21,14 @@ const getPackageVersions = (): Record<string, string> => {
 	return {};
 };
 
+/**
+ * Copies the bundled standalone template into `targetDir`, rewrites
+ * `package.json` with the new `projectName`, and replaces every `workspace:*`
+ * dependency with the concrete published version from `versions.json`.
+ *
+ * Throws if the template directory is missing (unprebuilt) or if any
+ * workspace dependency is not pinned in `versions.json`.
+ */
 export const scaffold = (targetDir: string, projectName: string): void => {
 	if (!existsSync(TEMPLATES_DIR)) {
 		throw new Error(
@@ -57,7 +73,11 @@ export const scaffold = (targetDir: string, projectName: string): void => {
 	writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 };
 
-// CLI entry point
+/**
+ * CLI entry point: reads the project name from argv, validates it as an
+ * unscoped npm package name, ensures the target directory does not exist,
+ * and scaffolds the template. Exits with non-zero on any validation failure.
+ */
 export const main = (): void => {
 	const args = process.argv.slice(2);
 	const projectName = args[0];

--- a/packages/builtins/src/__tests__/collectors/PayloadScopeCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/PayloadScopeCollector.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";

--- a/packages/builtins/src/__tests__/collectors/PayloadSubjectIdCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/PayloadSubjectIdCollector.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { ATTR_CLIENT_ID, ATTR_USER_ID } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";

--- a/packages/builtins/src/__tests__/collectors/StaticPermissionCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/StaticPermissionCollector.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { ATTR_PERMISSIONS } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";

--- a/packages/builtins/src/__tests__/collectors/StaticRoleCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/StaticRoleCollector.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";

--- a/packages/builtins/src/__tests__/module.test.mts
+++ b/packages/builtins/src/__tests__/module.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	type AttributeCollectorFactory,
 	type KeyResolverFactory,

--- a/packages/builtins/src/__tests__/resource/DotNotationResourceParser.test.mts
+++ b/packages/builtins/src/__tests__/resource/DotNotationResourceParser.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import { DotNotationResourceParser } from "#/resource/DotNotationResourceParser.mjs";
 

--- a/packages/builtins/src/__tests__/rules/AttrLiteralCompare.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralCompare.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrLiteralCompare } from "#/rules/AttrLiteralCompare.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralEqual.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrLiteralEqual } from "#/rules/AttrLiteralEqual.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralIn.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrLiteralIn } from "#/rules/AttrLiteralIn.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotEqual.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrLiteralNotEqual } from "#/rules/AttrLiteralNotEqual.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrLiteralNotIn.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrLiteralNotIn } from "#/rules/AttrLiteralNotIn.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrMatchRule.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrMatchRule } from "#/rules/AttrMatchRule.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrPairCompare.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairCompare.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrPairCompare } from "#/rules/AttrPairCompare.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrPairEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairEqual.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrPairEqual } from "#/rules/AttrPairEqual.mjs";

--- a/packages/builtins/src/__tests__/rules/AttrPairNotEqual.test.mts
+++ b/packages/builtins/src/__tests__/rules/AttrPairNotEqual.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { AttrPairNotEqual } from "#/rules/AttrPairNotEqual.mjs";

--- a/packages/builtins/src/__tests__/rules/HasPermission.test.mts
+++ b/packages/builtins/src/__tests__/rules/HasPermission.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { HasPermission } from "#/rules/HasPermission.mjs";

--- a/packages/builtins/src/__tests__/rules/HasScope.test.mts
+++ b/packages/builtins/src/__tests__/rules/HasScope.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { HasScope } from "#/rules/HasScope.mjs";

--- a/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
+++ b/packages/builtins/src/__tests__/rules/_sharedValidation.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import {
 	applyCompare,

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionPermissionRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionPermissionRuleCollector.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { ResourceActionPermissionRuleCollector } from "#/rules/collectors/ResourceActionPermissionRuleCollector.mjs";

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { ResourceActionScopeRuleCollector } from "#/rules/collectors/ResourceActionScopeRuleCollector.mjs";

--- a/packages/builtins/src/collectors/PayloadScopeCollector.mts
+++ b/packages/builtins/src/collectors/PayloadScopeCollector.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type {
 	AttributeCollector,
 	Attributes,
@@ -5,6 +8,11 @@ import type {
 } from "@o3co/auth.policy-verifier.core";
 import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 
+/**
+ * Attribute collector that splits the OAuth2 `scope` claim (space-delimited)
+ * into a `string[]` and exposes it under `ATTR_SCOPES`. Missing or non-string
+ * `scope` yields an empty array.
+ */
 export class PayloadScopeCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {
 		const scope = context.payload.scope;

--- a/packages/builtins/src/collectors/PayloadSubjectIdCollector.mts
+++ b/packages/builtins/src/collectors/PayloadSubjectIdCollector.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type {
 	AttributeCollector,
 	Attributes,
@@ -5,6 +8,10 @@ import type {
 } from "@o3co/auth.policy-verifier.core";
 import { ATTR_CLIENT_ID, ATTR_USER_ID } from "@o3co/auth.policy-verifier.core";
 
+/**
+ * Attribute collector that extracts `sub` and `azp` from the JWT payload into
+ * `ATTR_USER_ID` and `ATTR_CLIENT_ID`. Either claim may be absent.
+ */
 export class PayloadSubjectIdCollector implements AttributeCollector {
 	async collect(context: CollectorContext): Promise<Attributes> {
 		const attrs: Attributes = new Map();

--- a/packages/builtins/src/collectors/StaticPermissionCollector.mts
+++ b/packages/builtins/src/collectors/StaticPermissionCollector.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type {
 	AttributeCollector,
 	Attributes,
@@ -5,6 +8,11 @@ import type {
 } from "@o3co/auth.policy-verifier.core";
 import { ATTR_PERMISSIONS } from "@o3co/auth.policy-verifier.core";
 
+/**
+ * Attribute collector that returns a configured constant permission list under
+ * `ATTR_PERMISSIONS`, independent of the JWT payload. Useful for
+ * environments where permissions are static per deployment.
+ */
 export class StaticPermissionCollector implements AttributeCollector {
 	private permissions: string[];
 

--- a/packages/builtins/src/collectors/StaticRoleCollector.mts
+++ b/packages/builtins/src/collectors/StaticRoleCollector.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type {
 	AttributeCollector,
 	Attributes,
@@ -6,6 +9,11 @@ import type {
 } from "@o3co/auth.policy-verifier.core";
 import { ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 
+/**
+ * Attribute collector that returns a configured constant role list under
+ * `ATTR_ROLES`, independent of the JWT payload. Each role bundles a name and
+ * the permissions it implies.
+ */
 export class StaticRoleCollector implements AttributeCollector {
 	private roles: Role[];
 

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 // Collectors
 export { PayloadScopeCollector } from "./collectors/PayloadScopeCollector.mjs";
 export { PayloadSubjectIdCollector } from "./collectors/PayloadSubjectIdCollector.mjs";

--- a/packages/builtins/src/module.mts
+++ b/packages/builtins/src/module.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Module } from "@o3co/auth.policy-verifier.core";
 import { PayloadScopeCollector } from "./collectors/PayloadScopeCollector.mjs";
 import { PayloadSubjectIdCollector } from "./collectors/PayloadSubjectIdCollector.mjs";
@@ -7,6 +10,11 @@ import { DotNotationResourceParser } from "./resource/DotNotationResourceParser.
 import { ResourceActionPermissionRuleCollector } from "./rules/collectors/ResourceActionPermissionRuleCollector.mjs";
 import { ResourceActionScopeRuleCollector } from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";
 
+/**
+ * `Module` that registers the built-in attribute collectors, rule collectors,
+ * and resource parser with a policy-verifier server. Import and pass to
+ * `createApp({ modules: [builtinCollectorsModule, ...] })`.
+ */
 export const builtinCollectorsModule: Module = {
 	name: "builtin-collectors",
 	async init(context) {

--- a/packages/builtins/src/resource/DotNotationResourceParser.mts
+++ b/packages/builtins/src/resource/DotNotationResourceParser.mts
@@ -1,5 +1,14 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Resource, ResourceParser } from "@o3co/auth.policy-verifier.core";
 
+/**
+ * Resource parser for dot-separated, colon-qualified identifiers such as
+ * `"org:123.project:abc.document:42"`. Each dot segment is `type[:id]`; the
+ * resulting `resourceType` concatenates all segment types with `_`, and
+ * `resourceId` is the id of the last segment (if any).
+ */
 export class DotNotationResourceParser implements ResourceParser {
 	parse(raw: string): Resource {
 		const segments = raw

--- a/packages/builtins/src/rules/AttrLiteralCompare.mts
+++ b/packages/builtins/src/rules/AttrLiteralCompare.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	applyCompare,

--- a/packages/builtins/src/rules/AttrLiteralEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralEqual.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	type LiteralValue,

--- a/packages/builtins/src/rules/AttrLiteralIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralIn.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	computeValuesKey,

--- a/packages/builtins/src/rules/AttrLiteralNotEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotEqual.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	type LiteralValue,

--- a/packages/builtins/src/rules/AttrLiteralNotIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotIn.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	computeValuesKey,

--- a/packages/builtins/src/rules/AttrMatchRule.mts
+++ b/packages/builtins/src/rules/AttrMatchRule.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { AttrPairEqual, type AttrPairEqualConfig } from "./AttrPairEqual.mjs";
 
 export type AttrMatchRuleConfig = AttrPairEqualConfig;

--- a/packages/builtins/src/rules/AttrPairCompare.mts
+++ b/packages/builtins/src/rules/AttrPairCompare.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	applyCompare,

--- a/packages/builtins/src/rules/AttrPairEqual.mts
+++ b/packages/builtins/src/rules/AttrPairEqual.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { requireAttrName, requireOptionalGroup } from "./_sharedValidation.mjs";
 

--- a/packages/builtins/src/rules/AttrPairNotEqual.mts
+++ b/packages/builtins/src/rules/AttrPairNotEqual.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { requireAttrName, requireOptionalGroup } from "./_sharedValidation.mjs";
 

--- a/packages/builtins/src/rules/HasPermission.mts
+++ b/packages/builtins/src/rules/HasPermission.mts
@@ -1,6 +1,20 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Role, Rule } from "@o3co/auth.policy-verifier.core";
 import { ATTR_PERMISSIONS, ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 
+/**
+ * Rule that passes when the subject holds the required permission, either
+ * directly via `ATTR_PERMISSIONS` or transitively through a role in
+ * `ATTR_ROLES`.
+ *
+ * Matching is case-insensitive. A granted permission of `"*"` wildcards
+ * everything. A granted permission may contain a single `*` used as prefix,
+ * suffix, or middle separator (e.g. `"posts.*"`, `"*.read"`, `"posts.*.read"`);
+ * multiple wildcards are explicitly rejected because the two-part split would
+ * silently drop segments and over-grant.
+ */
 export class HasPermission implements Rule {
 	readonly ruleType = "permission";
 	readonly code = "no_permission";

--- a/packages/builtins/src/rules/HasScope.mts
+++ b/packages/builtins/src/rules/HasScope.mts
@@ -1,6 +1,15 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 
+/**
+ * Rule that passes when the token carries a scope matching the required
+ * `perm:resource` form (case-insensitive). A granted scope written as a single
+ * token (no `:`) is treated as `read:<token>`, matching OAuth2 conventions
+ * where bare resource names imply read access.
+ */
 export class HasScope implements Rule {
 	readonly ruleType = "scope";
 	readonly code = "invalid_scope";

--- a/packages/builtins/src/rules/_sharedValidation.mts
+++ b/packages/builtins/src/rules/_sharedValidation.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { createHash } from "node:crypto";
 
 /**

--- a/packages/builtins/src/rules/collectors/ResourceActionPermissionRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionPermissionRuleCollector.mts
@@ -1,6 +1,15 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, Rule, RuleCollector } from "@o3co/auth.policy-verifier.core";
 import { HasPermission } from "../HasPermission.mjs";
 
+/**
+ * Rule collector that emits a single `HasPermission` rule for the
+ * `{resource}.perm:{action}` permission string. Use when the effective
+ * permission is encoded directly into the token's permission attribute rather
+ * than derived from scopes.
+ */
 export class ResourceActionPermissionRuleCollector implements RuleCollector {
 	async collect(context: CollectorContext): Promise<Rule[]> {
 		const permission = `${context.resource.raw}.perm:${context.action}`;

--- a/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, Rule, RuleCollector } from "@o3co/auth.policy-verifier.core";
 import { HasScope } from "../HasScope.mjs";
 

--- a/packages/builtins/vitest.config.mts
+++ b/packages/builtins/vitest.config.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/core/src/AttributePipeline.mts
+++ b/packages/core/src/AttributePipeline.mts
@@ -1,14 +1,30 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { AttributeCollector, Attributes, CollectorContext } from "./types.mjs";
 
+/**
+ * Fan-out aggregator that runs every `AttributeCollector` in parallel and merges
+ * their results into a single `Attributes` map.
+ *
+ * Merge semantics: when the same key is produced by multiple collectors,
+ * array-valued entries concatenate (in collector order), and non-array values
+ * are overwritten by later collectors.
+ */
 export class AttributePipeline {
 	constructor(private collectors: AttributeCollector[]) {}
 
+	/** Runs every collector in parallel and returns the merged attribute map. */
 	async collect(context: CollectorContext): Promise<Attributes> {
 		const results = await Promise.all(this.collectors.map((c) => c.collect(context)));
 		return merge(results);
 	}
 }
 
+/**
+ * Merges attribute maps into a single map. Array-valued entries concatenate
+ * in input order; non-array values are overwritten by later maps.
+ */
 function merge(maps: Attributes[]): Attributes {
 	const merged: Attributes = new Map();
 	for (const map of maps) {

--- a/packages/core/src/RulePipeline.mts
+++ b/packages/core/src/RulePipeline.mts
@@ -1,8 +1,17 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { CollectorContext, Rule, RuleCollector } from "./types.mjs";
 
+/**
+ * Fan-out aggregator that runs every `RuleCollector` in parallel and flattens
+ * their results into a single `Rule[]`. Unlike `AttributePipeline`, rules do not
+ * merge — each collector's rules are simply concatenated.
+ */
 export class RulePipeline {
 	constructor(private collectors: RuleCollector[]) {}
 
+	/** Runs every collector in parallel and returns the flattened rule list. */
 	async collect(context: CollectorContext): Promise<Rule[]> {
 		const results = await Promise.all(this.collectors.map((c) => c.collect(context)));
 		return results.flat();

--- a/packages/core/src/__tests__/AttributePipeline.test.mts
+++ b/packages/core/src/__tests__/AttributePipeline.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import { AttributePipeline } from "../AttributePipeline.mjs";
 import type {

--- a/packages/core/src/__tests__/Registry.test.mts
+++ b/packages/core/src/__tests__/Registry.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import { Registry } from "../modules/Registry.mjs";
 

--- a/packages/core/src/__tests__/RulePipeline.test.mts
+++ b/packages/core/src/__tests__/RulePipeline.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import { RulePipeline } from "../RulePipeline.mjs";
 import type { CollectorContext, Rule, RuleCollector, VerifierPayload } from "../types.mjs";

--- a/packages/core/src/__tests__/evaluate.test.mts
+++ b/packages/core/src/__tests__/evaluate.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import { evaluate } from "../evaluate.mjs";
 import type { Attributes, Rule } from "../types.mjs";

--- a/packages/core/src/__tests__/keys.test.mts
+++ b/packages/core/src/__tests__/keys.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from "vitest";
 import {
 	ATTR_CLIENT_ID,

--- a/packages/core/src/evaluate.mts
+++ b/packages/core/src/evaluate.mts
@@ -1,27 +1,38 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Attributes, Decision, Rule } from "./types.mjs";
 
+/**
+ * Evaluates collected rules against attributes and returns an allow/deny decision.
+ *
+ * Semantics: rules are grouped by `ruleType`; each group is evaluated as OR
+ * (any rule passing satisfies the group), and all groups must pass (AND across groups)
+ * for an allow decision. On deny, the first rule of the failing group supplies
+ * the `code` and `message`.
+ *
+ * @param attrs - Attributes collected for the request (subject, resource, environment).
+ * @param rules - Flat list of rules collected from all rule collectors.
+ * @returns `{ decision: "allow" }` if every group passes, otherwise a deny decision.
+ */
 export function evaluate(attrs: Attributes, rules: Rule[]): Decision {
-	const groups = new Map<string, Rule[]>();
-	for (const rule of rules) {
-		const group = groups.get(rule.ruleType);
-		if (group) {
-			group.push(rule);
-		} else {
-			groups.set(rule.ruleType, [rule]);
-		}
-	}
+	// Phase 1: group rules by ruleType — rules within a group are alternatives (OR).
+	const groups = Map.groupBy(rules, (rule) => rule.ruleType);
 
+	// Phase 2: each group must have at least one passing rule (AND across groups).
 	for (const groupRules of groups.values()) {
 		const passed = groupRules.some((rule) => rule.verify(attrs));
-		if (!passed) {
-			const representative = groupRules[0];
-			return {
-				decision: "deny",
-				code: representative.code,
-				message: representative.message,
-			};
-		}
+		if (passed) continue;
+
+		// Deny on the first failing group; representative carries the user-facing reason.
+		const representative = groupRules[0];
+		return {
+			decision: "deny",
+			code: representative.code,
+			message: representative.message,
+		};
 	}
 
+	// Phase 3: all groups passed → allow.
 	return { decision: "allow" };
 }

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 export { AttributePipeline } from "./AttributePipeline.mjs";
 export { evaluate } from "./evaluate.mjs";
 export {

--- a/packages/core/src/keys.mts
+++ b/packages/core/src/keys.mts
@@ -1,3 +1,10 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Canonical attribute keys used by built-in collectors and rules. Consumers
+// should reference these constants instead of raw strings so that renames stay
+// centralized and TypeScript can infer literal types.
+
 export const ATTR_SCOPES = "scopes" as const;
 export const ATTR_PERMISSIONS = "permissions" as const;
 export const ATTR_ROLES = "roles" as const;

--- a/packages/core/src/modules/Registry.mts
+++ b/packages/core/src/modules/Registry.mts
@@ -1,6 +1,14 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Name-keyed registry of instances. Duplicate registrations and missing lookups
+ * throw — callers can treat registered names as always present after `register`.
+ */
 export class Registry<T> {
 	private readonly map = new Map<string, T>();
 
+	/** Registers `instance` under `name`. Throws if `name` is already registered. */
 	register(name: string, instance: T): void {
 		if (this.map.has(name)) {
 			throw new Error(`Registry: "${name}" is already registered`);
@@ -8,6 +16,7 @@ export class Registry<T> {
 		this.map.set(name, instance);
 	}
 
+	/** Returns the instance registered under `name`. Throws if not registered. */
 	get(name: string): T {
 		if (!this.map.has(name)) {
 			throw new Error(`Registry: "${name}" is not registered`);
@@ -15,10 +24,12 @@ export class Registry<T> {
 		return this.map.get(name) as T;
 	}
 
+	/** Returns `true` if an instance is registered under `name`. */
 	has(name: string): boolean {
 		return this.map.has(name);
 	}
 
+	/** Returns a snapshot of all `[name, instance]` pairs. */
 	entries(): [string, T][] {
 		return [...this.map.entries()];
 	}

--- a/packages/core/src/modules/index.mts
+++ b/packages/core/src/modules/index.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 export { Registry } from "./Registry.mjs";
 export type {
 	AttributeCollectorFactory,

--- a/packages/core/src/modules/types.mts
+++ b/packages/core/src/modules/types.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { AttributeCollector, KeyResolver, ResourceParser, RuleCollector } from "../types.mjs";
 import type { Registry } from "./Registry.mjs";
 
@@ -11,10 +14,13 @@ export type PathResolver = (specifier: string) => string;
  * Factory functions that accept a config entry and return an instance.
  * Config entries come from the application HOCON config (e.g. { collector: "Name", ...extras }).
  */
+/** Produces an `AttributeCollector` from its HOCON config entry. */
 // biome-ignore lint/suspicious/noExplicitAny: collector constructors accept varied config shapes
 export type AttributeCollectorFactory = (config: any) => AttributeCollector;
+/** Produces a `RuleCollector` from its HOCON config entry. */
 // biome-ignore lint/suspicious/noExplicitAny: rule collector constructors accept varied config shapes
 export type RuleCollectorFactory = (config: any) => RuleCollector;
+/** Produces a `ResourceParser` from its HOCON config entry. */
 // biome-ignore lint/suspicious/noExplicitAny: resource parser constructors accept varied config shapes
 export type ResourceParserFactory = (config: any) => ResourceParser;
 /**

--- a/packages/core/src/types.mts
+++ b/packages/core/src/types.mts
@@ -1,9 +1,18 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Structured form of a resource string after parsing. */
 export interface Resource {
 	raw: string;
 	resourceType: string;
 	resourceId?: string;
 }
 
+/**
+ * Parses a raw resource string (e.g. `"orders/42"`) into a `Resource`.
+ * Implementations define their own syntax; the resource string is pipeline
+ * input and must round-trip via `raw`.
+ */
 export interface ResourceParser {
 	parse(raw: string): Resource;
 }
@@ -18,6 +27,9 @@ export interface KeyResolver {
 	algorithms: string[];
 }
 
+/**
+ * Request-scoped input shared across every attribute and rule collector for a single verify call.
+ */
 export interface CollectorContext {
 	payload: VerifierPayload;
 	resource: Resource;
@@ -26,12 +38,26 @@ export interface CollectorContext {
 	requestContext?: Record<string, unknown>;
 }
 
+/**
+ * Map of attribute keys to values produced by attribute collectors.
+ * Values are `unknown` so collectors can contribute any shape; downstream rules
+ * are responsible for narrowing.
+ */
 export type Attributes = Map<string, unknown>;
 
+/**
+ * Produces attributes for a request. One collector contributes one logical slice
+ * (e.g. subject id, scopes, roles). Results are merged by the `AttributePipeline`.
+ */
 export interface AttributeCollector {
 	collect(context: CollectorContext): Promise<Attributes>;
 }
 
+/**
+ * A single authorization rule. `verify` runs against the merged attributes and
+ * returns whether the rule passes; `ruleType` groups alternative rules (OR within
+ * a group), and `code` / `message` surface on deny.
+ */
 export interface Rule {
 	ruleType: string;
 	code: string;
@@ -39,17 +65,30 @@ export interface Rule {
 	verify(attrs: Attributes): boolean;
 }
 
+/**
+ * Produces rules for a request. A rule collector may return zero or more rules;
+ * the `RulePipeline` flattens results from all collectors before evaluation.
+ */
 export interface RuleCollector {
 	collect(context: CollectorContext): Promise<Rule[]>;
 }
 
+/**
+ * Outcome of `evaluate`. On `"deny"`, `code` and `message` come from the first
+ * rule of the first failing group.
+ */
 export type Decision = { decision: "allow" } | { decision: "deny"; code: string; message: string };
 
+/** Named bundle of permissions. Used by role-based attribute collectors. */
 export interface Role {
 	name: string;
 	permissions: string[];
 }
 
+/**
+ * Decoded JWT claims consumed by the verifier, with an open index signature so
+ * custom claims (e.g. `tenant`, `scope_*`) can be propagated without changing core.
+ */
 export interface VerifierPayload {
 	sub?: string;
 	azp?: string;

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { Module } from "@o3co/auth.policy-verifier.core";
 import { SignJWT } from "jose";
 import request from "supertest";

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -1,16 +1,5 @@
-// Copyright 2026 1o1 Co. Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
 import { AppConfigSchema } from "#/config/application.schema.mjs";

--- a/packages/server/src/__tests__/builtinKeyResolversModule.test.mts
+++ b/packages/server/src/__tests__/builtinKeyResolversModule.test.mts
@@ -1,16 +1,5 @@
-// Copyright 2026 1o1 Co. Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
 import { generateKeyPair } from "node:crypto";
 import { promisify } from "node:util";

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -1,16 +1,5 @@
-// Copyright 2026 1o1 Co. Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
 import { generateKeyPair } from "node:crypto";
 import { promisify } from "node:util";

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	type AttributeCollectorFactory,
 	AttributePipeline,
@@ -14,12 +17,24 @@ import express from "express";
 import type { AppConfig } from "./config/application.schema.mjs";
 import { createVerifyRouter } from "./routes/verify.mjs";
 
+/** Options accepted by `createApp`. */
 export interface CreateAppOptions {
 	pathResolver: PathResolver;
 	config: AppConfig;
 	modules: Module[];
 }
 
+/**
+ * Builds the Express app with registries initialized by the supplied modules.
+ *
+ * Flow: (1) create registries, (2) run `mod.init` sequentially so later modules
+ * can see earlier ones' registrations, (3) resolve concrete collectors /
+ * resource parser / key resolver from config, (4) mount the `/verify` router
+ * and healthcheck under the configured path prefix.
+ *
+ * `config.oauth.jwt.validate = false` disables signature verification and only
+ * decodes the token. This is a development-only switch; a warning is logged.
+ */
 export async function createApp(options: CreateAppOptions): Promise<express.Express> {
 	const { pathResolver, config, modules } = options;
 

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { z } from "zod";
 
 const collectorSchema = z
@@ -6,6 +9,17 @@ const collectorSchema = z
 	})
 	.passthrough();
 
+/**
+ * Zod schema for the HOCON-loaded application configuration. Validates the
+ * shape of `http`, `oauth.jwt`, `attribute.collectors`, `rule.collectors`, and
+ * `resource.parser`. `.passthrough()` on nested objects lets custom collector
+ * and factory configs add their own fields without schema edits.
+ *
+ * Built-in JWT algorithms (HS256 / RS256 / ES256 / EdDSA) carry extra
+ * `superRefine` validation for their required key material. Unknown algorithm
+ * names pass schema validation and are expected to validate themselves in
+ * their `KeyResolverFactory`.
+ */
 export const AppConfigSchema = z.object({
 	http: z
 		.object({
@@ -59,4 +73,5 @@ export const AppConfigSchema = z.object({
 		.default(() => ({ parser: "DotNotationResourceParser" })),
 });
 
+/** Type inferred from `AppConfigSchema`. Consumed by `createApp`. */
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/packages/server/src/index.mts
+++ b/packages/server/src/index.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 export { type CreateAppOptions, createApp } from "./app.mjs";
 export { type AppConfig, AppConfigSchema } from "./config/application.schema.mjs";
 export {

--- a/packages/server/src/jwt/builtinKeyResolversModule.mts
+++ b/packages/server/src/jwt/builtinKeyResolversModule.mts
@@ -1,16 +1,5 @@
-// Copyright 2026 1o1 Co. Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
 import { createSecretKey } from "node:crypto";
 import { readFile } from "node:fs/promises";
@@ -24,6 +13,10 @@ interface JwtFactoryInput {
 	publicKeyPath?: string;
 }
 
+/**
+ * Shared resolver for RS256/ES256/EdDSA. Accepts JWKS URI, inline PEM, or PEM
+ * file path (in that priority). Throws if no key source is configured.
+ */
 async function resolveAsymmetric(algorithm: string, config: JwtFactoryInput): Promise<KeyResolver> {
 	if (config.jwksUri) {
 		const key = createRemoteJWKSet(new URL(config.jwksUri));
@@ -41,6 +34,7 @@ async function resolveAsymmetric(algorithm: string, config: JwtFactoryInput): Pr
 	throw new Error(`jwksUri or publicKey/publicKeyPath is required for ${algorithm}`);
 }
 
+/** Resolves an HS256 symmetric key from `config.secret`. Throws if absent. */
 export const HS256KeyResolverFactory: KeyResolverFactory = async (config: JwtFactoryInput) => {
 	if (!config.secret) {
 		throw new Error("secret is required for HS256");
@@ -49,15 +43,23 @@ export const HS256KeyResolverFactory: KeyResolverFactory = async (config: JwtFac
 	return { key, algorithms: ["HS256"] };
 };
 
+/** Resolves an RS256 public key from JWKS / PEM string / PEM file. */
 export const RS256KeyResolverFactory: KeyResolverFactory = (config: JwtFactoryInput) =>
 	resolveAsymmetric("RS256", config);
 
+/** Resolves an ES256 public key from JWKS / PEM string / PEM file. */
 export const ES256KeyResolverFactory: KeyResolverFactory = (config: JwtFactoryInput) =>
 	resolveAsymmetric("ES256", config);
 
+/** Resolves an EdDSA public key from JWKS / PEM string / PEM file. */
 export const EdDSAKeyResolverFactory: KeyResolverFactory = (config: JwtFactoryInput) =>
 	resolveAsymmetric("EdDSA", config);
 
+/**
+ * `Module` that registers the four built-in JWT key resolver factories
+ * (HS256 / RS256 / ES256 / EdDSA) on the `keyResolverRegistry`. Include in
+ * `createApp({ modules })` to enable the default algorithms.
+ */
 export const builtinKeyResolversModule: Module = {
 	name: "builtin-key-resolvers",
 	async init(context) {

--- a/packages/server/src/jwt/index.mts
+++ b/packages/server/src/jwt/index.mts
@@ -1,16 +1,5 @@
-// Copyright 2026 1o1 Co. Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
 export {
 	builtinKeyResolversModule,

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	type AttributePipeline,
 	evaluate,
@@ -8,6 +11,7 @@ import {
 import express from "express";
 import { decodeJwt, type JWTPayload, jwtVerify } from "jose";
 
+/** Config for `createVerifyRouter`. The `jwt.key` type is library-specific and is narrowed at call-time. */
 export interface VerifyRouterConfig {
 	jwt: {
 		// The `key` is produced by a KeyResolverFactory; its concrete type depends on
@@ -22,6 +26,13 @@ export interface VerifyRouterConfig {
 	rulePipeline: RulePipeline;
 }
 
+/**
+ * Builds the Express router that serves `POST /verify`.
+ *
+ * Request: `Authorization: Bearer <jwt>`, body `{ resource: string, action: string, context?: object }`.
+ * Response: `{ decision: "allow" }` (200), `{ decision: "deny", code, message }` (403),
+ * or 400 for bad request / 401 for auth errors / 500 for unexpected.
+ */
 export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	const router = express.Router();
 	router.use(express.json());

--- a/packages/server/vitest.config.mts
+++ b/packages/server/vitest.config.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * Smoke tests for the standalone template.
  *

--- a/templates/standalone/src/main.mts
+++ b/templates/standalone/src/main.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * Standalone entrypoint — creates and starts the policy-verifier server.
  */

--- a/templates/standalone/vitest.config.mts
+++ b/templates/standalone/vitest.config.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/tests/integration/src/evaluate-with-rules.test.mts
+++ b/tests/integration/src/evaluate-with-rules.test.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	AttrLiteralCompare,
 	AttrLiteralEqual,

--- a/tests/integration/vitest.config.mts
+++ b/tests/integration/vitest.config.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Two orthogonal documentation improvements, plus one drive-by code-quality polish, bundled into a single PR because they touch overlapping file sets:

- **SPDX license headers** prepended to every TypeScript/JavaScript file (76 files). Machine-readable by reuse-tool / licensecheck / GitHub license detection. Holder + year come from LICENSE; identifier is Apache-2.0.
- **TSDoc on every public export** in `core`, `builtins`, `server`, `create-app`, plus selected file-local helpers (`merge`, `resolveAsymmetric`, `getPackageVersions`) whose responsibility is not obvious from the name.
- **Cleanup**: 5 server files carried an Apache long-form header in addition to the SPDX lines; the redundant long form is removed so each file has a single canonical SPDX header.
- **Drive-by refactor** in `packages/core/src/evaluate.mts`: Phase 1 (group rules by ruleType) rewritten using `Map.groupBy` (ES2024, supported by tsconfig `target: esnext` and `engines.node: ">=22.0.0"`). Phase comments added.

## Why one PR

- License header and TSDoc are both pure documentation — no runtime behavior change.
- Separating into two PRs would create noisy overlap: every file touched twice in close succession.
- The evaluate.mts refactor is a 1-block, tested change that happens to sit in a file receiving TSDoc anyway.

## Non-goals

- No public API shape change.
- No test additions (existing 458 cover the refactored logic).
- No changes outside `packages/` / `create-app/` / `templates/` / `tests/`.

## Test plan

- [x] `pnpm test` — 458 / 458 pass (core 22 + builtins 390 + server 40 + integration 3 + standalone 3).
- [ ] Reviewer: spot-check TSDoc wording — the skill-driven process aims for "responsibility, not restatement"; feedback on specific phrasings welcome.
- [ ] Reviewer: verify SPDX headers appear once per file (see \`packages/server/src/jwt/\` where the legacy Apache long-form was removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)