### PR TITLE
fix(server): validate iss, aud and typ per RFC 9068 §4 (#105)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,6 +47,7 @@ Authorization: Bearer <jwt>
 
 - **Collector パターン** — 属性とルールはコンポーザブルな Collector で収集。静的なポリシーファイルではない。任意の属性ソース（DB, 外部 API, JWT クレーム）向けにカスタム Collector を追加可能。
 - **JWT 検証アルゴリズム設定可能** — HS256（共有シークレット）、RS256/ES256/EdDSA（JWKS URI または公開鍵直接指定）。[auth.provider](https://github.com/o3co/auth.provider) の JWT 設定と対称設計。
+- **RFC 9068 §4 のトークン検証** — 署名だけでなく `iss` / `aud` / `typ` ヘッダも検証する。同じ鍵で署名された `id_token` / refresh token / logout token や、他サービス向けに発行されたトークンは拒否される。`validate = true` のとき `issuer` と `audience` は必須。
 - **JWKS サポート** — `jwksUri` を auth.provider の `/.well-known/jwks.json` に向ければ鍵ローテーションに自動対応。
 - **プラグイン可能なアーキテクチャ** — Module システムでカスタム Collector、ルール、リソースパーサーをファクトリ経由で登録。
 - **DSL ロックインなし** — 認可ロジックは TypeScript。Rego も Cedar ポリシー言語も不要。スケールアウトが必要になれば [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) 経由で OPA や Cedar に差し替え可能 — interceptor がバックエンドを抽象化する。
@@ -63,7 +64,10 @@ Authorization: Bearer <jwt>
 npx @o3co/create-auth-policy-verifier my-policy-verifier
 cd my-policy-verifier
 pnpm install
-OAUTH_JWT_SECRET=your-secret pnpm start
+OAUTH_JWT_SECRET=your-secret \
+  OAUTH_JWT_ISSUER=https://issuer.example.com \
+  OAUTH_JWT_AUDIENCE=https://api.example.com \
+  pnpm start
 ```
 
 ```bash
@@ -133,6 +137,10 @@ oauth {
     jwksUri = ${?OAUTH_JWT_JWKS_URI}        # RS256/ES256/EdDSA — 例: http://auth-provider/.well-known/jwks.json
     publicKey = ${?OAUTH_JWT_PUBLIC_KEY}     # RS256/ES256/EdDSA — PEM 文字列
     publicKeyPath = ${?OAUTH_JWT_PUBLIC_KEY_PATH}  # またはファイルパス
+    issuer = ${?OAUTH_JWT_ISSUER}           # validate = true のとき必須 — RFC 9068 §4 iss
+    audience = ${?OAUTH_JWT_AUDIENCE}       # validate = true のとき必須 — RFC 9068 §4 aud
+    tokenType = "at+jwt"                     # 受け入れる typ ヘッダ
+    tokenType = ${?OAUTH_JWT_TOKEN_TYPE}
     validate = true
     validate = ${?OAUTH_JWT_VALIDATE}
   }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Authorization: Bearer <jwt>
 
 - **Collector pattern** — Attributes and rules are gathered by composable collectors, not a static policy file. Add custom collectors for any attribute source (database, external API, JWT claims).
 - **Configurable JWT verification** — HS256 (shared secret), RS256/ES256/EdDSA (JWKS URI or direct public key). Symmetric design with [auth.provider](https://github.com/o3co/auth.provider)'s JWT config.
+- **RFC 9068 §4 token validation** — `iss`, `aud` and the `typ` header are checked alongside the signature, so an `id_token`, refresh token or logout token signed with the same key, or a token minted for another service, is rejected. `issuer` and `audience` are required whenever `validate = true`.
 - **JWKS support** — Point `jwksUri` at auth.provider's `/.well-known/jwks.json` for automatic key rotation.
 - **Pluggable architecture** — Module system for registering custom collectors, rules, and resource parsers via factories.
 - **No DSL lock-in** — Authorization logic is TypeScript. No Rego, no Cedar policy language. If you outgrow this, swap to OPA or Cedar via [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) — the interceptor abstracts over the backend.
@@ -63,7 +64,10 @@ Authorization: Bearer <jwt>
 npx @o3co/create-auth-policy-verifier my-policy-verifier
 cd my-policy-verifier
 pnpm install
-OAUTH_JWT_SECRET=your-secret pnpm start
+OAUTH_JWT_SECRET=your-secret \
+  OAUTH_JWT_ISSUER=https://issuer.example.com \
+  OAUTH_JWT_AUDIENCE=https://api.example.com \
+  pnpm start
 ```
 
 ```bash
@@ -133,6 +137,10 @@ oauth {
     jwksUri = ${?OAUTH_JWT_JWKS_URI}        # RS256/ES256/EdDSA — e.g. http://auth-provider/.well-known/jwks.json
     publicKey = ${?OAUTH_JWT_PUBLIC_KEY}     # RS256/ES256/EdDSA — PEM string
     publicKeyPath = ${?OAUTH_JWT_PUBLIC_KEY_PATH}  # or file path
+    issuer = ${?OAUTH_JWT_ISSUER}           # required when validate = true — RFC 9068 §4 iss
+    audience = ${?OAUTH_JWT_AUDIENCE}       # required when validate = true — RFC 9068 §4 aud
+    tokenType = "at+jwt"                     # accepted typ header
+    tokenType = ${?OAUTH_JWT_TOKEN_TYPE}
     validate = true
     validate = ${?OAUTH_JWT_VALIDATE}
   }

--- a/packages/server/README.ja.md
+++ b/packages/server/README.ja.md
@@ -39,11 +39,23 @@ function createApp(options: CreateAppOptions): Promise<express.Express>
 
 ```typescript
 interface VerifyRouterConfig {
-  jwt: { secret: string; validate: boolean };
+  jwt: VerifyRouterJwtConfig;
   resourceParser: ResourceParser;
   attributePipeline: AttributePipeline;
   rulePipeline: RulePipeline;
 }
+
+// `validate` による判別可能ユニオン。検証パラメータは検証するときにだけ存在する。
+type VerifyRouterJwtConfig =
+  | {
+      validate: true;
+      key: unknown;             // KeyResolverFactory が返す鍵
+      algorithms: string[];
+      issuer: string | string[];    // RFC 9068 §4 iss
+      audience: string | string[];  // RFC 9068 §4 aud
+      tokenType: string;            // 受け入れる typ ヘッダ（例: "at+jwt"）
+    }
+  | { validate: false };
 
 function createVerifyRouter(config: VerifyRouterConfig): express.Router
 ```
@@ -53,7 +65,7 @@ function createVerifyRouter(config: VerifyRouterConfig): express.Router
 リクエスト処理フロー:
 
 1. `Authorization: <type> <token>` ヘッダーを取得する。存在しない場合は 401 を返す。
-2. `validate` が `true` の場合: HS256 で JWT を検証する。失敗時は 401 を返す。
+2. `validate` が `true` の場合: 署名に加えて RFC 9068 §4 のクレームを検証する — `iss` を `issuer` と、`aud` を `audience` と、`typ` ヘッダを `tokenType` と照合する（`application/` プレフィックスは無視）。失敗時は 401 を返す。3 つのいずれかが欠けている場合、`createVerifyRouter` は例外を投げる。
 3. `validate` が `false` の場合: JWT を検証なしでデコードする。不正なトークンの場合は 401 を返す。
 4. `req.body.resource` を `resourceParser` でパースし、`req.body.action` と `req.body.context` を読み取る。
 5. `x-request-id` ヘッダーが存在する場合、`CollectorContext.headers` に含める（コレクターが上流呼び出し時に転送可能）。
@@ -74,6 +86,9 @@ const AppConfigSchema = z.object({
     jwt: z.object({
       secret: z.string(),
       validate: z.boolean().default(true),
+      issuer: z.string().optional(),        // validate = true のとき必須
+      audience: z.union([z.string(), z.array(z.string())]).optional(), // validate = true のとき必須
+      tokenType: z.string().default("at+jwt"),
     }),
   }),
   attribute: z.object({

--- a/packages/server/README.ja.md
+++ b/packages/server/README.ja.md
@@ -86,7 +86,7 @@ const AppConfigSchema = z.object({
     jwt: z.object({
       secret: z.string(),
       validate: z.boolean().default(true),
-      issuer: z.string().optional(),        // validate = true のとき必須
+      issuer: z.union([z.string(), z.array(z.string())]).optional(),   // validate = true のとき必須
       audience: z.union([z.string(), z.array(z.string())]).optional(), // validate = true のとき必須
       tokenType: z.string().default("at+jwt"),
     }),

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -86,7 +86,7 @@ const AppConfigSchema = z.object({
     jwt: z.object({
       secret: z.string(),
       validate: z.boolean().default(true),
-      issuer: z.string().optional(),        // required when validate is true
+      issuer: z.union([z.string(), z.array(z.string())]).optional(),   // required when validate is true
       audience: z.union([z.string(), z.array(z.string())]).optional(), // required when validate is true
       tokenType: z.string().default("at+jwt"),
     }),

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -39,11 +39,23 @@ Steps performed:
 
 ```typescript
 interface VerifyRouterConfig {
-  jwt: { secret: string; validate: boolean };
+  jwt: VerifyRouterJwtConfig;
   resourceParser: ResourceParser;
   attributePipeline: AttributePipeline;
   rulePipeline: RulePipeline;
 }
+
+// Discriminated on `validate`: verification parameters exist only when verifying.
+type VerifyRouterJwtConfig =
+  | {
+      validate: true;
+      key: unknown;             // from a KeyResolverFactory
+      algorithms: string[];
+      issuer: string | string[];    // RFC 9068 §4 iss
+      audience: string | string[];  // RFC 9068 §4 aud
+      tokenType: string;            // accepted typ header, e.g. "at+jwt"
+    }
+  | { validate: false };
 
 function createVerifyRouter(config: VerifyRouterConfig): express.Router
 ```
@@ -53,7 +65,7 @@ Returns an Express Router that handles `POST /verify`. `createApp` calls this in
 Request flow:
 
 1. Extract `Authorization: <type> <token>` header. Returns 401 if missing.
-2. If `validate` is `true`: verify the JWT with HS256 using `secret`. Returns 401 on failure.
+2. If `validate` is `true`: verify the signature **and** the RFC 9068 §4 claims — `iss` against `issuer`, `aud` against `audience`, and the `typ` header against `tokenType` (an `application/` prefix is ignored). Returns 401 on failure. `createVerifyRouter` throws if any of the three is missing.
 3. If `validate` is `false`: decode the JWT without verification. Returns 401 if the token is malformed.
 4. Parse `req.body.resource` with `resourceParser`; read `req.body.action` and `req.body.context`.
 5. Include `x-request-id` header in `CollectorContext.headers` if present (collectors can forward it to upstream calls they make).
@@ -74,6 +86,9 @@ const AppConfigSchema = z.object({
     jwt: z.object({
       secret: z.string(),
       validate: z.boolean().default(true),
+      issuer: z.string().optional(),        // required when validate is true
+      audience: z.union([z.string(), z.array(z.string())]).optional(), // required when validate is true
+      tokenType: z.string().default("at+jwt"),
     }),
   }),
   attribute: z.object({

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -9,9 +9,16 @@ import { AppConfigSchema, builtinKeyResolversModule, createApp } from "#/index.m
 
 const JWT_SECRET = "test-secret";
 const secretKey = new TextEncoder().encode(JWT_SECRET);
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "https://api.test";
 
 async function signToken(payload: Record<string, unknown>): Promise<string> {
-	return new SignJWT(payload).setProtectedHeader({ alg: "HS256" }).setIssuedAt().sign(secretKey);
+	return new SignJWT(payload)
+		.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+		.setIssuedAt()
+		.setIssuer(ISSUER)
+		.setAudience(AUDIENCE)
+		.sign(secretKey);
 }
 
 // Minimal test module that registers factories for a scope collector and rule collector
@@ -48,7 +55,7 @@ const testModule: Module = {
 };
 
 const testConfig = AppConfigSchema.parse({
-	oauth: { jwt: { secret: JWT_SECRET, validate: true } },
+	oauth: { jwt: { secret: JWT_SECRET, validate: true, issuer: ISSUER, audience: AUDIENCE } },
 	attribute: { collectors: [{ collector: "TestScopeCollector" }] },
 	rule: { collectors: [{ collector: "TestScopeRuleCollector" }] },
 	resource: { parser: "SimpleParser" },
@@ -91,7 +98,7 @@ describe("createApp", () => {
 
 	it("throws if config references unregistered collector", async () => {
 		const badConfig = AppConfigSchema.parse({
-			oauth: { jwt: { secret: JWT_SECRET, validate: true } },
+			oauth: { jwt: { secret: JWT_SECRET, validate: true, issuer: ISSUER, audience: AUDIENCE } },
 			attribute: { collectors: [{ collector: "NonExistent" }] },
 			rule: { collectors: [] },
 		});
@@ -103,6 +110,46 @@ describe("createApp", () => {
 				modules: [testModule, builtinKeyResolversModule],
 			}),
 		).rejects.toThrow('Registry: "NonExistent" is not registered');
+	});
+
+	it("throws when validate=true but a hand-built config omits issuer/audience", async () => {
+		// AppConfigSchema rejects this shape, so reach createApp with an object that
+		// never went through it — the same path a library consumer can take.
+		const handBuilt = {
+			...testConfig,
+			oauth: { jwt: { ...testConfig.oauth.jwt, issuer: undefined, audience: undefined } },
+		} as unknown as typeof testConfig;
+
+		await expect(
+			createApp({
+				pathResolver: (s: string) => s,
+				config: handBuilt,
+				modules: [testModule, builtinKeyResolversModule],
+			}),
+		).rejects.toThrow(/issuer and oauth\.jwt\.audience are required/);
+	});
+
+	it("rejects a token minted for another audience end to end", async () => {
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: testConfig,
+			modules: [testModule, builtinKeyResolversModule],
+		});
+
+		const token = await new SignJWT({ scope: "read:project" })
+			.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.setAudience("https://other-service.test")
+			.sign(secretKey);
+
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
 	});
 
 	it("includes healthcheck endpoint", async () => {

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -132,3 +132,45 @@ describe("AppConfigSchema — RFC 9068 token validation (#105)", () => {
 		expect(result.success).toBe(true);
 	});
 });
+
+describe("AppConfigSchema — multiple acceptable issuers (#105)", () => {
+	const hs256 = { algorithm: "HS256", secret: "s" };
+
+	it("accepts an issuer list, matching the router's issuer type", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: {
+				jwt: {
+					...hs256,
+					validate: true,
+					issuer: ["https://issuer.test", "https://issuer-2.test"],
+					audience: "https://api.test",
+				},
+			},
+			...baseBody,
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects an empty issuer list", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { ...hs256, validate: true, issuer: [], audience: "https://api.test" } },
+			...baseBody,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an issuer list carrying an empty entry", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: {
+				jwt: {
+					...hs256,
+					validate: true,
+					issuer: ["https://issuer.test", ""],
+					audience: "https://api.test",
+				},
+			},
+			...baseBody,
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -9,10 +9,13 @@ const baseBody = {
 	rule: { collectors: [] },
 };
 
+/** Issuer/audience are required whenever validation is on; most cases here only care about keys. */
+const rfc9068 = { issuer: "https://issuer.test", audience: "https://api.test" };
+
 describe("AppConfigSchema — JWT algorithm validation", () => {
 	it("rejects HS256 without secret", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm: "HS256", validate: true } },
+			oauth: { jwt: { algorithm: "HS256", validate: true, ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.success).toBe(false);
@@ -25,7 +28,7 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 
 	it.each(["RS256", "ES256", "EdDSA"])("rejects %s without any key source", (algorithm) => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm, validate: true } },
+			oauth: { jwt: { algorithm, validate: true, ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.success).toBe(false);
@@ -42,7 +45,7 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 		// User-registered algorithms are responsible for their own config validation
 		// inside their KeyResolverFactory. The schema intentionally accepts any string.
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm: "ES384", validate: true, custom: "value" } },
+			oauth: { jwt: { algorithm: "ES384", validate: true, custom: "value", ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.success).toBe(true);
@@ -50,7 +53,7 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 
 	it("accepts HS256 with secret", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm: "HS256", secret: "s", validate: true } },
+			oauth: { jwt: { algorithm: "HS256", secret: "s", validate: true, ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.success).toBe(true);
@@ -59,6 +62,71 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 	it("skips validation when validate=false (no key material required)", () => {
 		const result = AppConfigSchema.safeParse({
 			oauth: { jwt: { algorithm: "RS256", validate: false } },
+			...baseBody,
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe("AppConfigSchema — RFC 9068 token validation (#105)", () => {
+	const hs256 = { algorithm: "HS256", secret: "s" };
+
+	it("rejects validate=true without an issuer", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { ...hs256, validate: true, audience: "https://api.test" } },
+			...baseBody,
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.some((i) => i.message.includes("issuer"))).toBe(true);
+		}
+	});
+
+	it("rejects validate=true without an audience", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { ...hs256, validate: true, issuer: "https://issuer.test" } },
+			...baseBody,
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.some((i) => i.message.includes("audience"))).toBe(true);
+		}
+	});
+
+	it("rejects an empty issuer string", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { ...hs256, validate: true, issuer: "", audience: "https://api.test" } },
+			...baseBody,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts an audience list", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: {
+				jwt: {
+					...hs256,
+					validate: true,
+					issuer: "https://issuer.test",
+					audience: ["https://api.test", "https://api2.test"],
+				},
+			},
+			...baseBody,
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("defaults tokenType to at+jwt", () => {
+		const result = AppConfigSchema.parse({
+			oauth: { jwt: { ...hs256, validate: true, ...rfc9068 } },
+			...baseBody,
+		});
+		expect(result.oauth.jwt.tokenType).toBe("at+jwt");
+	});
+
+	it("does not require issuer/audience when validation is disabled", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { algorithm: "HS256", validate: false } },
 			...baseBody,
 		});
 		expect(result.success).toBe(true);

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -30,10 +30,26 @@ const generateKeyPairAsync = promisify(generateKeyPair);
 const JWT_SECRET = "test-secret";
 const hs256Key = await HS256KeyResolverFactory({ secret: JWT_SECRET });
 
-async function signHS256Token(payload: Record<string, unknown>): Promise<string> {
+/** Canonical issuer/audience this verifier deployment pins (RFC 9068 §4). */
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "https://api.test";
+
+/** Overrides for minting a token that deviates from what the verifier accepts. */
+interface TokenOverrides {
+	issuer?: string;
+	audience?: string;
+	typ?: string;
+}
+
+async function signHS256Token(
+	payload: Record<string, unknown>,
+	overrides: TokenOverrides = {},
+): Promise<string> {
 	return new SignJWT(payload)
-		.setProtectedHeader({ alg: "HS256" })
+		.setProtectedHeader({ alg: "HS256", typ: overrides.typ ?? "at+jwt" })
 		.setIssuedAt()
+		.setIssuer(overrides.issuer ?? ISSUER)
+		.setAudience(overrides.audience ?? AUDIENCE)
 		.sign(hs256Key.key as import("node:crypto").KeyObject);
 }
 
@@ -41,7 +57,14 @@ function createTestApp(resourceParser?: ResourceParser) {
 	const app = express();
 	app.use(
 		createVerifyRouter({
-			jwt: { key: hs256Key.key, algorithms: hs256Key.algorithms, validate: true },
+			jwt: {
+				validate: true,
+				key: hs256Key.key,
+				algorithms: hs256Key.algorithms,
+				issuer: ISSUER,
+				audience: AUDIENCE,
+				tokenType: "at+jwt",
+			},
 			resourceParser: resourceParser ?? new DotNotationResourceParser(),
 			attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
 			rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
@@ -152,7 +175,14 @@ describe("POST /verify", () => {
 		const app = express();
 		app.use(
 			createVerifyRouter({
-				jwt: { key: hs256Key.key, algorithms: hs256Key.algorithms, validate: true },
+				jwt: {
+					validate: true,
+					key: hs256Key.key,
+					algorithms: hs256Key.algorithms,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				},
 				resourceParser: new DotNotationResourceParser(),
 				attributePipeline: new AttributePipeline([new SubscriberDidCollector()]),
 				rulePipeline: new RulePipeline([new RequireSubscriberDidCollector()]),
@@ -192,8 +222,10 @@ describe("POST /verify", () => {
 
 	it("returns 401 for expired JWT", async () => {
 		const token = await new SignJWT({ scope: "read:project" })
-			.setProtectedHeader({ alg: "HS256" })
+			.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
 			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
 			.setExpirationTime("-1s")
 			.sign(hs256Key.key as import("node:crypto").KeyObject);
 		const res = await request(app)
@@ -215,7 +247,14 @@ describe("POST /verify with RS256", () => {
 		const app = express();
 		app.use(
 			createVerifyRouter({
-				jwt: { key: rs256Resolver.key, algorithms: rs256Resolver.algorithms, validate: true },
+				jwt: {
+					validate: true,
+					key: rs256Resolver.key,
+					algorithms: rs256Resolver.algorithms,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				},
 				resourceParser: new DotNotationResourceParser(),
 				attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
 				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
@@ -223,8 +262,10 @@ describe("POST /verify with RS256", () => {
 		);
 
 		const token = await new SignJWT({ scope: "read:project" })
-			.setProtectedHeader({ alg: "RS256" })
+			.setProtectedHeader({ alg: "RS256", typ: "at+jwt" })
 			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
 			.sign(privateKey as unknown as CryptoKey);
 
 		const res = await request(app)
@@ -247,7 +288,14 @@ describe("POST /verify with RS256", () => {
 		const app = express();
 		app.use(
 			createVerifyRouter({
-				jwt: { key: rs256Resolver.key, algorithms: rs256Resolver.algorithms, validate: true },
+				jwt: {
+					validate: true,
+					key: rs256Resolver.key,
+					algorithms: rs256Resolver.algorithms,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				},
 				resourceParser: new DotNotationResourceParser(),
 				attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
 				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
@@ -255,8 +303,10 @@ describe("POST /verify with RS256", () => {
 		);
 
 		const token = await new SignJWT({ scope: "read:project" })
-			.setProtectedHeader({ alg: "RS256" })
+			.setProtectedHeader({ alg: "RS256", typ: "at+jwt" })
 			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
 			.sign(wrongPrivateKey as unknown as CryptoKey);
 
 		const res = await request(app)
@@ -368,5 +418,168 @@ describe("POST /verify — request body validation (#18)", () => {
 		const res = await makeRequest({ resource: "project:1", action: "" });
 		expect(res.status).toBe(400);
 		expect(res.body.code).toBe("invalid_request");
+	});
+});
+
+describe("POST /verify — RFC 9068 §4 token validation (#105)", () => {
+	const app = createTestApp();
+
+	it("allows a token from the configured issuer and audience with typ at+jwt", async () => {
+		const token = await signHS256Token({ scope: "read:project" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(200);
+		expect(res.body.decision).toBe("allow");
+	});
+
+	it("rejects a token minted by a foreign issuer", async () => {
+		const token = await signHS256Token({ scope: "read:project" }, { issuer: "https://evil.test" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
+	});
+
+	it("rejects a token minted for a different audience", async () => {
+		const token = await signHS256Token(
+			{ scope: "read:project" },
+			{ audience: "https://other-service.test" },
+		);
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
+	});
+
+	it("rejects a token carrying no iss claim", async () => {
+		const token = await new SignJWT({ scope: "read:project" })
+			.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+			.setIssuedAt()
+			.setAudience(AUDIENCE)
+			.sign(hs256Key.key as import("node:crypto").KeyObject);
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
+	});
+
+	it("rejects a token carrying no aud claim", async () => {
+		const token = await new SignJWT({ scope: "read:project" })
+			.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.sign(hs256Key.key as import("node:crypto").KeyObject);
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
+	});
+
+	// The paired provider signs id_tokens, refresh tokens and logout tokens with the
+	// same key as access tokens; only the typ header separates them.
+	it.each(["id+jwt", "rt+jwt", "logout+jwt"])(
+		"rejects a %s token signed with the same key",
+		async (typ) => {
+			const token = await signHS256Token({ scope: "read:project" }, { typ });
+			const res = await request(app)
+				.post("/verify")
+				.set("Authorization", `Bearer ${token}`)
+				.send({ resource: "project:1", action: "read" });
+
+			expect(res.status).toBe(401);
+			expect(res.body.code).toBe("invalid_token");
+		},
+	);
+
+	it("rejects a token with no typ header", async () => {
+		const token = await new SignJWT({ scope: "read:project" })
+			.setProtectedHeader({ alg: "HS256" })
+			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
+			.sign(hs256Key.key as import("node:crypto").KeyObject);
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
+	});
+
+	it("accepts the application/at+jwt spelling of the same media type", async () => {
+		const token = await signHS256Token({ scope: "read:project" }, { typ: "application/at+jwt" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(200);
+		expect(res.body.decision).toBe("allow");
+	});
+
+	it("accepts a token whose aud array contains the configured audience", async () => {
+		const token = await new SignJWT({ scope: "read:project" })
+			.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.setAudience(["https://other-service.test", AUDIENCE])
+			.sign(hs256Key.key as import("node:crypto").KeyObject);
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(200);
+		expect(res.body.decision).toBe("allow");
+	});
+
+	it("refuses to build a verifying router without an issuer", () => {
+		expect(() =>
+			createVerifyRouter({
+				jwt: {
+					validate: true,
+					key: hs256Key.key,
+					algorithms: hs256Key.algorithms,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				} as unknown as Parameters<typeof createVerifyRouter>[0]["jwt"],
+				resourceParser: new DotNotationResourceParser(),
+				attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
+				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+			}),
+		).toThrow(/issuer/);
+	});
+
+	it("refuses to build a verifying router without an audience", () => {
+		expect(() =>
+			createVerifyRouter({
+				jwt: {
+					validate: true,
+					key: hs256Key.key,
+					algorithms: hs256Key.algorithms,
+					issuer: ISSUER,
+					tokenType: "at+jwt",
+				} as unknown as Parameters<typeof createVerifyRouter>[0]["jwt"],
+				resourceParser: new DotNotationResourceParser(),
+				attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
+				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+			}),
+		).toThrow(/audience/);
 	});
 });

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -15,7 +15,7 @@ import {
 import { createHealthcheckRouter } from "@o3co/auth.utils/express";
 import express from "express";
 import type { AppConfig } from "./config/application.schema.mjs";
-import { createVerifyRouter } from "./routes/verify.mjs";
+import { createVerifyRouter, type VerifyRouterJwtConfig } from "./routes/verify.mjs";
 
 /** Options accepted by `createApp`. */
 export interface CreateAppOptions {
@@ -74,13 +74,29 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 	const resourceParserFactory = resourceParserRegistry.get(config.resource.parser);
 	const resourceParser = resourceParserFactory(config.resource);
 
-	// 6. Build key resolver from JWT config via the registry.
-	// When validate=false, decodeJwt is used instead of jwtVerify, so no key material is needed.
-	const keyResolver = config.oauth.jwt.validate
-		? await keyResolverRegistry.get(config.oauth.jwt.algorithm)(config.oauth.jwt)
-		: { key: new Uint8Array(0), algorithms: [] as string[] };
-
-	if (!config.oauth.jwt.validate) {
+	// 6. Build the router's JWT config. When validate=false, decodeJwt is used instead
+	// of jwtVerify, so neither key material nor RFC 9068 claim checks apply.
+	let jwt: VerifyRouterJwtConfig;
+	if (config.oauth.jwt.validate) {
+		const keyResolver = await keyResolverRegistry.get(config.oauth.jwt.algorithm)(config.oauth.jwt);
+		const { issuer, audience, tokenType } = config.oauth.jwt;
+		// AppConfigSchema already requires these; re-checked here because createApp also
+		// accepts hand-built config objects that never went through the schema.
+		if (!issuer || !audience) {
+			throw new Error(
+				"createApp: oauth.jwt.issuer and oauth.jwt.audience are required when oauth.jwt.validate is true (RFC 9068 §4)",
+			);
+		}
+		jwt = {
+			validate: true,
+			key: keyResolver.key,
+			algorithms: keyResolver.algorithms,
+			issuer,
+			audience,
+			tokenType,
+		};
+	} else {
+		jwt = { validate: false };
 		console.warn(
 			"WARNING: JWT signature validation is disabled. Tokens will be accepted without verification.",
 		);
@@ -93,11 +109,7 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 	app.use(
 		prefix,
 		createVerifyRouter({
-			jwt: {
-				key: keyResolver.key,
-				algorithms: keyResolver.algorithms,
-				validate: config.oauth.jwt.validate,
-			},
+			jwt,
 			resourceParser,
 			attributePipeline: new AttributePipeline(attributeCollectors),
 			rulePipeline: new RulePipeline(ruleCollectors),

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -43,7 +43,7 @@ export const AppConfigSchema = z.object({
 				validate: z.boolean().default(true),
 				// RFC 9068 §4 — a resource server validates iss and aud, not just the
 				// signature. Both are required whenever `validate` is on (see superRefine).
-				issuer: z.string().optional(),
+				issuer: z.union([z.string(), z.array(z.string())]).optional(),
 				audience: z.union([z.string(), z.array(z.string())]).optional(),
 				// Accepted `typ` header. `at+jwt` is the RFC 9068 access-token type; pinning
 				// it rejects id_tokens, refresh tokens and logout tokens signed with the same key.
@@ -52,8 +52,9 @@ export const AppConfigSchema = z.object({
 			.passthrough()
 			.superRefine((data, ctx) => {
 				if (!data.validate) return; // skip validation when disabled
+				const issuers = Array.isArray(data.issuer) ? data.issuer : [data.issuer];
 				const audiences = Array.isArray(data.audience) ? data.audience : [data.audience];
-				if (!data.issuer) {
+				if (issuers.length === 0 || issuers.some((i) => !i)) {
 					ctx.addIssue({
 						code: z.ZodIssueCode.custom,
 						message: "issuer is required when validate is true (RFC 9068 §4)",

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -41,10 +41,39 @@ export const AppConfigSchema = z.object({
 				publicKey: z.string().optional(),
 				publicKeyPath: z.string().optional(),
 				validate: z.boolean().default(true),
+				// RFC 9068 §4 — a resource server validates iss and aud, not just the
+				// signature. Both are required whenever `validate` is on (see superRefine).
+				issuer: z.string().optional(),
+				audience: z.union([z.string(), z.array(z.string())]).optional(),
+				// Accepted `typ` header. `at+jwt` is the RFC 9068 access-token type; pinning
+				// it rejects id_tokens, refresh tokens and logout tokens signed with the same key.
+				tokenType: z.string().default("at+jwt"),
 			})
 			.passthrough()
 			.superRefine((data, ctx) => {
 				if (!data.validate) return; // skip validation when disabled
+				const audiences = Array.isArray(data.audience) ? data.audience : [data.audience];
+				if (!data.issuer) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: "issuer is required when validate is true (RFC 9068 §4)",
+						path: ["issuer"],
+					});
+				}
+				if (audiences.length === 0 || audiences.some((a) => !a)) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: "audience is required when validate is true (RFC 9068 §4)",
+						path: ["audience"],
+					});
+				}
+				if (!data.tokenType) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: "tokenType must not be empty when validate is true (RFC 9068 §4)",
+						path: ["tokenType"],
+					});
+				}
 				if (data.algorithm === "HS256" && !data.secret) {
 					ctx.addIssue({
 						code: z.ZodIssueCode.custom,

--- a/packages/server/src/index.mts
+++ b/packages/server/src/index.mts
@@ -10,4 +10,10 @@ export {
 	HS256KeyResolverFactory,
 	RS256KeyResolverFactory,
 } from "./jwt/index.mjs";
-export { createVerifyRouter, type VerifyRouterConfig } from "./routes/verify.mjs";
+export {
+	createVerifyRouter,
+	type DecodingJwtConfig,
+	type VerifyingJwtConfig,
+	type VerifyRouterConfig,
+	type VerifyRouterJwtConfig,
+} from "./routes/verify.mjs";

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -11,19 +11,51 @@ import {
 import express from "express";
 import { decodeJwt, type JWTPayload, jwtVerify } from "jose";
 
+/**
+ * JWT parameters used when signature validation is on. Every field a resource
+ * server must check per RFC 9068 §4 is required here, so a deployment cannot
+ * end up verifying the signature alone.
+ */
+export interface VerifyingJwtConfig {
+	validate: true;
+	// The `key` is produced by a KeyResolverFactory; its concrete type depends on
+	// the algorithm (e.g. KeyObject for HS256, JWTVerifyGetKey for JWKS, etc.).
+	// The route narrows it via cast when calling jwtVerify.
+	key: unknown;
+	algorithms: string[];
+	/** Issuer(s) this deployment accepts. A token minted by anyone else is rejected. */
+	issuer: string | string[];
+	/** Audience identifying this resource server. A token minted for another service is rejected. */
+	audience: string | string[];
+	/**
+	 * Accepted `typ` header — `"at+jwt"` for RFC 9068 access tokens. An `application/`
+	 * prefix on either side is ignored when comparing. Pinning it is what keeps an
+	 * `id_token`, refresh token or logout token signed with the same key from passing.
+	 */
+	tokenType: string;
+}
+
+/** Development-only shape: the token is decoded, never verified. */
+export interface DecodingJwtConfig {
+	validate: false;
+}
+
+/** JWT half of `VerifyRouterConfig`, discriminated on `validate`. */
+export type VerifyRouterJwtConfig = VerifyingJwtConfig | DecodingJwtConfig;
+
 /** Config for `createVerifyRouter`. The `jwt.key` type is library-specific and is narrowed at call-time. */
 export interface VerifyRouterConfig {
-	jwt: {
-		// The `key` is produced by a KeyResolverFactory; its concrete type depends on
-		// the algorithm (e.g. KeyObject for HS256, JWTVerifyGetKey for JWKS, etc.).
-		// The route narrows it via cast when calling jwtVerify.
-		key: unknown;
-		algorithms: string[];
-		validate: boolean;
-	};
+	jwt: VerifyRouterJwtConfig;
 	resourceParser: ResourceParser;
 	attributePipeline: AttributePipeline;
 	rulePipeline: RulePipeline;
+}
+
+/** True for a non-empty string or a non-empty array of non-empty strings. */
+function isPresent(value: string | string[] | undefined): boolean {
+	return Array.isArray(value)
+		? value.length > 0 && value.every((v) => typeof v === "string" && v !== "")
+		: typeof value === "string" && value !== "";
 }
 
 /**
@@ -34,6 +66,29 @@ export interface VerifyRouterConfig {
  * or 400 for bad request / 401 for auth errors / 500 for unexpected.
  */
 export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
+	const jwt = config.jwt;
+
+	// Fail at construction rather than accept tokens with an unchecked iss/aud/typ.
+	// A JavaScript caller can reach here with the fields missing even though the
+	// TypeScript shape requires them.
+	if (jwt.validate) {
+		if (!isPresent(jwt.issuer)) {
+			throw new Error(
+				"createVerifyRouter: jwt.issuer is required when jwt.validate is true (RFC 9068 §4)",
+			);
+		}
+		if (!isPresent(jwt.audience)) {
+			throw new Error(
+				"createVerifyRouter: jwt.audience is required when jwt.validate is true (RFC 9068 §4)",
+			);
+		}
+		if (!isPresent(jwt.tokenType)) {
+			throw new Error(
+				"createVerifyRouter: jwt.tokenType is required when jwt.validate is true (RFC 9068 §4)",
+			);
+		}
+	}
+
 	const router = express.Router();
 	router.use(express.json());
 
@@ -73,11 +128,14 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 			}
 
 			let decoded: JWTPayload;
-			if (config.jwt.validate) {
+			if (jwt.validate) {
 				try {
 					// key is either a static key or a JWKS get-key function; both satisfy jwtVerify overloads
-					const result = await jwtVerify(token, config.jwt.key as Parameters<typeof jwtVerify>[1], {
-						algorithms: config.jwt.algorithms,
+					const result = await jwtVerify(token, jwt.key as Parameters<typeof jwtVerify>[1], {
+						algorithms: jwt.algorithms,
+						issuer: jwt.issuer,
+						audience: jwt.audience,
+						typ: jwt.tokenType,
 					});
 					decoded = result.payload;
 				} catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,10 +149,28 @@ importers:
       '@o3co/auth.policy-verifier.core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@o3co/auth.policy-verifier.server':
+        specifier: workspace:*
+        version: link:../../packages/server
     devDependencies:
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
+      '@types/supertest':
+        specifier: ^7.2.1
+        version: 7.2.1
+      express:
+        specifier: ^5.0.0
+        version: 5.2.1
+      jose:
+        specifier: ^6.2.8
+        version: 6.2.8
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@26.2.0)(esbuild@0.27.4)(tsx@4.23.11)(yaml@2.9.0))

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -6,7 +6,10 @@ auth.policy-verifier のデプロイ可能なサーバーテンプレートで�
 
 ```sh
 pnpm install
-OAUTH_JWT_SECRET=your-secret pnpm run start
+OAUTH_JWT_SECRET=your-secret \
+  OAUTH_JWT_ISSUER=https://issuer.example.com \
+  OAUTH_JWT_AUDIENCE=https://api.example.com \
+  pnpm run start
 ```
 
 ## 設定
@@ -30,6 +33,9 @@ OAUTH_JWT_SECRET=your-secret pnpm run start
 | `HTTP_PORT` | `3000` | バインドするポート番号 |
 | `HTTP_PATH_PREFIX` | `""` | URL パスプレフィックス |
 | `OAUTH_JWT_SECRET` | （必須） | HMAC-HS256 JWT 署名シークレット |
+| `OAUTH_JWT_ISSUER` | （必須） | この deployment が受け入れる issuer — RFC 9068 §4 `iss` |
+| `OAUTH_JWT_AUDIENCE` | （必須） | この resource server を指す audience — RFC 9068 §4 `aud` |
+| `OAUTH_JWT_TOKEN_TYPE` | `at+jwt` | 受け入れる `typ` ヘッダ。同じ鍵で署名された id/refresh/logout token を拒否する |
 | `OAUTH_JWT_VALIDATE` | `true` | JWT 署名を検証するかどうか |
 
 ## デフォルトコレクター
@@ -79,7 +85,11 @@ const app = await createApp({
 
 ```sh
 make build
-docker run -e OAUTH_JWT_SECRET=secret auth-policy-verifier
+docker run \
+  -e OAUTH_JWT_SECRET=secret \
+  -e OAUTH_JWT_ISSUER=https://issuer.example.com \
+  -e OAUTH_JWT_AUDIENCE=https://api.example.com \
+  auth-policy-verifier
 ```
 
 Docker Compose でローカル開発する場合:

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -6,7 +6,10 @@ Deployable server template for auth.policy-verifier. This is the composition roo
 
 ```sh
 pnpm install
-OAUTH_JWT_SECRET=your-secret pnpm run start
+OAUTH_JWT_SECRET=your-secret \
+  OAUTH_JWT_ISSUER=https://issuer.example.com \
+  OAUTH_JWT_AUDIENCE=https://api.example.com \
+  pnpm run start
 ```
 
 ## Configuration
@@ -30,6 +33,9 @@ Individual values can also be overridden with environment variables.
 | `HTTP_PORT` | `3000` | Bind port |
 | `HTTP_PATH_PREFIX` | `""` | URL path prefix |
 | `OAUTH_JWT_SECRET` | (required) | HMAC-HS256 JWT signing secret |
+| `OAUTH_JWT_ISSUER` | (required) | Issuer this deployment accepts — RFC 9068 §4 `iss` |
+| `OAUTH_JWT_AUDIENCE` | (required) | Audience identifying this resource server — RFC 9068 §4 `aud` |
+| `OAUTH_JWT_TOKEN_TYPE` | `at+jwt` | Accepted `typ` header; rejects id/refresh/logout tokens signed with the same key |
 | `OAUTH_JWT_VALIDATE` | `true` | Whether to verify JWT signature |
 
 ## Default Collectors
@@ -79,7 +85,11 @@ Build the image and run the container:
 
 ```sh
 make build
-docker run -e OAUTH_JWT_SECRET=secret auth-policy-verifier
+docker run \
+  -e OAUTH_JWT_SECRET=secret \
+  -e OAUTH_JWT_ISSUER=https://issuer.example.com \
+  -e OAUTH_JWT_AUDIENCE=https://api.example.com \
+  auth-policy-verifier
 ```
 
 For local development with Docker Compose:

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -15,6 +15,16 @@ oauth {
     jwksUri = ${?OAUTH_JWT_JWKS_URI}
     publicKey = ${?OAUTH_JWT_PUBLIC_KEY}
     publicKeyPath = ${?OAUTH_JWT_PUBLIC_KEY_PATH}
+
+    # RFC 9068 §4 — required whenever validate = true. No default: booting
+    # without them fails rather than accepting any validly-signed token.
+    issuer = ${?OAUTH_JWT_ISSUER}
+    audience = ${?OAUTH_JWT_AUDIENCE}
+    # Accepted `typ` header. at+jwt is the RFC 9068 access-token type; pinning it
+    # rejects id_tokens, refresh tokens and logout tokens signed with the same key.
+    tokenType = "at+jwt"
+    tokenType = ${?OAUTH_JWT_TOKEN_TYPE}
+
     validate = true
     validate = ${?OAUTH_JWT_VALIDATE}
   }

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -18,6 +18,7 @@ oauth {
 
     # RFC 9068 §4 — required whenever validate = true. No default: booting
     # without them fails rather than accepting any validly-signed token.
+    # A single issuer, or a list in a config file when several are acceptable.
     issuer = ${?OAUTH_JWT_ISSUER}
     audience = ${?OAUTH_JWT_AUDIENCE}
     # Accepted `typ` header. at+jwt is the RFC 9068 access-token type; pinning it

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -17,7 +17,21 @@ import { loadAppConfig } from "../loadConfig.js";
 
 const configDirPath = fileURLToPath(new URL("../../config/", import.meta.url));
 
-const envKeys = ["OAUTH_JWT_SECRET", "HTTP_HOSTNAME", "HTTP_PORT", "HTTP_PATH_PREFIX"] as const;
+const envKeys = [
+	"OAUTH_JWT_SECRET",
+	"OAUTH_JWT_ISSUER",
+	"OAUTH_JWT_AUDIENCE",
+	"HTTP_HOSTNAME",
+	"HTTP_PORT",
+	"HTTP_PATH_PREFIX",
+] as const;
+
+/** application.conf leaves issuer/audience unset, so every load must supply them. */
+function setRequiredEnv(): void {
+	process.env.OAUTH_JWT_SECRET = "test-secret";
+	process.env.OAUTH_JWT_ISSUER = "https://issuer.test";
+	process.env.OAUTH_JWT_AUDIENCE = "https://api.test";
+}
 
 afterEach(() => {
 	for (const key of envKeys) {
@@ -31,7 +45,7 @@ describe("loadAppConfig", () => {
 	it.each(["development", "production"])(
 		"resolves the %s overlay against application.conf",
 		(env) => {
-			process.env.OAUTH_JWT_SECRET = "test-secret";
+			setRequiredEnv();
 
 			const config = loadAppConfig(configDirPath, env);
 
@@ -39,11 +53,14 @@ describe("loadAppConfig", () => {
 			expect(config.oauth.jwt.algorithm).toBe("HS256");
 			expect(config.oauth.jwt.secret).toBe("test-secret");
 			expect(config.oauth.jwt.validate).toBe(true);
+			expect(config.oauth.jwt.issuer).toBe("https://issuer.test");
+			expect(config.oauth.jwt.audience).toBe("https://api.test");
+			expect(config.oauth.jwt.tokenType).toBe("at+jwt");
 		},
 	);
 
 	it("registers the collectors declared in application.conf", () => {
-		process.env.OAUTH_JWT_SECRET = "test-secret";
+		setRequiredEnv();
 
 		const config = loadAppConfig(configDirPath, "development");
 
@@ -59,7 +76,7 @@ describe("loadAppConfig", () => {
 	});
 
 	it("applies the optional environment substitutions from application.conf", () => {
-		process.env.OAUTH_JWT_SECRET = "test-secret";
+		setRequiredEnv();
 		process.env.HTTP_HOSTNAME = "127.0.0.1";
 		process.env.HTTP_PORT = "8080";
 		process.env.HTTP_PATH_PREFIX = "/auth";
@@ -77,5 +94,21 @@ describe("loadAppConfig", () => {
 
 	it("rejects an env name that escapes the config directory", () => {
 		expect(() => loadAppConfig(configDirPath, "../secrets")).toThrow(/resolves outside/);
+	});
+});
+
+describe("loadAppConfig — RFC 9068 requirements (#105)", () => {
+	it("fails to load when the issuer is not supplied", () => {
+		process.env.OAUTH_JWT_SECRET = "test-secret";
+		process.env.OAUTH_JWT_AUDIENCE = "https://api.test";
+
+		expect(() => loadAppConfig(configDirPath, "development")).toThrow();
+	});
+
+	it("fails to load when the audience is not supplied", () => {
+		process.env.OAUTH_JWT_SECRET = "test-secret";
+		process.env.OAUTH_JWT_ISSUER = "https://issuer.test";
+
+		expect(() => loadAppConfig(configDirPath, "development")).toThrow();
 	});
 });

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -28,9 +28,16 @@ import { describe, expect, it } from "vitest";
 
 const JWT_SECRET = "standalone-smoke-secret";
 const secretKey = new TextEncoder().encode(JWT_SECRET);
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "https://api.test";
 
 async function signToken(payload: Record<string, unknown>): Promise<string> {
-	return new SignJWT(payload).setProtectedHeader({ alg: "HS256" }).setIssuedAt().sign(secretKey);
+	return new SignJWT(payload)
+		.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+		.setIssuedAt()
+		.setIssuer(ISSUER)
+		.setAudience(AUDIENCE)
+		.sign(secretKey);
 }
 
 // Config mirrors the structure of application.conf, using the same builtin registry keys.
@@ -38,7 +45,7 @@ async function signToken(payload: Record<string, unknown>): Promise<string> {
 // ResourceActionScopeRuleCollector requires scope "<action>:<resourceType>" to be present.
 // DotNotationResourceParser is the default and matches the omitted resource.parser in application.conf.
 const baseConfig = AppConfigSchema.parse({
-	oauth: { jwt: { secret: JWT_SECRET, validate: true } },
+	oauth: { jwt: { secret: JWT_SECRET, validate: true, issuer: ISSUER, audience: AUDIENCE } },
 	attribute: {
 		collectors: [
 			{ collector: "PayloadScopeCollector" },
@@ -81,6 +88,30 @@ describe("standalone smoke", () => {
 
 		expect(res.status).toBe(200);
 		expect(res.body.decision).toBe("allow");
+	});
+
+	it("POST /verify with an id_token signed by the same key returns 401", async () => {
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: baseConfig,
+			modules: [builtinCollectorsModule, builtinKeyResolversModule],
+		});
+
+		// The paired provider signs id_tokens with the same key as access tokens;
+		// only the typ header separates them.
+		const token = await new SignJWT({ scope: "read:document" })
+			.setProtectedHeader({ alg: "HS256", typ: "id+jwt" })
+			.setIssuedAt()
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
+			.sign(secretKey);
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "document", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
 	});
 
 	it("POST /verify with insufficient scope returns 403 (deny)", async () => {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -10,11 +10,17 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
+		"@o3co/auth.policy-verifier.builtins": "workspace:*",
 		"@o3co/auth.policy-verifier.core": "workspace:*",
-		"@o3co/auth.policy-verifier.builtins": "workspace:*"
+		"@o3co/auth.policy-verifier.server": "workspace:*"
 	},
 	"devDependencies": {
+		"@types/express": "^5.0.6",
 		"@types/node": "^26.2.0",
+		"@types/supertest": "^7.2.1",
+		"express": "^5.0.0",
+		"jose": "^6.2.8",
+		"supertest": "^7.2.2",
 		"vitest": "^4.1.10"
 	}
 }

--- a/tests/integration/src/conformance/tokenValidation.mts
+++ b/tests/integration/src/conformance/tokenValidation.mts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+/** How a token deviates from the envelope the deployment under test accepts. */
+export interface TokenEnvelope {
+	/** `iss` claim; `null` omits it. */
+	issuer?: string | null;
+	/** `aud` claim; `null` omits it. */
+	audience?: string | string[] | null;
+	/** `typ` header; `null` omits it. */
+	tokenType?: string | null;
+}
+
+/** Whether the endpoint let the token through to policy evaluation. */
+export type TokenOutcome = "accepted" | "rejected";
+
+/**
+ * Hooks a decision endpoint must provide to be checked for RFC 9068 §4 token
+ * validation. `accepted` declares the envelope the deployment pins; `verify`
+ * mints a token deviating from it and reports whether the endpoint let it in.
+ */
+export interface TokenValidationAdapter {
+	/** Engine name, used in test titles. */
+	name: string;
+	/** The envelope this deployment accepts. */
+	accepted: { issuer: string; audience: string; tokenType: string };
+	/**
+	 * Mints a token from `accepted` with the given deviations applied, presents it
+	 * to the endpoint, and reports whether it reached policy evaluation. The token
+	 * is always correctly signed — this suite is about claim validation, not signatures.
+	 */
+	verify(envelope: TokenEnvelope): Promise<TokenOutcome>;
+}
+
+/**
+ * Conformance suite pinning RFC 9068 §4 token validation
+ * (o3co/auth.policy-verifier#105).
+ *
+ * An authorization server signs access tokens, id_tokens, refresh tokens and
+ * logout tokens with the same key, and neighbouring services share issuers. A
+ * decision endpoint that checks only the signature therefore accepts tokens it
+ * was never the audience for. Every engine that can sit behind the verifier's
+ * decision contract must reject the same set, otherwise swapping the engine
+ * changes which tokens are honored.
+ */
+export function describeTokenValidationConformance(adapter: TokenValidationAdapter): void {
+	describe(`RFC 9068 §4 token validation conformance — ${adapter.name}`, () => {
+		it("accepts a token carrying the pinned issuer, audience and type", async () => {
+			expect(await adapter.verify({})).toBe("accepted");
+		});
+
+		it("rejects a token minted by a foreign issuer", async () => {
+			expect(await adapter.verify({ issuer: "https://foreign-issuer.test" })).toBe("rejected");
+		});
+
+		it("rejects a token minted for a foreign audience", async () => {
+			expect(await adapter.verify({ audience: "https://foreign-service.test" })).toBe("rejected");
+		});
+
+		it("rejects a token with no issuer claim", async () => {
+			expect(await adapter.verify({ issuer: null })).toBe("rejected");
+		});
+
+		it("rejects a token with no audience claim", async () => {
+			expect(await adapter.verify({ audience: null })).toBe("rejected");
+		});
+
+		it.each(["id+jwt", "rt+jwt", "logout+jwt"])(
+			"rejects a %s token signed with the same key",
+			async (tokenType) => {
+				expect(await adapter.verify({ tokenType })).toBe("rejected");
+			},
+		);
+
+		it("rejects a token with no type header", async () => {
+			expect(await adapter.verify({ tokenType: null })).toBe("rejected");
+		});
+
+		it("accepts an audience list that contains the pinned audience", async () => {
+			const audience = ["https://foreign-service.test", adapter.accepted.audience];
+			expect(await adapter.verify({ audience })).toBe("accepted");
+		});
+	});
+}

--- a/tests/integration/src/token-validation-conformance.test.mts
+++ b/tests/integration/src/token-validation-conformance.test.mts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	DotNotationResourceParser,
+	PayloadScopeCollector,
+	ResourceActionScopeRuleCollector,
+} from "@o3co/auth.policy-verifier.builtins";
+import { AttributePipeline, RulePipeline } from "@o3co/auth.policy-verifier.core";
+import { createVerifyRouter } from "@o3co/auth.policy-verifier.server";
+import express from "express";
+import { SignJWT } from "jose";
+import request from "supertest";
+import {
+	describeTokenValidationConformance,
+	type TokenEnvelope,
+} from "./conformance/tokenValidation.mjs";
+
+const ACCEPTED = {
+	issuer: "https://issuer.test",
+	audience: "https://api.test",
+	tokenType: "at+jwt",
+};
+
+const secret = new TextEncoder().encode("token-validation-conformance-secret");
+
+const app = express();
+app.use(
+	createVerifyRouter({
+		jwt: { validate: true, key: secret, algorithms: ["HS256"], ...ACCEPTED },
+		resourceParser: new DotNotationResourceParser(),
+		attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
+		rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+	}),
+);
+
+/** Mints a correctly-signed token from ACCEPTED with the envelope's deviations applied. */
+async function mint(envelope: TokenEnvelope): Promise<string> {
+	const tokenType = envelope.tokenType === undefined ? ACCEPTED.tokenType : envelope.tokenType;
+	const issuer = envelope.issuer === undefined ? ACCEPTED.issuer : envelope.issuer;
+	const audience = envelope.audience === undefined ? ACCEPTED.audience : envelope.audience;
+
+	let jwt = new SignJWT({ scope: "read:project" })
+		.setProtectedHeader(tokenType === null ? { alg: "HS256" } : { alg: "HS256", typ: tokenType })
+		.setIssuedAt();
+	if (issuer !== null) jwt = jwt.setIssuer(issuer);
+	if (audience !== null) jwt = jwt.setAudience(audience);
+	return jwt.sign(secret);
+}
+
+describeTokenValidationConformance({
+	name: "@o3co/auth.policy-verifier.server createVerifyRouter()",
+	accepted: ACCEPTED,
+
+	async verify(envelope) {
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${await mint(envelope)}`)
+			.send({ resource: "project:1", action: "read" });
+
+		// 401 invalid_token means the token never reached policy evaluation. Any other
+		// status means it did — the decision itself is not what this suite pins.
+		return res.status === 401 ? "rejected" : "accepted";
+	},
+});


### PR DESCRIPTION
Closes #105. P0 migration prerequisite from the build-to-migrate strategy (o3co/auth#5).

## Problem

`jwtVerify(token, key, { algorithms })` — acceptance rested on the signature and `exp` alone, and the config schema exposed no `iss`/`aud` fields at all. The paired provider signs access tokens, `id_token`s (`typ: id+jwt`), refresh tokens (`rt+jwt`, which carry `scope`) and logout tokens **with the same key**; neighbouring services share issuers. So a caller could present its own `id_token`, a refresh token, or a token minted for another audience and have it flow straight into rule evaluation.

## Change

- `createVerifyRouter` checks `iss` against `issuer`, `aud` against `audience`, and the `typ` header against `tokenType` (default `at+jwt`; an `application/` prefix is ignored on either side).
- `VerifyRouterConfig.jwt` is now a union discriminated on `validate`:

  ```ts
  type VerifyRouterJwtConfig =
    | { validate: true; key: unknown; algorithms: string[];
        issuer: string | string[]; audience: string | string[]; tokenType: string }
    | { validate: false };
  ```

  Verification parameters exist exactly when verifying — a config cannot be assembled with the signature checked and the claims not. The router also throws at construction if a JavaScript caller omits one.
- `AppConfigSchema` requires `oauth.jwt.issuer` and `oauth.jwt.audience` whenever `validate` is true, and defaults `tokenType` to `at+jwt`. `createApp` re-checks, since it also accepts hand-built configs.
- The standalone template reads `OAUTH_JWT_ISSUER` / `OAUTH_JWT_AUDIENCE` with **no fallback**, so a deployment that omits them fails to boot rather than accepting anything validly signed. `OAUTH_JWT_TOKEN_TYPE` overrides the pinned type.

`maxTokenAge` is deliberately left to #110, which covers tokens without `exp`.

## Why this shape (migration seam)

RFC 9068 §4 is the standard token-consumption contract every engine behind `VerifierEndpoint` must honor. Validating to the standard now means feeding the same token to an OPA/OpenFGA adapter later cannot change acceptance. `tests/integration/src/conformance/tokenValidation.mts` pins that as a reusable suite: an adapter declares the envelope it accepts and mints deviations from it, and gets the same assertions. This impl is wired up as the first adapter.

## Tests (TDD, RED → GREEN)

- `packages/server/verify.test.mts` — foreign issuer, foreign audience, missing `iss`, missing `aud`, `id+jwt` / `rt+jwt` / `logout+jwt`, missing `typ` all 401; `application/at+jwt` and an `aud` array containing the pinned audience accepted; router construction refuses a missing issuer/audience
- `packages/server/application.schema.test.mts` — issuer/audience required under `validate: true`, empty issuer rejected, audience list accepted, `tokenType` defaults to `at+jwt`, none required when `validate: false`
- `packages/server/app.test.mts` — hand-built config without issuer/audience throws; foreign-audience token rejected end to end
- `templates/standalone` — config load fails without either env var; an `id_token` against the shipped config returns 401
- `tests/integration` — RFC 9068 §4 conformance suite

Full suite green (574 tests), lint clean.

## Breaking change

`oauth.jwt.issuer` and `oauth.jwt.audience` are required when `oauth.jwt.validate` is true, and tokens must carry `typ: at+jwt` unless `oauth.jwt.tokenType` says otherwise. Both READMEs, the server README and the standalone template docs carry the new env vars.