### PR TITLE
fix(core): deny on an empty rule set instead of allowing it (#104)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -106,7 +106,10 @@ standalone → server   → core
 - **グループ内:** OR — 1つでも通ればそのグループは通過
 - **グループ間:** AND — 全グループが通過する必要あり
 
-ルールなし → allow。RuleCollector が未設定なら全リクエストが許可される。
+ルールが 1 つも集まらなかった場合 → **deny**。どのルールも適用されなかったリクエストは「認可されていない」ので、
+`no_applicable_rule` で拒否する (OPA / OpenFGA / Cedar の implicit deny と同じ挙動)。
+`rule.onEmptyRuleSet = "allow"` を明示するとこの既定を opt-out して fail-open にできるが、認可を別レイヤで
+担保している場合に限る。RuleCollector が 1 つも設定されていない場合は起動時に失敗する。
 
 ### 組み込みルール
 
@@ -146,6 +149,8 @@ attribute {
 }
 
 rule {
+  onEmptyRuleSet = "deny"       # deny | allow — ルールが集まらなかったときの決定
+  onEmptyRuleSet = ${?RULE_ON_EMPTY_RULE_SET}
   collectors = [
     { collector = "ResourceActionScopeRuleCollector" }
   ]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ Rules are grouped by `ruleType` (e.g., "scope", "permission"):
 - **Within a group:** OR — any single passing rule satisfies the group
 - **Across groups:** AND — every group must be satisfied
 
-Empty rules → allow. This means if no rule collectors are configured, all requests are allowed.
+Empty rule set → **deny**. A request that collects no rule was never authorized by anything, so the
+engine denies it with `no_applicable_rule` — matching the implicit-deny semantics of OPA / OpenFGA /
+Cedar. `rule.onEmptyRuleSet = "allow"` is an explicit per-deployment opt-out that makes the engine
+fail-open; set it only when authorization is enforced elsewhere. Booting with no rule collector
+configured at all is rejected.
 
 ### Built-in Rule Types
 
@@ -146,6 +150,8 @@ attribute {
 }
 
 rule {
+  onEmptyRuleSet = "deny"       # deny | allow — decision when no rule is collected
+  onEmptyRuleSet = ${?RULE_ON_EMPTY_RULE_SET}
   collectors = [
     { collector = "ResourceActionScopeRuleCollector" }
   ]

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -171,7 +171,11 @@ new AttrPairCompare({ a: string, op: "lt" | "le" | "gt" | "ge", b: string, group
 | `ResourceActionPermissionRuleCollector` | `"<resource.raw>.perm:<action>"` | `[HasPermission(...)]` |
 | `ResourceActionScopeRuleCollector` | `"<action>:<resource.resourceType>"` | `[HasScope(...)]` |
 
-どちらもコンストラクタ引数はありません。
+`ResourceActionPermissionRuleCollector` にコンストラクタ引数はありません。
+`ResourceActionScopeRuleCollector` は `{ scopeless?: "deny" | "skip" }` を受け取ります (既定は `"deny"`)。既定では
+リクエストごとに必ず `HasScope` ルールを生成するため、`scope` claim を持たないトークンはこのルールに落ちます。
+`"skip"` は scopeless トークンに対してルールを生成しませんが、ルールが 1 つも集まらないリクエストは deny されるため、
+別のルールグループが認可を担うパイプラインでのみ使ってください。
 
 ## Resource Parser
 
@@ -205,7 +209,7 @@ import { builtinCollectorsModule } from "@o3co/auth.policy-verifier.builtins";
 | `attributeCollector` | `"PayloadSubjectIdCollector"` | `() => new PayloadSubjectIdCollector()` |
 | `attributeCollector` | `"StaticPermissionCollector"` | `(config) => new StaticPermissionCollector(config)` |
 | `attributeCollector` | `"StaticRoleCollector"` | `(config) => new StaticRoleCollector(config)` |
-| `ruleCollector` | `"ResourceActionScopeRuleCollector"` | `() => new ResourceActionScopeRuleCollector()` |
+| `ruleCollector` | `"ResourceActionScopeRuleCollector"` | `(config) => new ResourceActionScopeRuleCollector(config)` |
 | `ruleCollector` | `"ResourceActionPermissionRuleCollector"` | `() => new ResourceActionPermissionRuleCollector()` |
 | `resourceParser` | `"DotNotationResourceParser"` | `() => new DotNotationResourceParser()` |
 

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -171,7 +171,11 @@ All attribute comparison rules follow the same grouping semantics described for 
 | `ResourceActionPermissionRuleCollector` | `"<resource.raw>.perm:<action>"` | `[HasPermission(...)]` |
 | `ResourceActionScopeRuleCollector` | `"<action>:<resource.resourceType>"` | `[HasScope(...)]` |
 
-Both collectors take no constructor arguments.
+`ResourceActionPermissionRuleCollector` takes no constructor arguments.
+`ResourceActionScopeRuleCollector` accepts `{ scopeless?: "deny" | "skip" }` (default `"deny"`): it emits the
+`HasScope` rule for every request, so a token carrying no `scope` claim fails it. `"skip"` emits no rule for a
+scopeless token — only use it in a pipeline where another rule group authorizes the request, since a request
+that collects no rule at all is denied.
 
 ## Resource Parser
 
@@ -205,7 +209,7 @@ import { builtinCollectorsModule } from "@o3co/auth.policy-verifier.builtins";
 | `attributeCollector` | `"PayloadSubjectIdCollector"` | `() => new PayloadSubjectIdCollector()` |
 | `attributeCollector` | `"StaticPermissionCollector"` | `(config) => new StaticPermissionCollector(config)` |
 | `attributeCollector` | `"StaticRoleCollector"` | `(config) => new StaticRoleCollector(config)` |
-| `ruleCollector` | `"ResourceActionScopeRuleCollector"` | `() => new ResourceActionScopeRuleCollector()` |
+| `ruleCollector` | `"ResourceActionScopeRuleCollector"` | `(config) => new ResourceActionScopeRuleCollector(config)` |
 | `ruleCollector` | `"ResourceActionPermissionRuleCollector"` | `() => new ResourceActionPermissionRuleCollector()` |
 | `resourceParser` | `"DotNotationResourceParser"` | `() => new DotNotationResourceParser()` |
 

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
@@ -35,11 +35,35 @@ describe("ResourceActionScopeRuleCollector", () => {
 		expect(rules[0].verify(attrs)).toBe(true);
 	});
 
-	it("returns no rules when payload has no scope claim", async () => {
+	it("emits a failing scope rule when payload has no scope claim (default-deny)", async () => {
 		const ctx = makeContext("document", "read");
-		// payload has no scope — simulates DID JWT
+		// payload has no scope — a scopeless token must not silently drop the
+		// scope group from AND-evaluation, which would authorize by omission.
 		const rules = await collector.collect(ctx);
+		expect(rules).toHaveLength(1);
+		expect(rules[0].ruleType).toBe("scope");
+		expect(rules[0].verify(new Map())).toBe(false);
+	});
+
+	it("returns no rules for a scopeless token only when scopeless: skip is opted into", async () => {
+		const skipping = new ResourceActionScopeRuleCollector({ scopeless: "skip" });
+		const rules = await skipping.collect(makeContext("document", "read"));
 		expect(rules).toHaveLength(0);
+	});
+
+	it("still emits the scope rule under scopeless: skip when the token carries a scope claim", async () => {
+		const skipping = new ResourceActionScopeRuleCollector({ scopeless: "skip" });
+		const rules = await skipping.collect(makeContext("document", "read", "read:document"));
+		expect(rules).toHaveLength(1);
+	});
+
+	it("rejects an unrecognized scopeless option at construction time", () => {
+		expect(
+			() =>
+				new ResourceActionScopeRuleCollector({
+					scopeless: "allow",
+				} as unknown as { scopeless: "deny" | "skip" }),
+		).toThrow(/scopeless/);
 	});
 
 	it("returns HasScope rule when payload has scope claim", async () => {

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -24,6 +24,10 @@ export { AttrPairCompare, type AttrPairCompareConfig } from "./rules/AttrPairCom
 export { AttrPairEqual, type AttrPairEqualConfig } from "./rules/AttrPairEqual.mjs";
 export { AttrPairNotEqual, type AttrPairNotEqualConfig } from "./rules/AttrPairNotEqual.mjs";
 export { ResourceActionPermissionRuleCollector } from "./rules/collectors/ResourceActionPermissionRuleCollector.mjs";
-export { ResourceActionScopeRuleCollector } from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";
+export {
+	ResourceActionScopeRuleCollector,
+	type ResourceActionScopeRuleCollectorConfig,
+	type ScopelessPolicy,
+} from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";
 export { HasPermission } from "./rules/HasPermission.mjs";
 export { HasScope } from "./rules/HasScope.mjs";

--- a/packages/builtins/src/module.mts
+++ b/packages/builtins/src/module.mts
@@ -39,7 +39,7 @@ export const builtinCollectorsModule: Module = {
 		// Rule collector factories
 		context.ruleCollectorRegistry.register(
 			"ResourceActionScopeRuleCollector",
-			() => new ResourceActionScopeRuleCollector(),
+			(config) => new ResourceActionScopeRuleCollector(config),
 		);
 		context.ruleCollectorRegistry.register(
 			"ResourceActionPermissionRuleCollector",

--- a/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
@@ -4,6 +4,21 @@
 import type { CollectorContext, Rule, RuleCollector } from "@o3co/auth.policy-verifier.core";
 import { HasScope } from "../HasScope.mjs";
 
+/** How the collector treats a token that carries no `scope` claim. */
+export type ScopelessPolicy = "deny" | "skip";
+
+const SCOPELESS_POLICIES: readonly ScopelessPolicy[] = ["deny", "skip"];
+
+/** Config entry accepted by `ResourceActionScopeRuleCollector`. */
+export interface ResourceActionScopeRuleCollectorConfig {
+	/**
+	 * `"deny"` (default) emits the scope rule for every request, so a scopeless
+	 * token fails it. `"skip"` emits no rule for a scopeless token, leaving the
+	 * scope group out of AND-evaluation.
+	 */
+	scopeless?: ScopelessPolicy;
+}
+
 /**
  * Generates a HasScope rule derived from the request action and resource type.
  *
@@ -18,22 +33,37 @@ import { HasScope } from "../HasScope.mjs";
  *
  * ## Behavior for scopeless tokens
  *
- * Flows where the IdP does not issue a `scope` claim (e.g. DID-grant tokens)
- * produce scopeless JWTs. For those requests this collector returns no rules,
- * so the scope rule group is absent from AND-evaluation and other rule groups
- * decide independently. The collector is therefore safe to include in
- * pipelines that mix OAuth and DID flows.
+ * By default the rule is emitted regardless of whether the token carries a
+ * `scope` claim, so a scopeless token fails it. Dropping the rule instead would
+ * remove the scope group from AND-evaluation, and in a scope-only pipeline that
+ * turns "the token asserts no capability" into "every capability is allowed".
  *
- * For pipelines that exclusively serve scopeless flows, this collector
- * contributes nothing — prefer collectors that derive rules from identity
- * claims (e.g. DID, `sub`, role) instead.
+ * Flows where the IdP does not issue a `scope` claim (e.g. DID-grant tokens)
+ * must opt out explicitly with `{ scopeless: "skip" }`, and only in a pipeline
+ * where another rule group authorizes the request — otherwise the request is
+ * left with no applicable rule, which the evaluator denies.
+ *
+ * For pipelines that exclusively serve scopeless flows, prefer collectors that
+ * derive rules from identity claims (e.g. DID, `sub`, role) instead.
  *
  * See https://github.com/o3co/auth.provider/issues/56 for background on why
  * the IdP asserts identity, not permissions.
  */
 export class ResourceActionScopeRuleCollector implements RuleCollector {
+	private readonly scopeless: ScopelessPolicy;
+
+	constructor(config?: ResourceActionScopeRuleCollectorConfig) {
+		const scopeless = config?.scopeless ?? "deny";
+		if (!SCOPELESS_POLICIES.includes(scopeless)) {
+			throw new Error(
+				`ResourceActionScopeRuleCollector: scopeless must be one of ${SCOPELESS_POLICIES.join(", ")}, got "${scopeless}"`,
+			);
+		}
+		this.scopeless = scopeless;
+	}
+
 	async collect(context: CollectorContext): Promise<Rule[]> {
-		if (context.payload.scope === undefined) {
+		if (this.scopeless === "skip" && context.payload.scope === undefined) {
 			return [];
 		}
 		const scope = `${context.action}:${context.resource.resourceType}`;

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -20,6 +20,8 @@ function evaluate(attrs: Attributes, rules: Rule[]): Decision
 
 収集した属性をルールセットに対して評価します。ルールは `ruleType` でグループ化され、グループ内はいずれかのルールが通れば満足（OR）、すべてのグループが満たされた場合に許可（グループ間 AND）となります。戻り値は `{ decision: "allow" }` または `{ decision: "deny"; code: string; message: string }` です。
 
+**ルールが 1 つも集まらなかった場合は deny** (`code: "no_applicable_rule"`) です。どのルールも適用されなかったリクエストは認可されていないためです。第 3 引数に `{ onEmptyRuleSet: "allow" }` を渡すと、この既定を deployment 単位で opt-out できます。
+
 ### AttributePipeline
 
 ```typescript

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -15,7 +15,12 @@ npm install @o3co/auth.policy-verifier.core
 ### evaluate
 
 ```typescript
-function evaluate(attrs: Attributes, rules: Rule[]): Decision
+interface EvaluateOptions {
+  /** Decision for an empty rule set. Defaults to "deny". */
+  onEmptyRuleSet?: "deny" | "allow"
+}
+
+function evaluate(attrs: Attributes, rules: Rule[], options?: EvaluateOptions): Decision
 ```
 
 収集した属性をルールセットに対して評価します。ルールは `ruleType` でグループ化され、グループ内はいずれかのルールが通れば満足（OR）、すべてのグループが満たされた場合に許可（グループ間 AND）となります。戻り値は `{ decision: "allow" }` または `{ decision: "deny"; code: string; message: string }` です。

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,7 +15,12 @@ npm install @o3co/auth.policy-verifier.core
 ### evaluate
 
 ```typescript
-function evaluate(attrs: Attributes, rules: Rule[]): Decision
+interface EvaluateOptions {
+  /** Decision for an empty rule set. Defaults to "deny". */
+  onEmptyRuleSet?: "deny" | "allow"
+}
+
+function evaluate(attrs: Attributes, rules: Rule[], options?: EvaluateOptions): Decision
 ```
 
 Evaluates collected attributes against a set of rules. Rules are grouped by `ruleType`; within a group, any passing rule satisfies the group (OR); all groups must be satisfied for an allow decision (AND across groups). Returns `{ decision: "allow" }` or `{ decision: "deny"; code: string; message: string }`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,6 +20,8 @@ function evaluate(attrs: Attributes, rules: Rule[]): Decision
 
 Evaluates collected attributes against a set of rules. Rules are grouped by `ruleType`; within a group, any passing rule satisfies the group (OR); all groups must be satisfied for an allow decision (AND across groups). Returns `{ decision: "allow" }` or `{ decision: "deny"; code: string; message: string }`.
 
+An **empty rule set is denied** (`code: "no_applicable_rule"`): a request no rule spoke to was never authorized. Pass `{ onEmptyRuleSet: "allow" }` as the third argument to opt a deployment out of that default.
+
 ### AttributePipeline
 
 ```typescript

--- a/packages/core/src/__tests__/evaluate.test.mts
+++ b/packages/core/src/__tests__/evaluate.test.mts
@@ -13,10 +13,35 @@ const makeRule = (ruleType: string, code: string, result: boolean): Rule => ({
 });
 
 describe("evaluate", () => {
-	it("returns allow when no rules are provided", () => {
+	it("returns deny when no rules are provided (default-deny)", () => {
 		const attrs: Attributes = new Map();
 		const result = evaluate(attrs, []);
+		expect(result).toEqual({
+			decision: "deny",
+			code: "no_applicable_rule",
+			message: "No applicable rule was collected for this request",
+		});
+	});
+
+	it("returns deny when every collector yields no rules for this request", () => {
+		// A rule collector may legitimately return [] for a given request shape
+		// (e.g. a scope collector facing a scopeless token). The engine must not
+		// read "nothing to check" as "nothing to enforce".
+		const attrs: Attributes = new Map([["scopes", []]]);
+		const result = evaluate(attrs, []);
+		expect(result.decision).toBe("deny");
+	});
+
+	it("returns allow on an empty rule set only when allow-on-empty is opted into", () => {
+		const attrs: Attributes = new Map();
+		const result = evaluate(attrs, [], { onEmptyRuleSet: "allow" });
 		expect(result).toEqual({ decision: "allow" });
+	});
+
+	it("returns deny on an empty rule set when deny-on-empty is stated explicitly", () => {
+		const attrs: Attributes = new Map();
+		const result = evaluate(attrs, [], { onEmptyRuleSet: "deny" });
+		expect(result.decision).toBe("deny");
 	});
 
 	it("returns allow when single rule passes", () => {

--- a/packages/core/src/evaluate.mts
+++ b/packages/core/src/evaluate.mts
@@ -3,6 +3,26 @@
 
 import type { Attributes, Decision, Rule } from "./types.mjs";
 
+/** Deny returned when no rule group applied to the request. */
+const NO_APPLICABLE_RULE: Decision = {
+	decision: "deny",
+	code: "no_applicable_rule",
+	message: "No applicable rule was collected for this request",
+};
+
+/** Options controlling evaluator semantics that a deployment may override. */
+export interface EvaluateOptions {
+	/**
+	 * Decision returned when the rule set is empty — no collector produced a rule
+	 * for this request. Defaults to `"deny"`.
+	 *
+	 * `"allow"` is an explicit, per-deployment opt-out of default-deny and turns
+	 * the engine fail-open: any request that collects no rules is permitted. Only
+	 * set it for a pipeline whose authorization is enforced elsewhere.
+	 */
+	onEmptyRuleSet?: "deny" | "allow";
+}
+
 /**
  * Evaluates collected rules against attributes and returns an allow/deny decision.
  *
@@ -11,15 +31,27 @@ import type { Attributes, Decision, Rule } from "./types.mjs";
  * for an allow decision. On deny, the first rule of the failing group supplies
  * the `code` and `message`.
  *
+ * An empty rule set is **denied by default**: "no rule applied" means the request
+ * was never authorized, not that it needs no authorization. This matches the
+ * implicit-deny semantics of OPA / OpenFGA / Cedar, so an engine swapped in behind
+ * the same decision contract does not change the outcome. `onEmptyRuleSet: "allow"`
+ * opts a deployment out of it.
+ *
  * @param attrs - Attributes collected for the request (subject, resource, environment).
  * @param rules - Flat list of rules collected from all rule collectors.
+ * @param options - Optional evaluator semantics overrides.
  * @returns `{ decision: "allow" }` if every group passes, otherwise a deny decision.
  */
-export function evaluate(attrs: Attributes, rules: Rule[]): Decision {
+export function evaluate(attrs: Attributes, rules: Rule[], options?: EvaluateOptions): Decision {
 	// Phase 1: group rules by ruleType — rules within a group are alternatives (OR).
 	const groups = Map.groupBy(rules, (rule) => rule.ruleType);
 
-	// Phase 2: each group must have at least one passing rule (AND across groups).
+	// Phase 2: nothing to evaluate → default-deny unless the deployment opted out.
+	if (groups.size === 0) {
+		return options?.onEmptyRuleSet === "allow" ? { decision: "allow" } : NO_APPLICABLE_RULE;
+	}
+
+	// Phase 3: each group must have at least one passing rule (AND across groups).
 	for (const groupRules of groups.values()) {
 		const passed = groupRules.some((rule) => rule.verify(attrs));
 		if (passed) continue;
@@ -33,6 +65,6 @@ export function evaluate(attrs: Attributes, rules: Rule[]): Decision {
 		};
 	}
 
-	// Phase 3: all groups passed → allow.
+	// Phase 4: all groups passed → allow.
 	return { decision: "allow" };
 }

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { AttributePipeline } from "./AttributePipeline.mjs";
+export type { EvaluateOptions } from "./evaluate.mjs";
 export { evaluate } from "./evaluate.mjs";
 export {
 	ATTR_CLIENT_ID,

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -39,6 +39,11 @@ const testModule: Module = {
 				];
 			},
 		}));
+		context.ruleCollectorRegistry.register("EmptyRuleCollector", () => ({
+			async collect() {
+				return [];
+			},
+		}));
 		context.resourceParserRegistry.register("SimpleParser", () => ({
 			parse(raw: string) {
 				return { raw, resourceType: raw, resourceId: undefined };
@@ -93,7 +98,7 @@ describe("createApp", () => {
 		const badConfig = AppConfigSchema.parse({
 			oauth: { jwt: { secret: JWT_SECRET, validate: true } },
 			attribute: { collectors: [{ collector: "NonExistent" }] },
-			rule: { collectors: [] },
+			rule: { collectors: [{ collector: "TestScopeRuleCollector" }] },
 		});
 
 		await expect(
@@ -132,6 +137,75 @@ describe("createApp", () => {
 		});
 
 		// Token is decoded (not verified) — use the same secret but validation is skipped
+		const token = await signToken({ scope: "read:project" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project", action: "read" });
+
+		expect(res.status).toBe(200);
+		expect(res.body.decision).toBe("allow");
+	});
+
+	it("throws when no rule collector is configured", async () => {
+		const noRuleConfig = AppConfigSchema.parse({
+			oauth: { jwt: { secret: JWT_SECRET, validate: true } },
+			attribute: { collectors: [{ collector: "TestScopeCollector" }] },
+			rule: { collectors: [] },
+			resource: { parser: "SimpleParser" },
+		});
+
+		await expect(
+			createApp({
+				pathResolver: (s: string) => s,
+				config: noRuleConfig,
+				modules: [testModule, builtinKeyResolversModule],
+			}),
+		).rejects.toThrow(/at least one rule collector/);
+	});
+
+	it("denies with no_applicable_rule when the pipeline collects no rules", async () => {
+		const emptyRuleConfig = AppConfigSchema.parse({
+			oauth: { jwt: { secret: JWT_SECRET, validate: true } },
+			attribute: { collectors: [{ collector: "TestScopeCollector" }] },
+			rule: { collectors: [{ collector: "EmptyRuleCollector" }] },
+			resource: { parser: "SimpleParser" },
+		});
+
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: emptyRuleConfig,
+			modules: [testModule, builtinKeyResolversModule],
+		});
+
+		const token = await signToken({ scope: "read:project" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body).toEqual({
+			decision: "deny",
+			code: "no_applicable_rule",
+			message: "No applicable rule was collected for this request",
+		});
+	});
+
+	it("allows an empty rule set only when the deployment opts into onEmptyRuleSet=allow", async () => {
+		const failOpenConfig = AppConfigSchema.parse({
+			oauth: { jwt: { secret: JWT_SECRET, validate: true } },
+			attribute: { collectors: [{ collector: "TestScopeCollector" }] },
+			rule: { collectors: [{ collector: "EmptyRuleCollector" }], onEmptyRuleSet: "allow" },
+			resource: { parser: "SimpleParser" },
+		});
+
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: failOpenConfig,
+			modules: [testModule, builtinKeyResolversModule],
+		});
+
 		const token = await signToken({ scope: "read:project" });
 		const res = await request(app)
 			.post("/verify")

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -64,3 +64,31 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 		expect(result.success).toBe(true);
 	});
 });
+
+describe("AppConfigSchema — empty rule set policy", () => {
+	it("defaults rule.onEmptyRuleSet to deny", () => {
+		const result = AppConfigSchema.parse({
+			oauth: { jwt: { algorithm: "HS256", secret: "s", validate: true } },
+			...baseBody,
+		});
+		expect(result.rule.onEmptyRuleSet).toBe("deny");
+	});
+
+	it("accepts an explicit allow opt-out", () => {
+		const result = AppConfigSchema.parse({
+			oauth: { jwt: { algorithm: "HS256", secret: "s", validate: true } },
+			attribute: { collectors: [] },
+			rule: { collectors: [], onEmptyRuleSet: "allow" },
+		});
+		expect(result.rule.onEmptyRuleSet).toBe("allow");
+	});
+
+	it("rejects an unrecognized onEmptyRuleSet value", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { algorithm: "HS256", secret: "s", validate: true } },
+			attribute: { collectors: [] },
+			rule: { collectors: [], onEmptyRuleSet: "maybe" },
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -37,14 +37,14 @@ async function signHS256Token(payload: Record<string, unknown>): Promise<string>
 		.sign(hs256Key.key as import("node:crypto").KeyObject);
 }
 
-function createTestApp(resourceParser?: ResourceParser) {
+function createTestApp(resourceParser?: ResourceParser, ruleCollectors?: RuleCollector[]) {
 	const app = express();
 	app.use(
 		createVerifyRouter({
 			jwt: { key: hs256Key.key, algorithms: hs256Key.algorithms, validate: true },
 			resourceParser: resourceParser ?? new DotNotationResourceParser(),
 			attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
-			rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+			rulePipeline: new RulePipeline(ruleCollectors ?? [new ResourceActionScopeRuleCollector()]),
 		}),
 	);
 	return app;
@@ -305,12 +305,81 @@ describe("POST /verify — Bearer scheme validation (#17)", () => {
 	});
 });
 
-describe("POST /verify — scopeless JWT (DID grant) (#27)", () => {
+describe("POST /verify — scopeless JWT (DID grant) (#27, #104)", () => {
 	const app = createTestApp();
 
-	it("returns allow for valid token without scope claim", async () => {
+	/** Rule collector standing in for a DID-grant pipeline: authorizes by `sub` prefix. */
+	const didRuleCollector: RuleCollector = {
+		async collect() {
+			return [
+				{
+					ruleType: "did",
+					code: "unknown_subject",
+					message: "Subject is not a recognized DID",
+					verify(attrs: Attributes) {
+						return String(attrs.get("sub") ?? "").startsWith("did:example:");
+					},
+				},
+			];
+		},
+	};
+
+	const didAttributeCollector: AttributeCollector = {
+		async collect(context: CollectorContext) {
+			return new Map<string, unknown>([["sub", context.payload.sub]]);
+		},
+	};
+
+	it("denies a scopeless token in a scope-only pipeline", async () => {
+		// The scope rule is emitted regardless of the claim, so a token asserting no
+		// capability fails it instead of dropping the group from AND-evaluation.
 		const token = await signHS256Token({ sub: "did:example:123" });
 		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("invalid_scope");
+	});
+
+	it("still denies a scopeless token when the scope collector opts into scopeless: skip alone", async () => {
+		// Skipping leaves the request with no applicable rule; the engine default-denies
+		// rather than treating "nothing collected" as "nothing to enforce".
+		const skipApp = createTestApp(undefined, [
+			new ResourceActionScopeRuleCollector({ scopeless: "skip" }),
+		]);
+		const token = await signHS256Token({ sub: "did:example:123" });
+		const res = await request(skipApp)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.code).toBe("no_applicable_rule");
+	});
+
+	it("allows a scopeless token when scopeless: skip is paired with an identity rule that passes", async () => {
+		// The supported DID-grant wiring: another rule group carries the decision.
+		const didApp = express();
+		didApp.use(
+			createVerifyRouter({
+				jwt: { key: hs256Key.key, algorithms: hs256Key.algorithms, validate: true },
+				resourceParser: new DotNotationResourceParser(),
+				attributePipeline: new AttributePipeline([
+					new PayloadScopeCollector(),
+					didAttributeCollector,
+				]),
+				rulePipeline: new RulePipeline([
+					new ResourceActionScopeRuleCollector({ scopeless: "skip" }),
+					didRuleCollector,
+				]),
+			}),
+		);
+
+		const token = await signHS256Token({ sub: "did:example:123" });
+		const res = await request(didApp)
 			.post("/verify")
 			.set("Authorization", `Bearer ${token}`)
 			.send({ resource: "project:1", action: "read" });

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -64,7 +64,13 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 		return factory(entry);
 	});
 
-	// 4. Resolve rule collectors from config — call factory with config entry
+	// 4. Resolve rule collectors from config — call factory with config entry.
+	// A pipeline with no rule collector can never authorize anything: every request
+	// would collect an empty rule set and be denied. Fail at boot rather than serve
+	// a verifier that only ever says no.
+	if (config.rule.collectors.length === 0) {
+		throw new Error("createApp: at least one rule collector must be configured (rule.collectors)");
+	}
 	const ruleCollectors = config.rule.collectors.map((entry) => {
 		const factory = ruleCollectorRegistry.get(entry.collector);
 		return factory(entry);
@@ -101,6 +107,7 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 			resourceParser,
 			attributePipeline: new AttributePipeline(attributeCollectors),
 			rulePipeline: new RulePipeline(ruleCollectors),
+			evaluateOptions: { onEmptyRuleSet: config.rule.onEmptyRuleSet },
 		}),
 	);
 

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -65,6 +65,9 @@ export const AppConfigSchema = z.object({
 	}),
 	rule: z.object({
 		collectors: z.array(collectorSchema),
+		// Decision for a request that collects no rules. "deny" (default) keeps the
+		// engine fail-closed; "allow" is an explicit per-deployment opt-out.
+		onEmptyRuleSet: z.enum(["deny", "allow"]).default("deny"),
 	}),
 	resource: z
 		.object({

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -3,6 +3,7 @@
 
 import {
 	type AttributePipeline,
+	type EvaluateOptions,
 	evaluate,
 	type ResourceParser,
 	type RulePipeline,
@@ -24,6 +25,8 @@ export interface VerifyRouterConfig {
 	resourceParser: ResourceParser;
 	attributePipeline: AttributePipeline;
 	rulePipeline: RulePipeline;
+	/** Evaluator semantics overrides; omitted means engine defaults (deny on an empty rule set). */
+	evaluateOptions?: EvaluateOptions;
 }
 
 /**
@@ -136,7 +139,7 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				config.rulePipeline.collect(context),
 			]);
 
-			const decision = evaluate(attrs, rules);
+			const decision = evaluate(attrs, rules, config.evaluateOptions);
 
 			if (decision.decision === "deny") {
 				res.status(403).json(decision);

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -28,6 +28,11 @@ attribute {
 }
 
 rule {
+  # Decision for a request that collects no rule at all. "deny" (the default)
+  # keeps the verifier fail-closed; "allow" is an explicit opt-out and makes
+  # any request that matches no rule succeed.
+  onEmptyRuleSet = "deny"
+  onEmptyRuleSet = ${?RULE_ON_EMPTY_RULE_SET}
   collectors = [
     { collector = "ResourceActionScopeRuleCollector" }
     { collector = "ResourceActionPermissionRuleCollector" }

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -83,6 +83,25 @@ describe("standalone smoke", () => {
 		expect(res.body.decision).toBe("allow");
 	});
 
+	it("POST /verify with a scopeless token returns 403 (deny)", async () => {
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: baseConfig,
+			modules: [builtinCollectorsModule, builtinKeyResolversModule],
+		});
+
+		// A validly-signed token carrying no scope claim asserts no capability, so a
+		// scope-only pipeline must deny it rather than collect zero rules and allow.
+		const token = await signToken({ sub: "user-1" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "document", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+	});
+
 	it("POST /verify with insufficient scope returns 403 (deny)", async () => {
 		const app = await createApp({
 			pathResolver: (s: string) => s,

--- a/tests/integration/src/conformance/defaultDeny.mts
+++ b/tests/integration/src/conformance/defaultDeny.mts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Decision } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Engine-neutral authorization request. Deliberately shaped as
+ * `(subject, resource, action, context)` so an adapter for a heavy-class engine
+ * (OPA, OpenFGA, Cedar) can satisfy the same suite.
+ */
+export interface AuthorizationRequest {
+	subject: string;
+	resource: string;
+	action: string;
+	context?: Record<string, unknown>;
+}
+
+/**
+ * Hooks a decision engine must provide to be checked for default-deny.
+ *
+ * The suite never constructs an engine's policy itself — each adapter knows how
+ * to put its own engine into the two states under test, which is what lets the
+ * same assertions run against this repo's evaluator and against a heavy-class
+ * engine placed behind the same decision contract.
+ */
+export interface DefaultDenyAdapter {
+	/** Engine name, used in test titles. */
+	name: string;
+	/** Decide with no policy loaded at all. */
+	decideWithNoPolicy(request: AuthorizationRequest): Promise<Decision>;
+	/** Decide with a policy loaded that produces no applicable rule for this request. */
+	decideWithNonApplicablePolicy(request: AuthorizationRequest): Promise<Decision>;
+}
+
+const REQUEST: AuthorizationRequest = {
+	subject: "user:1",
+	resource: "document:1",
+	action: "read",
+	context: {},
+};
+
+/**
+ * Conformance suite pinning the default-deny guarantee (o3co/auth.policy-verifier#104).
+ *
+ * A request that no policy speaks to is unauthorized, not unrestricted. Every
+ * engine that can sit behind the verifier's decision contract must agree on
+ * this, otherwise swapping the engine silently changes who is allowed in.
+ */
+export function describeDefaultDenyConformance(adapter: DefaultDenyAdapter): void {
+	describe(`default-deny conformance — ${adapter.name}`, () => {
+		it("denies when no policy is loaded", async () => {
+			const decision = await adapter.decideWithNoPolicy(REQUEST);
+			expect(decision.decision).toBe("deny");
+		});
+
+		it("denies when the loaded policy has no applicable rule for the request", async () => {
+			const decision = await adapter.decideWithNonApplicablePolicy(REQUEST);
+			expect(decision.decision).toBe("deny");
+		});
+
+		it("reports a reason on the default deny", async () => {
+			const decision = await adapter.decideWithNoPolicy(REQUEST);
+			expect(decision).toMatchObject({
+				decision: "deny",
+				code: expect.any(String),
+				message: expect.any(String),
+			});
+		});
+	});
+}

--- a/tests/integration/src/default-deny-conformance.test.mts
+++ b/tests/integration/src/default-deny-conformance.test.mts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ResourceActionScopeRuleCollector } from "@o3co/auth.policy-verifier.builtins";
+import type { Attributes, CollectorContext } from "@o3co/auth.policy-verifier.core";
+import { evaluate } from "@o3co/auth.policy-verifier.core";
+import {
+	type AuthorizationRequest,
+	describeDefaultDenyConformance,
+} from "./conformance/defaultDeny.mjs";
+
+/** Maps an engine-neutral request onto this repo's `CollectorContext`. */
+function toCollectorContext(request: AuthorizationRequest): CollectorContext {
+	const [resourceType, resourceId] = request.resource.split(":");
+	return {
+		payload: { sub: request.subject },
+		resource: { raw: request.resource, resourceType, resourceId },
+		action: request.action,
+		requestContext: request.context,
+	};
+}
+
+describeDefaultDenyConformance({
+	name: "@o3co/auth.policy-verifier.core evaluate()",
+
+	async decideWithNoPolicy(_request) {
+		// No rule collector configured at all → nothing is collected.
+		const attrs: Attributes = new Map();
+		return evaluate(attrs, []);
+	},
+
+	async decideWithNonApplicablePolicy(request) {
+		// A rule collector is configured, but it produces nothing for this request:
+		// the scope collector opted into `scopeless: "skip"` facing a scopeless token.
+		const collector = new ResourceActionScopeRuleCollector({ scopeless: "skip" });
+		const rules = await collector.collect(toCollectorContext(request));
+		return evaluate(new Map(), rules);
+	},
+});


### PR DESCRIPTION
Closes #104. P0 migration prerequisite from the build-to-migrate strategy (o3co/auth#5).

## Problem

`evaluate` returned `{ decision: "allow" }` whenever no rule was collected, and `ResourceActionScopeRuleCollector` returned `[]` for a token with no `scope` claim. In a scope-only pipeline — one is in real use in the stack — those compose into an authorization bypass: any validly-signed scopeless token (the paired provider issues them, `id_token`s among them) was allowed for every resource and action.

## Change

| Layer | Before | After |
| --- | --- | --- |
| `evaluate` | empty rule set → `allow` | empty rule set → `deny` (`no_applicable_rule`); `EvaluateOptions.onEmptyRuleSet: "allow"` is the explicit opt-out |
| server config | — | `rule.onEmptyRuleSet` (`deny` \| `allow`, default `deny`), plumbed into the evaluator |
| `ResourceActionScopeRuleCollector` | no rule when `scope` absent | always emits `HasScope`, so a scopeless token fails it; `{ scopeless: "skip" }` restores the old per-collector behavior |
| `createApp` | booted with zero rule collectors | throws — such a pipeline can never authorize anything |

`{ scopeless: "skip" }` alone no longer authorizes: skipping leaves the request with no applicable rule, which the engine denies. The supported DID-grant wiring pairs it with an identity rule group, and `verify.test.mts` now covers all three cases.

## Why this shape (migration seam)

Default-deny is the semantics OPA / OpenFGA / Cedar all guarantee. Keeping it identical here means an engine swapped in behind the same decision contract cannot change who is allowed in. `tests/integration/src/conformance/defaultDeny.mts` pins that as a reusable suite: an adapter implements `decideWithNoPolicy` / `decideWithNonApplicablePolicy` over an engine-neutral `(subject, resource, action, context)` request and gets the same assertions. This impl is wired up as the first adapter.

## Tests (TDD, RED → GREEN)

- `packages/core` — empty rule set denies; `onEmptyRuleSet: "allow"` opt-out; explicit `"deny"`
- `packages/builtins` — scopeless token yields a failing scope rule; `scopeless: "skip"` opts out; unknown `scopeless` value rejected at construction
- `packages/server` — boot fails with no rule collector; `/verify` returns 403 `no_applicable_rule` on an empty rule set; `onEmptyRuleSet=allow` returns 200; scopeless-JWT suite rewritten around the corrected semantics
- `templates/standalone` — scopeless token against the shipped scope-only smoke config returns 403
- `tests/integration` — default-deny conformance suite

Full suite green (558 tests), lint clean.

## Breaking change

A request that collects no rule is now denied, and a scopeless token no longer bypasses a scope rule. Deployments relying on the old behavior set `rule.onEmptyRuleSet = "allow"` and/or `{ scopeless = "skip" }` on the scope collector. Both READMEs and the standalone `application.conf` document the switch.