### PR TITLE
chore(dependabot): group minor/patch updates to prevent lockfile merge races

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,23 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Group routine minor/patch churn into few PRs. Many separate lockfile-
+    # touching PRs race at merge time: GitHub's server-side squash/merge does
+    # NOT honor the .gitattributes `merge=binary` driver, so a PR merged without
+    # first rebasing onto the updated base can duplicate pnpm-lock.yaml entries
+    # (ERR_PNPM_BROKEN_LOCKFILE). Fewer concurrent PRs = fewer such races. Majors
+    # stay ungrouped so each remains a deliberate review.
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # TypeScript major bumps require workspace-wide migration across the four
       # auth.* OSS repos (auth.provider / auth.policy-verifier / auth.proxy /


### PR DESCRIPTION
Collapses routine dev + production minor/patch dependabot updates into grouped PRs.

**Why:** multiple separate lockfile-touching PRs race at merge time. GitHub's server-side squash/merge does **not** honor the `.gitattributes` `pnpm-lock.yaml merge=binary` driver, so a PR merged without first rebasing onto the updated base can duplicate `pnpm-lock.yaml` entries (`ERR_PNPM_BROKEN_LOCKFILE`). Fewer concurrent PRs ⇒ far fewer such races. Majors stay ungrouped for deliberate review.

**Complementary:** enabling branch protection *"Require branches to be up to date before merging"* forces rebase-before-merge — the direct structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)