### PR TITLE
fix(server): require explicit double opt-in for decode-only mode, enforce exp/nbf

### DIFF
--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -168,10 +168,10 @@ describe("createApp", () => {
 		expect(res.status).toBe(200);
 	});
 
-	it("starts successfully and decodes tokens when validate=false with no key material", async () => {
-		// validate=false + no secret/publicKey/jwksUri must not throw at startup
+	it("starts successfully and decodes tokens when acknowledged validate=false with no key material", async () => {
+		// validate=false + allowInsecureDecode + no key material must not throw at startup
 		const noKeyConfig = AppConfigSchema.parse({
-			oauth: { jwt: { validate: false } },
+			oauth: { jwt: { validate: false, allowInsecureDecode: true } },
 			attribute: { collectors: [{ collector: "TestScopeCollector" }] },
 			rule: { collectors: [{ collector: "TestScopeRuleCollector" }] },
 			resource: { parser: "SimpleParser" },
@@ -293,14 +293,14 @@ describe("createApp logging (#107)", () => {
 	}
 
 	const noKeyConfig = AppConfigSchema.parse({
-		oauth: { jwt: { validate: false } },
+		oauth: { jwt: { validate: false, allowInsecureDecode: true } },
 		attribute: { collectors: [{ collector: "TestScopeCollector" }] },
 		rule: { collectors: [{ collector: "TestScopeRuleCollector" }] },
 		resource: { parser: "SimpleParser" },
 	});
 
-	it("routes the validate=false warning through the injected logger, not console.warn", async () => {
-		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+	it("routes the validate=false event through the injected logger, not the console", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
 			const { calls, logger } = captureLogger();
 			await createApp({
@@ -310,17 +310,16 @@ describe("createApp logging (#107)", () => {
 				logger,
 			});
 
-			const warns = calls.filter((c) => c.level === "warn");
-			expect(warns).toHaveLength(1);
-			expect(warns[0].msg).toBe("jwt_validation_disabled");
+			const events = calls.filter((c) => c.msg === "jwt_validation_disabled");
+			expect(events).toHaveLength(1);
 			expect(consoleSpy).not.toHaveBeenCalled();
 		} finally {
 			consoleSpy.mockRestore();
 		}
 	});
 
-	it("emits the validate=false warning on the console-backed default when no logger is injected", async () => {
-		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+	it("emits the validate=false event on the console-backed default when no logger is injected", async () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
 			await createApp({
 				pathResolver: (s: string) => s,
@@ -334,10 +333,10 @@ describe("createApp logging (#107)", () => {
 	});
 
 	it("honours logging.level for the console-backed default logger", async () => {
-		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
 			const silentConfig = AppConfigSchema.parse({
-				oauth: { jwt: { validate: false } },
+				oauth: { jwt: { validate: false, allowInsecureDecode: true } },
 				logging: { level: "silent" },
 				attribute: { collectors: [{ collector: "TestScopeCollector" }] },
 				rule: { collectors: [{ collector: "TestScopeRuleCollector" }] },
@@ -389,5 +388,68 @@ describe("createApp logging (#107)", () => {
 		const errors = calls.filter((c) => c.level === "error");
 		expect(errors).toHaveLength(1);
 		expect(errors[0].msg).toBe("verify_internal_error");
+	});
+});
+
+describe("createApp insecure decode guard (#106)", () => {
+	const ackConfig = AppConfigSchema.parse({
+		oauth: { jwt: { validate: false, allowInsecureDecode: true } },
+		attribute: { collectors: [{ collector: "TestScopeCollector" }] },
+		rule: { collectors: [{ collector: "TestScopeRuleCollector" }] },
+		resource: { parser: "SimpleParser" },
+	});
+
+	it("refuses to boot a hand-built config with validate=false and no acknowledgment", async () => {
+		// AppConfigSchema rejects this shape, so reach createApp with an object
+		// that never went through it — the same path a library consumer can take.
+		const handBuilt = {
+			...ackConfig,
+			oauth: { jwt: { ...ackConfig.oauth.jwt, allowInsecureDecode: false } },
+		} as unknown as typeof ackConfig;
+
+		await expect(
+			createApp({
+				pathResolver: (s: string) => s,
+				config: handBuilt,
+				modules: [testModule, builtinKeyResolversModule],
+			}),
+		).rejects.toThrow(/allowInsecureDecode/);
+	});
+
+	it("boots acknowledged decode mode and emits jwt_validation_disabled at error level", async () => {
+		const calls: Array<{ level: string; msg?: string }> = [];
+		const record =
+			(level: string) =>
+			(_obj: Record<string, unknown> | string, msg?: string): void => {
+				calls.push({ level, msg });
+			};
+		const logger: Logger = {
+			trace: record("trace"),
+			debug: record("debug"),
+			info: record("info"),
+			warn: record("warn"),
+			error: record("error"),
+			fatal: record("fatal"),
+			child: () => logger,
+		};
+
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: ackConfig,
+			modules: [testModule, builtinKeyResolversModule],
+			logger,
+		});
+
+		// A mis-set env var disabling all verification is an operator-facing
+		// incident, not a curiosity: error, so a level=error fleet still sees it.
+		expect(calls).toContainEqual({ level: "error", msg: "jwt_validation_disabled" });
+		expect(calls.filter((c) => c.msg === "jwt_validation_disabled")).toHaveLength(1);
+
+		const token = await signToken({ scope: "read:project" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project", action: "read" });
+		expect(res.status).toBe(200);
 	});
 });

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -61,7 +61,7 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 
 	it("skips validation when validate=false (no key material required)", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm: "RS256", validate: false } },
+			oauth: { jwt: { algorithm: "RS256", validate: false, allowInsecureDecode: true } },
 			...baseBody,
 		});
 		expect(result.success).toBe(true);
@@ -154,7 +154,7 @@ describe("AppConfigSchema — RFC 9068 token validation (#105)", () => {
 
 	it("does not require issuer/audience when validation is disabled", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm: "HS256", validate: false } },
+			oauth: { jwt: { algorithm: "HS256", validate: false, allowInsecureDecode: true } },
 			...baseBody,
 		});
 		expect(result.success).toBe(true);
@@ -241,7 +241,7 @@ describe("AppConfigSchema — multiple acceptable issuers (#105)", () => {
 
 describe("AppConfigSchema — logging (#107)", () => {
 	const validBody = {
-		oauth: { jwt: { validate: false } },
+		oauth: { jwt: { validate: false, allowInsecureDecode: true } },
 		...baseBody,
 	};
 
@@ -262,6 +262,44 @@ describe("AppConfigSchema — logging (#107)", () => {
 
 	it("rejects an unknown logging.level", () => {
 		const result = AppConfigSchema.safeParse({ ...validBody, logging: { level: "verbose" } });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("AppConfigSchema — insecure decode acknowledgment (#106)", () => {
+	it("rejects validate=false without allowInsecureDecode", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { validate: false } },
+			...baseBody,
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.some((i) => i.message.includes("allowInsecureDecode"))).toBe(true);
+		}
+	});
+
+	it("accepts validate=false when allowInsecureDecode=true acknowledges it", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { validate: false, allowInsecureDecode: true } },
+			...baseBody,
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("defaults allowInsecureDecode to false", () => {
+		const result = AppConfigSchema.parse({
+			oauth: { jwt: { validate: true, secret: "s", ...rfc9068 } },
+			...baseBody,
+		});
+		expect(result.oauth.jwt.allowInsecureDecode).toBe(false);
+	});
+
+	it("does not let allowInsecureDecode relax the validate=true requirements", () => {
+		// The flag acknowledges decode-only mode; it must not weaken anything else.
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { validate: true, allowInsecureDecode: true } },
+			...baseBody,
+		});
 		expect(result.success).toBe(false);
 	});
 });

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -658,6 +658,19 @@ describe("POST /verify — RFC 9068 §4 token validation (#105)", () => {
 			}),
 		).toThrow(/audience/);
 	});
+
+	it("refuses to build a decode-only router without the acknowledgment (#106)", () => {
+		// The double opt-in must hold at the server package's API boundary too:
+		// wiring the router directly is not a way around it.
+		expect(() =>
+			createVerifyRouter({
+				jwt: { validate: false } as unknown as Parameters<typeof createVerifyRouter>[0]["jwt"],
+				resourceParser: new DotNotationResourceParser(),
+				attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
+				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+			}),
+		).toThrow(/allowInsecureDecode/);
+	});
 });
 
 describe("POST /verify — decision contract (#124)", () => {

--- a/packages/server/src/__tests__/verifyLogging.test.mts
+++ b/packages/server/src/__tests__/verifyLogging.test.mts
@@ -71,6 +71,7 @@ function captureEvents(): { events: CapturedEvent[]; logger: EventLogger } {
 interface SignOptions {
 	key?: unknown;
 	expiresAt?: number;
+	notBefore?: number;
 }
 
 async function signToken(payload: Record<string, unknown>, options: SignOptions = {}) {
@@ -81,6 +82,9 @@ async function signToken(payload: Record<string, unknown>, options: SignOptions 
 		.setAudience(AUDIENCE);
 	if (options.expiresAt !== undefined) {
 		jwt.setExpirationTime(options.expiresAt);
+	}
+	if (options.notBefore !== undefined) {
+		jwt.setNotBefore(options.notBefore);
 	}
 	return jwt.sign((options.key ?? hs256Key.key) as import("node:crypto").KeyObject);
 }
@@ -351,6 +355,76 @@ describe("verify router failure logging: default sink and quiet paths", () => {
 
 		expect(missing.status).toBe(401);
 		expect(badScheme.status).toBe(401);
+		expect(events).toHaveLength(0);
+	});
+});
+
+describe("decode-only path time-claim enforcement (#106)", () => {
+	// decodeJwt performs no validation at all; the route must enforce exp/nbf
+	// itself with jwtVerify's semantics so a leaked expired token is not a
+	// permanent credential in decode-only deployments.
+	const decodeApp = (logger: EventLogger) => createTestApp({ jwt: { validate: false }, logger });
+
+	const now = () => Math.floor(Date.now() / 1000);
+
+	it("rejects an expired token with 401 and logs ERR_JWT_EXPIRED", async () => {
+		const { events, logger } = captureEvents();
+		const token = await signToken({ scope: "read:project" }, { expiresAt: now() - 3600 });
+
+		const res = await request(decodeApp(logger))
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ level: "warn", msg: "jwt_token_rejected" });
+		expect((events[0].obj.err as { code?: string }).code).toBe("ERR_JWT_EXPIRED");
+	});
+
+	it("rejects a not-yet-valid token with 401 and logs a claim validation failure", async () => {
+		const { events, logger } = captureEvents();
+		const token = await signToken({ scope: "read:project" }, { notBefore: now() + 3600 });
+
+		const res = await request(decodeApp(logger))
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(events).toHaveLength(1);
+		expect((events[0].obj.err as { code?: string }).code).toBe("ERR_JWT_CLAIM_VALIDATION_FAILED");
+	});
+
+	it("rejects a token whose exp claim is not a number", async () => {
+		const { events, logger } = captureEvents();
+		// jwtVerify rejects a non-numeric exp; the decode path must not be laxer.
+		const token = await signToken({ scope: "read:project", exp: "tomorrow" });
+
+		const res = await request(decodeApp(logger))
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ level: "warn", msg: "jwt_token_rejected" });
+	});
+
+	it("accepts a fresh token and a token with no exp claim (jwtVerify parity)", async () => {
+		const { events, logger } = captureEvents();
+		const app = decodeApp(logger);
+		const fresh = await signToken({ scope: "read:project" }, { expiresAt: now() + 3600 });
+		const noExp = await signToken({ scope: "read:project" });
+
+		for (const token of [fresh, noExp]) {
+			const res = await request(app)
+				.post("/verify")
+				.set("Authorization", `Bearer ${token}`)
+				.send({ resource: "project", action: "read" });
+			expect(res.status).toBe(200);
+		}
 		expect(events).toHaveLength(0);
 	});
 });

--- a/packages/server/src/__tests__/verifyLogging.test.mts
+++ b/packages/server/src/__tests__/verifyLogging.test.mts
@@ -72,14 +72,18 @@ interface SignOptions {
 	key?: unknown;
 	expiresAt?: number;
 	notBefore?: number;
+	/** Keep the payload's own `iat` instead of stamping a numeric one. */
+	skipIssuedAt?: boolean;
 }
 
 async function signToken(payload: Record<string, unknown>, options: SignOptions = {}) {
 	const jwt = new SignJWT(payload)
 		.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
-		.setIssuedAt()
 		.setIssuer(ISSUER)
 		.setAudience(AUDIENCE);
+	if (!options.skipIssuedAt) {
+		jwt.setIssuedAt();
+	}
 	if (options.expiresAt !== undefined) {
 		jwt.setExpirationTime(options.expiresAt);
 	}
@@ -397,10 +401,16 @@ describe("decode-only path time-claim enforcement (#106)", () => {
 		expect((events[0].obj.err as { code?: string }).code).toBe("ERR_JWT_CLAIM_VALIDATION_FAILED");
 	});
 
-	it("rejects a token whose exp claim is not a number", async () => {
+	it.each([
+		{ claim: "exp", payload: { exp: "tomorrow" } },
+		{ claim: "nbf", payload: { nbf: "yesterday" } },
+		{ claim: "iat", payload: { iat: "yesterday" } },
+	])("rejects a token whose $claim claim is not a number", async ({ payload }) => {
 		const { events, logger } = captureEvents();
-		// jwtVerify rejects a non-numeric exp; the decode path must not be laxer.
-		const token = await signToken({ scope: "read:project", exp: "tomorrow" });
+		// jwtVerify rejects a present non-numeric exp/nbf/iat; the decode path
+		// must not be laxer. skipIssuedAt keeps setIssuedAt() from stamping a
+		// numeric iat over the malformed one.
+		const token = await signToken({ scope: "read:project", ...payload }, { skipIssuedAt: true });
 
 		const res = await request(decodeApp(logger))
 			.post("/verify")

--- a/packages/server/src/__tests__/verifyLogging.test.mts
+++ b/packages/server/src/__tests__/verifyLogging.test.mts
@@ -169,7 +169,7 @@ describe("verify router failure logging: token rejections (warn)", () => {
 
 	it("logs jwt_token_rejected for a malformed token on the decode-only path", async () => {
 		const { events, logger } = captureEvents();
-		const app = createTestApp({ jwt: { validate: false }, logger });
+		const app = createTestApp({ jwt: { validate: false, allowInsecureDecode: true }, logger });
 
 		const res = await request(app)
 			.post("/verify")
@@ -367,7 +367,8 @@ describe("decode-only path time-claim enforcement (#106)", () => {
 	// decodeJwt performs no validation at all; the route must enforce exp/nbf
 	// itself with jwtVerify's semantics so a leaked expired token is not a
 	// permanent credential in decode-only deployments.
-	const decodeApp = (logger: EventLogger) => createTestApp({ jwt: { validate: false }, logger });
+	const decodeApp = (logger: EventLogger) =>
+		createTestApp({ jwt: { validate: false, allowInsecureDecode: true }, logger });
 
 	const now = () => Math.floor(Date.now() / 1000);
 

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -42,7 +42,9 @@ export interface CreateAppOptions {
  * and healthcheck under the configured path prefix.
  *
  * `config.oauth.jwt.validate = false` disables signature verification and only
- * decodes the token. This is a development-only switch; a warning is logged.
+ * decodes the token (`exp` / `nbf` are still enforced). It is test-only and
+ * refuses to boot unless `oauth.jwt.allowInsecureDecode = true` explicitly
+ * acknowledges it; booting in that mode is logged at error level (#106).
  */
 export async function createApp(options: CreateAppOptions): Promise<express.Express> {
 	const { pathResolver, config, modules } = options;
@@ -112,10 +114,18 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 			tokenType,
 		};
 	} else {
+		// AppConfigSchema already requires the acknowledgment; re-checked here
+		// because createApp also accepts hand-built config objects that never
+		// went through the schema (#106).
+		if (!config.oauth.jwt.allowInsecureDecode) {
+			throw new Error(
+				"createApp: oauth.jwt.validate=false disables ALL token verification (test-only); set oauth.jwt.allowInsecureDecode=true to acknowledge, or restore validate=true",
+			);
+		}
 		jwt = { validate: false };
-		// Structured event, not console.warn: an aggregated-log pipeline can
-		// alert on the event name instead of losing a bare string (#107).
-		logger.warn({ validate: false }, "jwt_validation_disabled");
+		// error, not warn: a deployment that reaches this line accepts unsigned
+		// tokens, and a fleet filtering at level=error must still see it (#106).
+		logger.error({ validate: false, allowInsecureDecode: true }, "jwt_validation_disabled");
 	}
 
 	// 7. Build Express app

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -122,7 +122,7 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 				"createApp: oauth.jwt.validate=false disables ALL token verification (test-only); set oauth.jwt.allowInsecureDecode=true to acknowledge, or restore validate=true",
 			);
 		}
-		jwt = { validate: false };
+		jwt = { validate: false, allowInsecureDecode: true };
 		// error, not warn: a deployment that reaches this line accepts unsigned
 		// tokens, and a fleet filtering at level=error must still see it (#106).
 		logger.error({ validate: false, allowInsecureDecode: true }, "jwt_validation_disabled");

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -57,7 +57,8 @@ export const AppConfigSchema = z.object({
 			.passthrough()
 			.superRefine((data, ctx) => {
 				if (!data.validate) {
-					// Decode-only mode: no signature check, no claim checks. One config
+					// Decode-only mode: no signature check (exp/nbf are still enforced
+					// at request time, but nothing else is). One config
 					// key (often one env var) must not be enough to get here — demand
 					// the explicit second key.
 					if (!data.allowInsecureDecode) {

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -41,6 +41,11 @@ export const AppConfigSchema = z.object({
 				publicKey: z.string().optional(),
 				publicKeyPath: z.string().optional(),
 				validate: z.boolean().default(true),
+				// Second key of the double opt-in for decode-only mode (#106). A single
+				// mistyped env var must never be able to disable all token verification,
+				// so `validate=false` alone refuses to boot; this flag is the explicit,
+				// test-only acknowledgment.
+				allowInsecureDecode: z.boolean().default(false),
 				// RFC 9068 §4 — a resource server validates iss and aud, not just the
 				// signature. Both are required whenever `validate` is on (see superRefine).
 				issuer: z.union([z.string(), z.array(z.string())]).optional(),
@@ -51,7 +56,20 @@ export const AppConfigSchema = z.object({
 			})
 			.passthrough()
 			.superRefine((data, ctx) => {
-				if (!data.validate) return; // skip validation when disabled
+				if (!data.validate) {
+					// Decode-only mode: no signature check, no claim checks. One config
+					// key (often one env var) must not be enough to get here — demand
+					// the explicit second key.
+					if (!data.allowInsecureDecode) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							message:
+								"validate=false disables ALL token verification (test-only); set allowInsecureDecode=true to acknowledge, or restore validate=true",
+							path: ["allowInsecureDecode"],
+						});
+					}
+					return; // key-material checks below only apply when validating
+				}
 				const issuers = Array.isArray(data.issuer) ? data.issuer : [data.issuer];
 				const audiences = Array.isArray(data.audience) ? data.audience : [data.audience];
 				if (issuers.length === 0 || issuers.some((i) => !i)) {

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -42,11 +42,13 @@ export interface VerifyingJwtConfig {
 
 /**
  * Test-only shape: the token is decoded, never signature-verified. Its `exp` /
- * `nbf` claims are still enforced (#106). Reaching this mode through
- * `createApp` additionally requires `oauth.jwt.allowInsecureDecode = true`.
+ * `nbf` claims are still enforced (#106). The acknowledgment is part of the
+ * shape — and re-checked at construction time — so wiring the router directly
+ * is not a way around the double opt-in `createApp` enforces.
  */
 export interface DecodingJwtConfig {
 	validate: false;
+	allowInsecureDecode: true;
 }
 
 /** JWT half of `VerifyRouterConfig`, discriminated on `validate`. */
@@ -285,6 +287,13 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				"createVerifyRouter: jwt.tokenType is required when jwt.validate is true (RFC 9068 §4)",
 			);
 		}
+	} else if (jwt.allowInsecureDecode !== true) {
+		// The double opt-in (#106) holds at this API boundary too: a JavaScript
+		// caller can reach here without the acknowledgment even though the
+		// TypeScript shape requires it.
+		throw new Error(
+			"createVerifyRouter: jwt.validate=false disables ALL signature verification (test-only); set jwt.allowInsecureDecode=true to acknowledge, or use a verifying config",
+		);
 	}
 
 	/** Extracts and verifies the bearer token. Shared by both endpoints. */

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -40,7 +40,11 @@ export interface VerifyingJwtConfig {
 	tokenType: string;
 }
 
-/** Development-only shape: the token is decoded, never verified. */
+/**
+ * Test-only shape: the token is decoded, never signature-verified. Its `exp` /
+ * `nbf` claims are still enforced (#106). Reaching this mode through
+ * `createApp` additionally requires `oauth.jwt.allowInsecureDecode = true`.
+ */
 export interface DecodingJwtConfig {
 	validate: false;
 }
@@ -158,6 +162,55 @@ function isVerificationUnavailable(cause: unknown): boolean {
 }
 
 /**
+ * `exp` / `nbf` checks for the decode-only path (#106). `decodeJwt` performs
+ * no validation at all, so the route enforces the token's own lifetime with
+ * `jwtVerify`'s semantics and error classes: reject a numeric `exp` in the
+ * past or a numeric `nbf` in the future, reject a non-numeric value for
+ * either, tolerate absence, zero clock tolerance. Skipping the signature is an
+ * (acknowledged, test-only) trust decision about the issuer; honouring an
+ * expired token is simply wrong in every mode.
+ */
+function assertTimeClaims(payload: JWTPayload): void {
+	const now = Math.floor(Date.now() / 1000);
+	if (payload.nbf !== undefined) {
+		if (typeof payload.nbf !== "number") {
+			throw new errors.JWTClaimValidationFailed(
+				'"nbf" claim must be a number',
+				payload,
+				"nbf",
+				"invalid",
+			);
+		}
+		if (payload.nbf > now) {
+			throw new errors.JWTClaimValidationFailed(
+				'"nbf" claim timestamp check failed',
+				payload,
+				"nbf",
+				"check_failed",
+			);
+		}
+	}
+	if (payload.exp !== undefined) {
+		if (typeof payload.exp !== "number") {
+			throw new errors.JWTClaimValidationFailed(
+				'"exp" claim must be a number',
+				payload,
+				"exp",
+				"invalid",
+			);
+		}
+		if (payload.exp <= now) {
+			throw new errors.JWTExpired(
+				'"exp" claim timestamp check failed',
+				payload,
+				"exp",
+				"check_failed",
+			);
+		}
+	}
+}
+
+/**
  * Validates one entry of a decision request. Returns the entry or the reason it
  * is unusable, phrased with `label` so a batch can name the offending index.
  */
@@ -269,6 +322,7 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				decoded = result.payload;
 			} else {
 				decoded = decodeJwt(token);
+				assertTimeClaims(decoded);
 			}
 		} catch (cause) {
 			// Same 401 either way — the caller is unauthenticated regardless — but

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -165,13 +165,22 @@ function isVerificationUnavailable(cause: unknown): boolean {
  * `exp` / `nbf` checks for the decode-only path (#106). `decodeJwt` performs
  * no validation at all, so the route enforces the token's own lifetime with
  * `jwtVerify`'s semantics and error classes: reject a numeric `exp` in the
- * past or a numeric `nbf` in the future, reject a non-numeric value for
- * either, tolerate absence, zero clock tolerance. Skipping the signature is an
- * (acknowledged, test-only) trust decision about the issuer; honouring an
- * expired token is simply wrong in every mode.
+ * past or a numeric `nbf` in the future, reject a present non-numeric value
+ * for any time claim (`iat` included — `jwtVerify` type-checks it
+ * unconditionally), tolerate absence, zero clock tolerance. Skipping the
+ * signature is an (acknowledged, test-only) trust decision about the issuer;
+ * honouring an expired token is simply wrong in every mode.
  */
 function assertTimeClaims(payload: JWTPayload): void {
 	const now = Math.floor(Date.now() / 1000);
+	if (payload.iat !== undefined && typeof payload.iat !== "number") {
+		throw new errors.JWTClaimValidationFailed(
+			'"iat" claim must be a number',
+			payload,
+			"iat",
+			"invalid",
+		);
+	}
 	if (payload.nbf !== undefined) {
 		if (typeof payload.nbf !== "number") {
 			throw new errors.JWTClaimValidationFailed(

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -28,6 +28,12 @@ oauth {
 
     validate = true
     validate = ${?OAUTH_JWT_VALIDATE}
+    # TEST-ONLY double opt-in for validate = false. Decode-only mode accepts
+    # tokens without signature verification (exp/nbf are still enforced), so
+    # validate = false alone refuses to boot; both keys must be set explicitly.
+    # Never set this in production.
+    allowInsecureDecode = false
+    allowInsecureDecode = ${?OAUTH_JWT_ALLOW_INSECURE_DECODE}
   }
 }
 

--- a/templates/standalone/src/__tests__/logger.test.mts
+++ b/templates/standalone/src/__tests__/logger.test.mts
@@ -18,7 +18,7 @@ import { createAppLogger } from "../logger.js";
 
 function configWithLevel(level?: string) {
 	return AppConfigSchema.parse({
-		oauth: { jwt: { validate: false } },
+		oauth: { jwt: { validate: false, allowInsecureDecode: true } },
 		attribute: { collectors: [] },
 		rule: { collectors: [{ collector: "ResourceActionScopeRuleCollector" }] },
 		...(level === undefined ? {} : { logging: { level } }),

--- a/tests/integration/src/conformance/tokenExpiry.mts
+++ b/tests/integration/src/conformance/tokenExpiry.mts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * How a token's time claims deviate from a fresh, currently-valid token.
+ * `undefined` leaves the suite's default (a valid value); `null` omits the
+ * claim entirely.
+ */
+export interface TimeClaimDeviation {
+	/** `exp` claim as a unix-seconds offset from now; `null` omits it. */
+	expOffsetSeconds?: number | null;
+	/** `nbf` claim as a unix-seconds offset from now; omitted by default. */
+	nbfOffsetSeconds?: number;
+}
+
+/** Whether the endpoint let the token through to policy evaluation. */
+export type TimeClaimOutcome = "accepted" | "rejected";
+
+/**
+ * Hooks a decision endpoint must provide to be checked for time-claim
+ * enforcement. `verify` mints an otherwise-acceptable token with the given
+ * deviations applied, presents it, and reports whether it reached policy
+ * evaluation.
+ */
+export interface TokenExpiryAdapter {
+	/** Deployment mode name, used in test titles. */
+	name: string;
+	verify(deviation: TimeClaimDeviation): Promise<TimeClaimOutcome>;
+}
+
+/**
+ * Conformance suite pinning `exp` / `nbf` enforcement
+ * (o3co/auth.policy-verifier#106).
+ *
+ * Every deployment mode of the verifier must honour a token's own lifetime —
+ * including the decode-only mode that skips signature verification: skipping
+ * the signature is an (acknowledged, test-only) trust decision about the
+ * issuer, but honouring an expired token is simply wrong in every mode, and is
+ * what turns a leaked old token into a permanent credential.
+ *
+ * Absence of `exp` is deliberately accepted: `jwtVerify` validates time claims
+ * only when present, and the decode path mirrors those semantics exactly so
+ * the two modes never disagree about the same token.
+ */
+export function describeTokenExpiryConformance(adapter: TokenExpiryAdapter): void {
+	describe(`token time-claim conformance — ${adapter.name}`, () => {
+		it("accepts a fresh token", async () => {
+			expect(await adapter.verify({})).toBe("accepted");
+		});
+
+		it("rejects an expired token", async () => {
+			expect(await adapter.verify({ expOffsetSeconds: -3600 })).toBe("rejected");
+		});
+
+		it("rejects a token that is not yet valid", async () => {
+			expect(await adapter.verify({ nbfOffsetSeconds: 3600 })).toBe("rejected");
+		});
+
+		it("accepts a token carrying no exp claim (jwtVerify parity)", async () => {
+			expect(await adapter.verify({ expOffsetSeconds: null })).toBe("accepted");
+		});
+	});
+}

--- a/tests/integration/src/token-expiry-conformance.test.mts
+++ b/tests/integration/src/token-expiry-conformance.test.mts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	DotNotationResourceParser,
+	PayloadScopeCollector,
+	ResourceActionScopeRuleCollector,
+} from "@o3co/auth.policy-verifier.builtins";
+import { AttributePipeline, RulePipeline } from "@o3co/auth.policy-verifier.core";
+import { createVerifyRouter, type VerifyRouterJwtConfig } from "@o3co/auth.policy-verifier.server";
+import express from "express";
+import { SignJWT } from "jose";
+import request from "supertest";
+import {
+	describeTokenExpiryConformance,
+	type TimeClaimDeviation,
+} from "./conformance/tokenExpiry.mjs";
+
+const ACCEPTED = {
+	issuer: "https://issuer.test",
+	audience: "https://api.test",
+	tokenType: "at+jwt",
+};
+
+const secret = new TextEncoder().encode("token-expiry-conformance-secret");
+
+function createApp(jwt: VerifyRouterJwtConfig) {
+	const app = express();
+	app.use(
+		createVerifyRouter({
+			jwt,
+			resourceParser: new DotNotationResourceParser(),
+			attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
+			rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+		}),
+	);
+	return app;
+}
+
+/** Mints a correctly-signed, otherwise-acceptable token with the deviations applied. */
+async function mint(deviation: TimeClaimDeviation): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	let jwt = new SignJWT({ scope: "read:project" })
+		.setProtectedHeader({ alg: "HS256", typ: ACCEPTED.tokenType })
+		.setIssuedAt()
+		.setIssuer(ACCEPTED.issuer)
+		.setAudience(ACCEPTED.audience);
+	if (deviation.expOffsetSeconds !== null) {
+		jwt = jwt.setExpirationTime(now + (deviation.expOffsetSeconds ?? 3600));
+	}
+	if (deviation.nbfOffsetSeconds !== undefined) {
+		jwt = jwt.setNotBefore(now + deviation.nbfOffsetSeconds);
+	}
+	return jwt.sign(secret);
+}
+
+function adapterFor(name: string, jwt: VerifyRouterJwtConfig) {
+	const app = createApp(jwt);
+	return {
+		name,
+		async verify(deviation: TimeClaimDeviation) {
+			const res = await request(app)
+				.post("/verify")
+				.set("Authorization", `Bearer ${await mint(deviation)}`)
+				.send({ resource: "project:1", action: "read" });
+
+			// 401 invalid_token means the token never reached policy evaluation. Any
+			// other status means it did — the decision itself is not what this suite pins.
+			return res.status === 401 ? ("rejected" as const) : ("accepted" as const);
+		},
+	};
+}
+
+describeTokenExpiryConformance(
+	adapterFor("createVerifyRouter() verifying mode (validate: true)", {
+		validate: true,
+		key: secret,
+		algorithms: ["HS256"],
+		...ACCEPTED,
+	}),
+);
+
+// The decode-only mode skips signature verification, but a token's own
+// lifetime must still be honoured (#106) — otherwise a leaked expired token
+// stays a working credential in every deployment that runs this mode.
+describeTokenExpiryConformance(
+	adapterFor("createVerifyRouter() decode-only mode (validate: false)", { validate: false }),
+);

--- a/tests/integration/src/token-expiry-conformance.test.mts
+++ b/tests/integration/src/token-expiry-conformance.test.mts
@@ -64,9 +64,13 @@ function adapterFor(name: string, jwt: VerifyRouterJwtConfig) {
 				.set("Authorization", `Bearer ${await mint(deviation)}`)
 				.send({ resource: "project:1", action: "read" });
 
-			// 401 invalid_token means the token never reached policy evaluation. Any
-			// other status means it did — the decision itself is not what this suite pins.
-			return res.status === 401 ? ("rejected" as const) : ("accepted" as const);
+			// 401 invalid_token means the token never reached policy evaluation;
+			// 200/403 means it did — the decision itself is not what this suite
+			// pins. Anything else (400/500) is a broken harness, not an answer,
+			// and must fail the test rather than masquerade as either outcome.
+			if (res.status === 401) return "rejected" as const;
+			if (res.status === 200 || res.status === 403) return "accepted" as const;
+			throw new Error(`unexpected status ${res.status}: ${JSON.stringify(res.body)}`);
 		},
 	};
 }
@@ -84,5 +88,8 @@ describeTokenExpiryConformance(
 // lifetime must still be honoured (#106) — otherwise a leaked expired token
 // stays a working credential in every deployment that runs this mode.
 describeTokenExpiryConformance(
-	adapterFor("createVerifyRouter() decode-only mode (validate: false)", { validate: false }),
+	adapterFor("createVerifyRouter() decode-only mode (validate: false)", {
+		validate: false,
+		allowInsecureDecode: true,
+	}),
 );


### PR DESCRIPTION
Closes #106

## Problem

`validate=false` switched token handling to `decodeJwt` — **no signature check and no `exp` check** — accepting arbitrary attacker-created claims. The option was exposed through production configuration (`OAUTH_JWT_VALIDATE`) and guarded only by a `console.warn` (upgraded to a structured warn in #130). A single mistyped/overridden env var silently disabled all token verification.

## Design decision: environment-agnostic double opt-in

The issue's suggested fix was "refuse to boot in production" — but only `templates/standalone/src/main.mts` knows `CONFIG_ENV`/`NODE_ENV`, and `packages/server`'s `createApp` deliberately doesn't. Rather than teaching a new layer which environment is production, the dangerous mode now requires **two explicit keys in every environment**:

- `oauth.jwt.validate = false` **alone refuses to boot** — `AppConfigSchema` rejects it at config-parse time, and `createApp` re-checks hand-built configs (mirroring the existing issuer/audience re-check pattern).
- `oauth.jwt.allowInsecureDecode = true` (env: `OAUTH_JWT_ALLOW_INSECURE_DECODE`) is the acknowledgment. One mistyped env var can never disable verification; you need two, one of which is named for what it does.
- Booting in acknowledged decode mode logs `jwt_validation_disabled` at **error** level (was warn) — a fleet filtering at `level=error` still sees it.

## exp/nbf enforced on the decode path

`decodeJwt` performs no validation at all, so the route now enforces the token's own lifetime with `jwtVerify`'s semantics and error classes: numeric `exp` in the past → rejected (`ERR_JWT_EXPIRED`), numeric `nbf` in the future → rejected, non-numeric values → rejected; absence tolerated (jwtVerify parity); zero clock tolerance. A leaked expired token is no longer a permanent credential in decode-only deployments. Rejections flow through the #130 logging (`jwt_token_rejected`).

## Conformance

New engine-agnostic time-claim suite `tests/integration/src/conformance/tokenExpiry.mts`, run against **both** verifying mode and decode-only mode — the falsifiable assertion that the two modes can never disagree about the same token's lifetime.

## Cross-repo impact

`o3co/auth` E2E: the compose file never sets `OAUTH_JWT_VALIDATE` (verifier runs with `validate=true`), and both suites mint tokens with `expiresIn: 60`. Verified by parsing the actual mounted overlay config (`tests/abac/application.conf`) against the new schema with the E2E env vars and `NODE_ENV=production`: parses OK, acceptance unchanged. The mounted-overlay constraint is why `allowInsecureDecode` defaults to `false` in the schema rather than being shape-required.

## Verification

TDD (RED → GREEN → REFACTOR): 9 new RED tests before implementation (2 conformance, 4 schema, 2 createApp, 3 router — decode expiry/nbf/malformed-exp) plus fixture updates for the new boot requirement. Full suite: 720 tests green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Breaking change

Existing deployments running `validate=false` (with or without `OAUTH_JWT_VALIDATE`) will **refuse to boot** after upgrading until they either restore `validate=true` or explicitly set `oauth.jwt.allowInsecureDecode=true` / `OAUTH_JWT_ALLOW_INSECURE_DECODE=true`. The boot error message states exactly this. Decode-only deployments additionally start rejecting expired / not-yet-valid tokens. Call this out in the next release notes.