### PR TITLE
docs(core,builtins): drop browser from supported runtime list

### DIFF
--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -2,7 +2,7 @@
 
 auth.policy-verifier 向けの組み込み attribute collector、rule collector、および resource parser です。
 
-**Runtime:** Runtime-agnostic。`BigInt` と `Map.groupBy` をサポートする任意のモダン JavaScript ランタイムで動作します — Node.js 22+（`engines.node` で宣言しており、古い Node ではインストール時にブロックされます）、モダンブラウザ、Cloudflare Workers、Deno、Bun、Vercel Edge 等。同梱の `server` パッケージは引き続き Node 専用です。
+**Runtime:** `BigInt` と `Map.groupBy` をサポートするサーバー／エッジ JavaScript ランタイムが対象です — Node.js 22+（`engines.node` で宣言しており、古い Node ではインストール時にブロックされます）、Cloudflare Workers、Vercel Edge、Deno、Bun。ブラウザは設計上対象外です（認可判定はサーバー側で enforcement する必要があるため）。同梱の `server` パッケージは引き続き Node 専用です。
 
 ## インストール
 
@@ -107,7 +107,7 @@ new AttrLiteralIn({ a: string, values: (string | number | boolean)[], group?: st
 ```
 
 - `code`: `"attr_not_in_set"`。
-- 既定の `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — `count` は重複除去後の要素数、`hashPrefix` は重複除去かつソート済みの `values` を文字列化した内容に対する FNV-1a 64-bit ハッシュの 16 桁 16 進表記です。ハッシュは非暗号学的ですが、64-bit 幅により現実的な policy サイズで偶発的・意図的な衝突はいずれもほぼ起きません。`node:*` 依存はなく、ブラウザ／エッジランタイムでも読み込めます。同じ `a` と内容上等価な `values`（順序・重複を無視）を持つ 2 つのインスタンスは同じ `ruleType` を持ち、評価器で OR 結合されます。
+- 既定の `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — `count` は重複除去後の要素数、`hashPrefix` は重複除去かつソート済みの `values` を文字列化した内容に対する FNV-1a 64-bit ハッシュの 16 桁 16 進表記です。ハッシュは非暗号学的ですが、64-bit 幅により現実的な policy サイズで偶発的・意図的な衝突はいずれもほぼ起きません。`node:*` 依存はなく、対象とするサーバー／エッジランタイム（冒頭「Runtime」参照）でロードできます。同じ `a` と内容上等価な `values`（順序・重複を無視）を持つ 2 つのインスタンスは同じ `ruleType` を持ち、評価器で OR 結合されます。
 - `values` は非空かつ同種の配列（`string[]`、`number[]`、`boolean[]` のいずれか）でなければなりません。`attrs.get(a)` が集合に含まれるときに通過します。`values` 内の重複要素は Rule の挙動に影響しません（内部では `Set` として扱われます）。
 
 ### AttrLiteralNotIn

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -2,7 +2,7 @@
 
 Built-in attribute collectors, rule collectors, and resource parser for auth.policy-verifier.
 
-**Runtime:** Runtime-agnostic. Loads in any modern JavaScript runtime that supports `BigInt` and `Map.groupBy` — Node.js 22+ (declared via `engines.node` so older Node installs are blocked at install time), modern browsers, Cloudflare Workers, Deno, Bun, Vercel Edge, etc. The `server` companion package remains Node-only.
+**Runtime:** Server- and edge-side JavaScript runtimes that support `BigInt` and `Map.groupBy` — Node.js 22+ (declared via `engines.node` so older Node installs are blocked at install time), Cloudflare Workers, Vercel Edge, Deno, Bun. Browsers are out of scope by design: authorization decisions must be enforced server-side. The `server` companion package remains Node-only.
 
 ## Install
 
@@ -107,7 +107,7 @@ new AttrLiteralIn({ a: string, values: (string | number | boolean)[], group?: st
 ```
 
 - `code`: `"attr_not_in_set"`.
-- Default `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — where `count` is the post-deduplication element count and `hashPrefix` is a 16-hex-character FNV-1a 64-bit hash over the deduplicated, sorted, stringified values. The hash is non-cryptographic but the 64-bit width makes accidental and adversarial collisions vanishingly unlikely for any realistic policy size; the package has no `node:*` dependency and loads in browser / edge runtimes. Two instances with the same `a` and logically equivalent `values` (duplicates and order do not matter) share the same `ruleType` and are OR-combined by the evaluator.
+- Default `ruleType`: `` `attr_literal_in:${a}:${type}:${count}:${hashPrefix}` `` — where `count` is the post-deduplication element count and `hashPrefix` is a 16-hex-character FNV-1a 64-bit hash over the deduplicated, sorted, stringified values. The hash is non-cryptographic but the 64-bit width makes accidental and adversarial collisions vanishingly unlikely for any realistic policy size; the package has no `node:*` dependency and loads in any supported server/edge runtime (see "Runtime" above). Two instances with the same `a` and logically equivalent `values` (duplicates and order do not matter) share the same `ruleType` and are OR-combined by the evaluator.
 - `values` must be a non-empty, homogeneous array (`string[]`, `number[]`, or `boolean[]`). Passes when `attrs.get(a)` is in the set. Duplicate elements in `values` are ignored (the rule uses `Set` semantics internally).
 
 ### AttrLiteralNotIn

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -2,7 +2,7 @@
 
 auth.policy-verifier の型定義・評価エンジン・モジュール基盤。コレクター、ルール、モジュールが実装すべきインターフェースを定義するパッケージです。
 
-**Runtime:** Runtime-agnostic。`Map.groupBy` をサポートする任意のモダン JavaScript ランタイムで動作します — Node.js 22+（`engines.node` で宣言しており、古い Node ではインストール時にブロックされます）、モダンブラウザ、Cloudflare Workers、Deno、Bun、Vercel Edge 等。同梱の `server` パッケージは引き続き Node 専用です。
+**Runtime:** `Map.groupBy` をサポートするサーバー／エッジ JavaScript ランタイムが対象です — Node.js 22+（`engines.node` で宣言しており、古い Node ではインストール時にブロックされます）、Cloudflare Workers、Vercel Edge、Deno、Bun。ブラウザは設計上対象外です（認可判定はサーバー側で enforcement する必要があるため）。同梱の `server` パッケージは引き続き Node 専用です。
 
 ## インストール
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Types, evaluation engine, and module infrastructure for auth.policy-verifier. This package defines the interfaces that collectors, rules, and modules implement.
 
-**Runtime:** Runtime-agnostic. Loads in any modern JavaScript runtime that supports `Map.groupBy` — Node.js 22+ (declared via `engines.node` so older Node installs are blocked at install time), modern browsers, Cloudflare Workers, Deno, Bun, Vercel Edge, etc. The `server` companion package remains Node-only.
+**Runtime:** Server- and edge-side JavaScript runtimes that support `Map.groupBy` — Node.js 22+ (declared via `engines.node` so older Node installs are blocked at install time), Cloudflare Workers, Vercel Edge, Deno, Bun. Browsers are out of scope by design: authorization decisions must be enforced server-side. The `server` companion package remains Node-only.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- PR #50 (issue #34) listed "modern browsers" alongside edge / non-Node server runtimes when describing where `core` + `builtins` can load. That was wrong for an authorization verifier — a browser-side decision can be bypassed by patching the JS, so authz must always be enforced server-side.
- This PR removes "browser" from the runtime list in all four READMEs (`core` EN+JP, `builtins` EN+JP) and adds a one-sentence note that browsers are out of scope by design.

The runtime-agnostic work was motivated by **edge / non-Node server runtimes** (Cloudflare Workers, Vercel Edge, Deno, Bun) — not by client-side use. The README now reflects that intent.

The `_sharedValidation.mts` JSDoc reference to "all evergreen browsers" is left in place: it is justifying why `BigInt` is a portable algorithm choice, not claiming browser support for the package.

## Test plan

- [x] `make test` — all suites still green (docs-only change)
- [x] `make lint` — biome clean
- [x] `grep -rn "browser" packages/{core,builtins}` shows only the intentional out-of-scope disclaimer in JP READMEs and the JSDoc explanation note

## Related

- Follow-up to #50 / #34 (correcting README scope claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)