### PR TITLE
fix(ci): run every workspace's tests, and cover the config path main.mts boots from

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run build
       - run: pnpm -r --if-present run typecheck
+
+      # Every workspace, including the ones with no `test:coverage` script:
+      # templates/standalone, tests/integration and create-app. The coverage
+      # step below skips those (`--if-present`), so without this they were
+      # never run in CI at all.
+      - run: pnpm run test
+
+      # Re-runs the three published packages under instrumentation to produce
+      # the reports uploaded below.
       - run: pnpm run test:coverage
 
       - name: Upload coverage to Codecov (core)

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Tests for the config loading path that main.mts boots from.
+ *
+ * These read the real files under templates/standalone/config/, so they cover
+ * the shipped layering rather than a hand-built object: an env overlay that
+ * contains only comments is an empty HOCON document, and it must fall back to
+ * application.conf instead of failing to parse. Nothing else in the suite
+ * exercises parseFile, so a HOCON parser regression is otherwise invisible
+ * until the container fails to start.
+ */
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadAppConfig } from "../loadConfig.js";
+
+const configDirPath = fileURLToPath(new URL("../../config/", import.meta.url));
+
+const envKeys = ["OAUTH_JWT_SECRET", "HTTP_HOSTNAME", "HTTP_PORT", "HTTP_PATH_PREFIX"] as const;
+
+afterEach(() => {
+	for (const key of envKeys) {
+		delete process.env[key];
+	}
+});
+
+describe("loadAppConfig", () => {
+	// Both shipped overlays are comment-only. They parse to an empty document,
+	// which withFallback must resolve to the application.conf values.
+	it.each(["development", "production"])(
+		"resolves the %s overlay against application.conf",
+		(env) => {
+			process.env.OAUTH_JWT_SECRET = "test-secret";
+
+			const config = loadAppConfig(configDirPath, env);
+
+			expect(config.http).toEqual({ hostname: "0.0.0.0", port: 3000, pathPrefix: "" });
+			expect(config.oauth.jwt.algorithm).toBe("HS256");
+			expect(config.oauth.jwt.secret).toBe("test-secret");
+			expect(config.oauth.jwt.validate).toBe(true);
+		},
+	);
+
+	it("registers the collectors declared in application.conf", () => {
+		process.env.OAUTH_JWT_SECRET = "test-secret";
+
+		const config = loadAppConfig(configDirPath, "development");
+
+		expect(config.attribute.collectors.map((c) => c.collector)).toEqual([
+			"PayloadScopeCollector",
+			"PayloadSubjectIdCollector",
+		]);
+		expect(config.rule.collectors.map((c) => c.collector)).toEqual([
+			"ResourceActionScopeRuleCollector",
+			"ResourceActionPermissionRuleCollector",
+		]);
+		expect(config.resource.parser).toBe("DotNotationResourceParser");
+	});
+
+	it("applies the optional environment substitutions from application.conf", () => {
+		process.env.OAUTH_JWT_SECRET = "test-secret";
+		process.env.HTTP_HOSTNAME = "127.0.0.1";
+		process.env.HTTP_PORT = "8080";
+		process.env.HTTP_PATH_PREFIX = "/auth";
+
+		const config = loadAppConfig(configDirPath, "development");
+
+		expect(config.http).toEqual({ hostname: "127.0.0.1", port: 8080, pathPrefix: "/auth" });
+	});
+
+	it("rejects an HS256 config with no secret in the environment", () => {
+		expect(() => loadAppConfig(configDirPath, "development")).toThrow(
+			/secret is required for HS256/,
+		);
+	});
+
+	it("rejects an env name that escapes the config directory", () => {
+		expect(() => loadAppConfig(configDirPath, "../secrets")).toThrow(/resolves outside/);
+	});
+});

--- a/templates/standalone/src/loadConfig.ts
+++ b/templates/standalone/src/loadConfig.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type AppConfig, AppConfigSchema } from "@o3co/auth.policy-verifier.server";
+import { parseFile } from "@o3co/ts.hocon";
+import { validate } from "@o3co/ts.hocon/zod";
+import { resolveConfigPaths } from "./configPath.js";
+
+/**
+ * Loads the validated application config for `env` from `configDirPath`.
+ *
+ * The `<env>.conf` overlay is layered over `application.conf`. An overlay that
+ * declares nothing (the shipped development/production files are comments
+ * only) is an empty HOCON document and falls through to the base layer.
+ */
+export function loadAppConfig(configDirPath: string, env: string): AppConfig {
+	const { applicationConfPath, envConfPath } = resolveConfigPaths(configDirPath, env);
+	return validate(
+		parseFile(envConfPath).withFallback(parseFile(applicationConfPath)),
+		AppConfigSchema,
+	);
+}

--- a/templates/standalone/src/main.mts
+++ b/templates/standalone/src/main.mts
@@ -6,27 +6,17 @@
  */
 import { fileURLToPath } from "node:url";
 import { builtinCollectorsModule } from "@o3co/auth.policy-verifier.builtins";
-import {
-	AppConfigSchema,
-	builtinKeyResolversModule,
-	createApp,
-} from "@o3co/auth.policy-verifier.server";
+import { builtinKeyResolversModule, createApp } from "@o3co/auth.policy-verifier.server";
 import { createLogger, gracefulShutdown } from "@o3co/auth.utils";
-import { parseFile } from "@o3co/ts.hocon";
-import { validate } from "@o3co/ts.hocon/zod";
-import { resolveConfigPaths } from "./configPath.js";
+import { loadAppConfig } from "./loadConfig.js";
 
 const logger = createLogger("policy-verifier");
 
 const env = process.env.CONFIG_ENV || process.env.NODE_ENV || "development";
 const configDir = new URL("../config/", import.meta.url);
 const configDirPath = fileURLToPath(configDir);
-const { applicationConfPath, envConfPath } = resolveConfigPaths(configDirPath, env);
 
-const config = validate(
-	parseFile(envConfPath).withFallback(parseFile(applicationConfPath)),
-	AppConfigSchema,
-);
+const config = loadAppConfig(configDirPath, env);
 
 const app = await createApp({
 	pathResolver: import.meta.resolve,


### PR DESCRIPTION
## Summary

CI ran only `pnpm run test:coverage`, which expands to
`pnpm -r --if-present run test:coverage`. Only `packages/core`, `packages/builtins`
and `packages/server` define that script, so `--if-present` silently skipped
`templates/standalone`, `tests/integration` and `create-app` — those suites had
never run in CI. `release.yml` already ran the full suite, so CI was the weaker
of the two gates.

Wiring those suites in is not enough on its own: they all passed. The standalone
smoke test builds its config with `AppConfigSchema.parse` on a literal, so
nothing exercised `parseFile`, and the layering that actually runs at startup had
no coverage at all.

That blind spot hid a real breakage. Both shipped overlays (`development.conf`,
`production.conf`) are comment-only — an empty HOCON document — and `@o3co/ts.hocon`
1.8 rejected those with `empty file is not a valid HOCON document`. The template
threw on boot in every environment, on every branch, with CI green. #94 bumped
ts.hocon to 1.11 and fixed it; this PR adds the regression test that would have
caught it, and makes CI a gate that can catch the next one.

- `templates/standalone/src/loadConfig.ts` — extracted from `main.mts` so the real
  code path is reachable from a test instead of being copied into one
- `templates/standalone/src/__tests__/loadConfig.test.mts` — drives `loadAppConfig`
  against the real files under `config/`, pinning the empty-overlay fallback, the
  `${?VAR}` substitutions, and the HS256-without-secret rejection
- `.github/workflows/ci.yml` — adds `pnpm run test` (no `--if-present`) alongside
  the coverage step, which stays for the Codecov reports

## Test plan

- `pnpm run test` — 540 tests pass across all 6 workspaces (standalone goes from 7 to 13)
- Verified the new test actually catches the bug: on ts.hocon 1.8.0 it fails 5/6
  with `ParseError: empty file is not a valid HOCON document`; on 1.11.0 it passes 6/6
- `pnpm run lint`, `pnpm run build`, `pnpm -r --if-present run typecheck` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)