### PR TITLE
refactor(server): extract jwt/tokenAuthenticator; one guard for the config invariant

### DIFF
--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -131,7 +131,41 @@ describe("createApp", () => {
 				config: handBuilt,
 				modules: [testModule, builtinKeyResolversModule],
 			}),
-		).rejects.toThrow(/issuer and oauth\.jwt\.audience are required/);
+		).rejects.toThrow(/createApp: oauth\.jwt\.issuer is required/);
+	});
+
+	// The next two shapes slipped past the pre-#132 createApp check (a bare falsy
+	// test that accepted empty arrays and never looked at tokenType) and only
+	// failed one call later, inside the router. The shared guard now rejects
+	// them at this boundary, naming the oauth.jwt.* key the operator wrote.
+	it("throws when a hand-built config pins issuer to an empty array", async () => {
+		const handBuilt = {
+			...testConfig,
+			oauth: { jwt: { ...testConfig.oauth.jwt, issuer: [] } },
+		} as unknown as typeof testConfig;
+
+		await expect(
+			createApp({
+				pathResolver: (s: string) => s,
+				config: handBuilt,
+				modules: [testModule, builtinKeyResolversModule],
+			}),
+		).rejects.toThrow(/createApp: oauth\.jwt\.issuer is required/);
+	});
+
+	it("throws when a hand-built config omits tokenType", async () => {
+		const handBuilt = {
+			...testConfig,
+			oauth: { jwt: { ...testConfig.oauth.jwt, tokenType: undefined } },
+		} as unknown as typeof testConfig;
+
+		await expect(
+			createApp({
+				pathResolver: (s: string) => s,
+				config: handBuilt,
+				modules: [testModule, builtinKeyResolversModule],
+			}),
+		).rejects.toThrow(/createApp: oauth\.jwt\.tokenType is required/);
 	});
 
 	it("rejects a token minted for another audience end to end", async () => {

--- a/packages/server/src/__tests__/tokenAuthenticator.test.mts
+++ b/packages/server/src/__tests__/tokenAuthenticator.test.mts
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Unit tests for the construction-time JWT config guard (#132).
+ *
+ * The guard is the single runtime enforcement point for the two config
+ * invariants ("iss/aud/typ present when validating", "decode-only requires the
+ * explicit acknowledgment"). Before the extraction the same invariants were
+ * restated in three places, and the `createApp` copy had drifted: a bare falsy
+ * check that accepted `issuer: []` and `issuer: [""]` and never looked at
+ * `tokenType`. The drift cases are pinned here so the one guard can never
+ * regress to the weak form.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	assertVerifyRouterJwtConfig,
+	createTokenAuthenticator,
+	type VerifyRouterJwtConfig,
+} from "#/jwt/tokenAuthenticator.mjs";
+
+const VALID_VERIFYING = {
+	validate: true as const,
+	key: new TextEncoder().encode("test-secret"),
+	algorithms: ["HS256"],
+	issuer: "https://issuer.test",
+	audience: "https://api.test",
+	tokenType: "at+jwt",
+};
+
+describe("assertVerifyRouterJwtConfig — verifying configs (RFC 9068 §4 presence invariant)", () => {
+	it("accepts a complete verifying config", () => {
+		expect(() => assertVerifyRouterJwtConfig(VALID_VERIFYING)).not.toThrow();
+	});
+
+	it("accepts array-valued issuer and audience with non-empty entries", () => {
+		expect(() =>
+			assertVerifyRouterJwtConfig({
+				...VALID_VERIFYING,
+				issuer: ["https://issuer-a.test", "https://issuer-b.test"],
+				audience: ["https://api.test"],
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects a missing issuer", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, issuer: undefined })).toThrow(
+			/jwt\.issuer is required when jwt\.validate is true/,
+		);
+	});
+
+	it("rejects an empty-string issuer", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, issuer: "" })).toThrow(
+			/jwt\.issuer is required/,
+		);
+	});
+
+	// Drift case: the drifted createApp copy's bare `!issuer` check (now a call
+	// to this guard) accepted [] — an empty array is truthy, yet pins no issuer.
+	it("rejects an empty issuer array", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, issuer: [] })).toThrow(
+			/jwt\.issuer is required/,
+		);
+	});
+
+	// Drift case: [""] is a non-empty array, but its only entry pins nothing.
+	it("rejects an issuer array containing an empty string", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, issuer: [""] })).toThrow(
+			/jwt\.issuer is required/,
+		);
+	});
+
+	it("rejects a missing audience", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, audience: undefined })).toThrow(
+			/jwt\.audience is required when jwt\.validate is true/,
+		);
+	});
+
+	it("rejects an empty audience array and an audience array containing an empty string", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, audience: [] })).toThrow(
+			/jwt\.audience is required/,
+		);
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, audience: [""] })).toThrow(
+			/jwt\.audience is required/,
+		);
+	});
+
+	// Drift case: the drifted createApp copy never looked at tokenType, so a
+	// hand-built config could pin issuer and audience yet accept id_tokens.
+	it("rejects a missing tokenType", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, tokenType: undefined })).toThrow(
+			/jwt\.tokenType is required when jwt\.validate is true/,
+		);
+	});
+
+	it("rejects an empty-string tokenType", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, tokenType: "" })).toThrow(
+			/jwt\.tokenType is required/,
+		);
+	});
+});
+
+describe("assertVerifyRouterJwtConfig — decode-only configs (double opt-in, #106)", () => {
+	it("accepts validate=false with the explicit acknowledgment", () => {
+		expect(() =>
+			assertVerifyRouterJwtConfig({ validate: false, allowInsecureDecode: true }),
+		).not.toThrow();
+	});
+
+	it("rejects validate=false without the acknowledgment", () => {
+		expect(() => assertVerifyRouterJwtConfig({ validate: false })).toThrow(/allowInsecureDecode/);
+	});
+
+	it("rejects validate=false with a merely-truthy acknowledgment — it must be `true`", () => {
+		expect(() =>
+			assertVerifyRouterJwtConfig({
+				validate: false,
+				allowInsecureDecode: "yes" as unknown as boolean,
+			}),
+		).toThrow(/allowInsecureDecode/);
+	});
+});
+
+describe("assertVerifyRouterJwtConfig — caller-facing error context", () => {
+	it("names the caller and the caller's config path so operators find the field they wrote", () => {
+		expect(() =>
+			assertVerifyRouterJwtConfig(
+				{ ...VALID_VERIFYING, issuer: [] },
+				{ caller: "createApp", path: "oauth.jwt" },
+			),
+		).toThrow(/^createApp: oauth\.jwt\.issuer is required when oauth\.jwt\.validate is true/);
+	});
+
+	it("defaults to the authenticator's own boundary", () => {
+		expect(() => assertVerifyRouterJwtConfig({ ...VALID_VERIFYING, tokenType: undefined })).toThrow(
+			/^createTokenAuthenticator: jwt\.tokenType/,
+		);
+	});
+});
+
+describe("createTokenAuthenticator — construction and bearer parsing", () => {
+	const silentLogger = { warn() {}, error() {} };
+
+	it("runs the guard at construction, so a hand-built invalid config cannot produce an authenticator", () => {
+		expect(() =>
+			createTokenAuthenticator(
+				{ ...VALID_VERIFYING, issuer: [""] } as unknown as VerifyRouterJwtConfig,
+				silentLogger,
+			),
+		).toThrow(/jwt\.issuer is required/);
+		expect(() =>
+			createTokenAuthenticator(
+				{ validate: false } as unknown as VerifyRouterJwtConfig,
+				silentLogger,
+			),
+		).toThrow(/allowInsecureDecode/);
+	});
+
+	it("rejects an absent Authorization header as missing_token", async () => {
+		const authenticator = createTokenAuthenticator(VALID_VERIFYING, silentLogger);
+		const result = await authenticator.authenticate(undefined);
+		expect(result).toMatchObject({ ok: false, code: "missing_token" });
+	});
+
+	it("rejects a non-Bearer scheme as unsupported_scheme", async () => {
+		const authenticator = createTokenAuthenticator(VALID_VERIFYING, silentLogger);
+		const result = await authenticator.authenticate("Basic dXNlcjpwdw==");
+		expect(result).toMatchObject({ ok: false, code: "unsupported_scheme" });
+	});
+
+	it("rejects a Bearer header with no token as missing_token", async () => {
+		const authenticator = createTokenAuthenticator(VALID_VERIFYING, silentLogger);
+		const result = await authenticator.authenticate("Bearer ");
+		expect(result).toMatchObject({ ok: false, code: "missing_token" });
+	});
+});

--- a/packages/server/src/__tests__/verifyLogging.test.mts
+++ b/packages/server/src/__tests__/verifyLogging.test.mts
@@ -36,8 +36,8 @@ import express from "express";
 import { errors, SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
-import { HS256KeyResolverFactory } from "#/jwt/index.mjs";
-import { createVerifyRouter, type VerifyRouterJwtConfig } from "#/routes/verify.mjs";
+import { HS256KeyResolverFactory, type VerifyRouterJwtConfig } from "#/jwt/index.mjs";
+import { createVerifyRouter } from "#/routes/verify.mjs";
 
 const JWT_SECRET = "test-secret";
 const hs256Key = await HS256KeyResolverFactory({ secret: JWT_SECRET });

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -17,7 +17,11 @@ import {
 import { createHealthcheckRouter } from "@o3co/auth.utils/express";
 import express from "express";
 import type { AppConfig } from "./config/application.schema.mjs";
-import { createVerifyRouter, type VerifyRouterJwtConfig } from "./routes/verify.mjs";
+import {
+	assertVerifyRouterJwtConfig,
+	type VerifyRouterJwtConfig,
+} from "./jwt/tokenAuthenticator.mjs";
+import { createVerifyRouter } from "./routes/verify.mjs";
 
 /** Options accepted by `createApp`. */
 export interface CreateAppOptions {
@@ -94,17 +98,16 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 
 	// 6. Build the router's JWT config. When validate=false, decodeJwt is used instead
 	// of jwtVerify, so neither key material nor RFC 9068 claim checks apply.
+	// AppConfigSchema already enforces both invariants (iss/aud/typ presence,
+	// the decode-only double opt-in) for schema-validated configs; re-asserted
+	// here because createApp also accepts hand-built config objects that never
+	// went through the schema (#106) — with this boundary's field paths, so the
+	// operator is pointed at the oauth.jwt.* key they actually wrote.
+	assertVerifyRouterJwtConfig(config.oauth.jwt, { caller: "createApp", path: "oauth.jwt" });
 	let jwt: VerifyRouterJwtConfig;
 	if (config.oauth.jwt.validate) {
-		const keyResolver = await keyResolverRegistry.get(config.oauth.jwt.algorithm)(config.oauth.jwt);
 		const { issuer, audience, tokenType } = config.oauth.jwt;
-		// AppConfigSchema already requires these; re-checked here because createApp also
-		// accepts hand-built config objects that never went through the schema.
-		if (!issuer || !audience) {
-			throw new Error(
-				"createApp: oauth.jwt.issuer and oauth.jwt.audience are required when oauth.jwt.validate is true (RFC 9068 §4)",
-			);
-		}
+		const keyResolver = await keyResolverRegistry.get(config.oauth.jwt.algorithm)(config.oauth.jwt);
 		jwt = {
 			validate: true,
 			key: keyResolver.key,
@@ -114,14 +117,6 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 			tokenType,
 		};
 	} else {
-		// AppConfigSchema already requires the acknowledgment; re-checked here
-		// because createApp also accepts hand-built config objects that never
-		// went through the schema (#106).
-		if (!config.oauth.jwt.allowInsecureDecode) {
-			throw new Error(
-				"createApp: oauth.jwt.validate=false disables ALL token verification (test-only); set oauth.jwt.allowInsecureDecode=true to acknowledge, or restore validate=true",
-			);
-		}
 		jwt = { validate: false, allowInsecureDecode: true };
 		// error, not warn: a deployment that reaches this line accepts unsigned
 		// tokens, and a fleet filtering at level=error must still see it (#106).

--- a/packages/server/src/index.mts
+++ b/packages/server/src/index.mts
@@ -4,16 +4,17 @@
 export { type CreateAppOptions, createApp } from "./app.mjs";
 export { type AppConfig, AppConfigSchema } from "./config/application.schema.mjs";
 export {
+	type AssertedJwtConfig,
+	assertVerifyRouterJwtConfig,
 	builtinKeyResolversModule,
+	type DecodingJwtConfig,
 	EdDSAKeyResolverFactory,
 	ES256KeyResolverFactory,
 	HS256KeyResolverFactory,
+	type JwtConfigErrorContext,
 	RS256KeyResolverFactory,
-} from "./jwt/index.mjs";
-export {
-	createVerifyRouter,
-	type DecodingJwtConfig,
+	type UncheckedJwtConfig,
 	type VerifyingJwtConfig,
-	type VerifyRouterConfig,
 	type VerifyRouterJwtConfig,
-} from "./routes/verify.mjs";
+} from "./jwt/index.mjs";
+export { createVerifyRouter, type VerifyRouterConfig } from "./routes/verify.mjs";

--- a/packages/server/src/jwt/index.mts
+++ b/packages/server/src/jwt/index.mts
@@ -8,3 +8,15 @@ export {
 	HS256KeyResolverFactory,
 	RS256KeyResolverFactory,
 } from "./builtinKeyResolversModule.mjs";
+export {
+	type AssertedJwtConfig,
+	type AuthenticationResult,
+	assertVerifyRouterJwtConfig,
+	createTokenAuthenticator,
+	type DecodingJwtConfig,
+	type JwtConfigErrorContext,
+	type TokenAuthenticator,
+	type UncheckedJwtConfig,
+	type VerifyingJwtConfig,
+	type VerifyRouterJwtConfig,
+} from "./tokenAuthenticator.mjs";

--- a/packages/server/src/jwt/tokenAuthenticator.mts
+++ b/packages/server/src/jwt/tokenAuthenticator.mts
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Bearer-token authentication for the verify endpoints: the JWT config union,
+ * its construction-time invariants, and the request-time token checks.
+ *
+ * The verifying path (`jwtVerify`) and the decode-only path
+ * (`decodeJwt` + `assertTimeClaims`) are two halves of one contract and are
+ * deliberately co-located: the decode path restates by hand every request-time
+ * check that survives without key material (today: the time claims), so any
+ * validation option threaded to the verifying path must be weighed — and
+ * usually threaded — into the decode path as well. Keeping both paths in this
+ * one module is what keeps that coupling visible.
+ */
+
+import type { EventLogger, VerifierPayload } from "@o3co/auth.policy-verifier.core";
+import { decodeJwt, errors, type JWTPayload, jwtVerify } from "jose";
+
+/**
+ * JWT parameters used when signature validation is on. Every field a resource
+ * server must check per RFC 9068 §4 is required here, so a deployment cannot
+ * end up verifying the signature alone.
+ */
+export interface VerifyingJwtConfig {
+	validate: true;
+	// The `key` is produced by a KeyResolverFactory; its concrete type depends on
+	// the algorithm (e.g. KeyObject for HS256, JWTVerifyGetKey for JWKS, etc.).
+	// The authenticator narrows it via cast when calling jwtVerify.
+	key: unknown;
+	algorithms: string[];
+	/** Issuer(s) this deployment accepts. A token minted by anyone else is rejected. */
+	issuer: string | string[];
+	/** Audience identifying this resource server. A token minted for another service is rejected. */
+	audience: string | string[];
+	/**
+	 * Accepted `typ` header — `"at+jwt"` for RFC 9068 access tokens. An `application/`
+	 * prefix on either side is ignored when comparing. Pinning it is what keeps an
+	 * `id_token`, refresh token or logout token signed with the same key from passing.
+	 */
+	tokenType: string;
+}
+
+/**
+ * Test-only shape: the token is decoded, never signature-verified. Its `exp` /
+ * `nbf` claims are still enforced (#106). The acknowledgment is part of the
+ * shape — and re-checked at construction time — so wiring the router directly
+ * is not a way around the double opt-in `createApp` enforces.
+ */
+export interface DecodingJwtConfig {
+	validate: false;
+	allowInsecureDecode: true;
+}
+
+/** JWT half of `VerifyRouterConfig`, discriminated on `validate`. */
+export type VerifyRouterJwtConfig = VerifyingJwtConfig | DecodingJwtConfig;
+
+/**
+ * The invariant-carrying subset of a JWT config, deliberately loose:
+ * {@link assertVerifyRouterJwtConfig} exists precisely for objects whose static
+ * types cannot be trusted, so its input type must admit them.
+ */
+export interface UncheckedJwtConfig {
+	validate: boolean;
+	issuer?: string | string[];
+	audience?: string | string[];
+	tokenType?: string;
+	allowInsecureDecode?: boolean;
+}
+
+/**
+ * What {@link assertVerifyRouterJwtConfig} proves about the config it accepted.
+ * Intersecting rather than replacing the input type keeps whatever else the
+ * caller's config carries (key material, algorithm names).
+ */
+export type AssertedJwtConfig =
+	| { validate: true; issuer: string | string[]; audience: string | string[]; tokenType: string }
+	| { validate: false; allowInsecureDecode: true };
+
+/**
+ * Where a guard failure is reported from, for operator-facing error messages:
+ * the boundary the operator actually called and the config path as they wrote
+ * it (`createApp` sees the JWT block at `oauth.jwt`, the router at `jwt`).
+ */
+export interface JwtConfigErrorContext {
+	/** Boundary named in the message, e.g. `"createApp"`. */
+	caller: string;
+	/** Config path of the JWT block at that boundary, e.g. `"oauth.jwt"`. */
+	path: string;
+}
+
+/** True for a non-empty string or a non-empty array of non-empty strings. */
+function isPresent(value: string | string[] | undefined): boolean {
+	return Array.isArray(value)
+		? value.length > 0 && value.every((v) => typeof v === "string" && v !== "")
+		: typeof value === "string" && value !== "";
+}
+
+/**
+ * Construction-time guard for the two JWT config invariants. Fails fast rather
+ * than letting a misbuilt config accept tokens:
+ *
+ * 1. `issuer`, `audience` and `tokenType` must be present — a non-empty string
+ *    or a non-empty array of non-empty strings — whenever `validate` is true
+ *    (RFC 9068 §4): a deployment must never verify the signature alone.
+ * 2. `validate: false` requires the explicit `allowInsecureDecode: true`
+ *    acknowledgment (#106): one mistyped flag must never be enough to disable
+ *    all signature verification.
+ *
+ * Division of labor with `AppConfigSchema`: the schema's `superRefine` enforces
+ * the same invariants for schema-validated configs at config-parse time,
+ * reporting every issue at once with zod paths. This guard is the runtime
+ * enforcement for hand-built configs that never went through the schema — a
+ * JavaScript caller can reach `createApp` or `createVerifyRouter` with fields
+ * missing even though the TypeScript shapes require them. Both stay: the
+ * schema serves config files, the guard serves the API boundary.
+ */
+export function assertVerifyRouterJwtConfig<T extends UncheckedJwtConfig>(
+	jwt: T,
+	context: JwtConfigErrorContext = { caller: "createTokenAuthenticator", path: "jwt" },
+): asserts jwt is T & AssertedJwtConfig {
+	const { caller, path } = context;
+	if (jwt.validate) {
+		for (const field of ["issuer", "audience", "tokenType"] as const) {
+			if (!isPresent(jwt[field])) {
+				throw new Error(
+					`${caller}: ${path}.${field} is required when ${path}.validate is true (RFC 9068 §4)`,
+				);
+			}
+		}
+	} else if (jwt.allowInsecureDecode !== true) {
+		throw new Error(
+			`${caller}: ${path}.validate=false disables ALL signature verification (test-only); ` +
+				`set ${path}.allowInsecureDecode=true to acknowledge, or use a verifying config`,
+		);
+	}
+}
+
+/**
+ * True when token verification could not be attempted or completed for reasons
+ * unrelated to the presented token — the situation an operator must be able to
+ * tell apart from a bad token (#107: a JWKS outage flips the whole fleet to
+ * 401-deny while the verifier's own logs stay empty).
+ *
+ * Infrastructure side: a JWKS fetch timeout, a malformed JWKS document, a bare
+ * `JOSEError` (`ERR_JOSE_GENERIC` — jose reserves the base class for the JWKS
+ * fetch path: its only two throw sites are a non-200 JWKS response and a body
+ * that fails to parse as JSON), or any non-jose error escaping `jwtVerify`
+ * (fetch/DNS failures from the remote key getter, a broken key resolver).
+ * Every subclass jose throws about the token itself is judged token-side —
+ * deliberately including `JWKSNoMatchingKey`, because the `kid` that failed to
+ * match is attacker-controllable and must not open an error-level log-flooding
+ * channel; its `err.code` in the warn line still identifies a stale-JWKS
+ * rotation problem.
+ */
+export function isVerificationUnavailable(cause: unknown): boolean {
+	if (!(cause instanceof errors.JOSEError)) {
+		return true;
+	}
+	return (
+		cause instanceof errors.JWKSTimeout ||
+		cause instanceof errors.JWKSInvalid ||
+		cause.code === "ERR_JOSE_GENERIC"
+	);
+}
+
+/**
+ * `exp` / `nbf` checks for the decode-only path (#106). `decodeJwt` performs
+ * no validation at all, so the authenticator enforces the token's own lifetime
+ * with `jwtVerify`'s semantics and error classes: reject a numeric `exp` in
+ * the past or a numeric `nbf` in the future, reject a present non-numeric
+ * value for any time claim (`iat` included — `jwtVerify` type-checks it
+ * unconditionally), tolerate absence, zero clock tolerance. Skipping the
+ * signature is an (acknowledged, test-only) trust decision about the issuer;
+ * honouring an expired token is simply wrong in every mode.
+ */
+export function assertTimeClaims(payload: JWTPayload): void {
+	const now = Math.floor(Date.now() / 1000);
+	if (payload.iat !== undefined && typeof payload.iat !== "number") {
+		throw new errors.JWTClaimValidationFailed(
+			'"iat" claim must be a number',
+			payload,
+			"iat",
+			"invalid",
+		);
+	}
+	if (payload.nbf !== undefined) {
+		if (typeof payload.nbf !== "number") {
+			throw new errors.JWTClaimValidationFailed(
+				'"nbf" claim must be a number',
+				payload,
+				"nbf",
+				"invalid",
+			);
+		}
+		if (payload.nbf > now) {
+			throw new errors.JWTClaimValidationFailed(
+				'"nbf" claim timestamp check failed',
+				payload,
+				"nbf",
+				"check_failed",
+			);
+		}
+	}
+	if (payload.exp !== undefined) {
+		if (typeof payload.exp !== "number") {
+			throw new errors.JWTClaimValidationFailed(
+				'"exp" claim must be a number',
+				payload,
+				"exp",
+				"invalid",
+			);
+		}
+		if (payload.exp <= now) {
+			throw new errors.JWTExpired(
+				'"exp" claim timestamp check failed',
+				payload,
+				"exp",
+				"check_failed",
+			);
+		}
+	}
+}
+
+/**
+ * Outcome of authenticating a caller. On failure the authenticator names the
+ * machine-readable code and the caller-safe message; what HTTP status that
+ * maps to (401 for all of them today) is the route's concern, not this
+ * module's.
+ */
+export type AuthenticationResult =
+	| { ok: true; payload: VerifierPayload }
+	| { ok: false; code: "missing_token" | "unsupported_scheme" | "invalid_token"; message: string };
+
+/** Authenticates one `Authorization` header value into a verified payload. */
+export interface TokenAuthenticator {
+	authenticate(authorizationHeader: string | undefined): Promise<AuthenticationResult>;
+}
+
+/**
+ * Builds the bearer-token authenticator shared by the verify endpoints:
+ * extracts the bearer token and runs it down the path the config selects.
+ * Runs {@link assertVerifyRouterJwtConfig} first, so an invalid hand-built
+ * config fails at construction rather than accept tokens.
+ */
+export function createTokenAuthenticator(
+	jwt: VerifyRouterJwtConfig,
+	logger: EventLogger,
+): TokenAuthenticator {
+	assertVerifyRouterJwtConfig(jwt);
+
+	return {
+		async authenticate(authorizationHeader: string | undefined): Promise<AuthenticationResult> {
+			if (!authorizationHeader) {
+				return {
+					ok: false,
+					code: "missing_token",
+					message: "Authorization header is missing",
+				};
+			}
+
+			const authHeader = authorizationHeader.trim();
+			const spaceIndex = authHeader.indexOf(" ");
+			const scheme = spaceIndex > 0 ? authHeader.slice(0, spaceIndex) : authHeader;
+			const token = spaceIndex > 0 ? authHeader.slice(spaceIndex + 1).trim() : undefined;
+
+			if (scheme.toLowerCase() !== "bearer") {
+				return {
+					ok: false,
+					code: "unsupported_scheme",
+					message: `Unsupported authorization scheme: ${scheme}`,
+				};
+			}
+			if (!token) {
+				return {
+					ok: false,
+					code: "missing_token",
+					message: "Authorization header is missing",
+				};
+			}
+
+			let decoded: JWTPayload;
+			try {
+				// The coupled pair this module exists for: every validation option
+				// handed to jwtVerify below must be re-considered for the decode
+				// branch, which has to restate by hand whatever still applies
+				// without key material (see assertTimeClaims).
+				if (jwt.validate) {
+					// key is either a static key or a JWKS get-key function; both satisfy jwtVerify overloads
+					const result = await jwtVerify(token, jwt.key as Parameters<typeof jwtVerify>[1], {
+						algorithms: jwt.algorithms,
+						issuer: jwt.issuer,
+						audience: jwt.audience,
+						typ: jwt.tokenType,
+					});
+					decoded = result.payload;
+				} else {
+					decoded = decodeJwt(token);
+					assertTimeClaims(decoded);
+				}
+			} catch (cause) {
+				// Same invalid_token rejection either way — the caller is
+				// unauthenticated regardless — but the log line is what lets the
+				// operator tell a provider outage from a bad token.
+				if (isVerificationUnavailable(cause)) {
+					logger.error({ err: cause }, "jwt_verification_unavailable");
+				} else {
+					logger.warn({ err: cause }, "jwt_token_rejected");
+				}
+				return {
+					ok: false,
+					code: "invalid_token",
+					message: "Invalid token",
+				};
+			}
+
+			return { ok: true, payload: { ...decoded, token, tokenType: scheme } };
+		},
+	};
+}

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -14,46 +14,11 @@ import {
 	type VerifierPayload,
 } from "@o3co/auth.policy-verifier.core";
 import express from "express";
-import { decodeJwt, errors, type JWTPayload, jwtVerify } from "jose";
 import { DEFAULT_MAX_BATCH_SIZE } from "../config/defaults.mjs";
-
-/**
- * JWT parameters used when signature validation is on. Every field a resource
- * server must check per RFC 9068 §4 is required here, so a deployment cannot
- * end up verifying the signature alone.
- */
-export interface VerifyingJwtConfig {
-	validate: true;
-	// The `key` is produced by a KeyResolverFactory; its concrete type depends on
-	// the algorithm (e.g. KeyObject for HS256, JWTVerifyGetKey for JWKS, etc.).
-	// The route narrows it via cast when calling jwtVerify.
-	key: unknown;
-	algorithms: string[];
-	/** Issuer(s) this deployment accepts. A token minted by anyone else is rejected. */
-	issuer: string | string[];
-	/** Audience identifying this resource server. A token minted for another service is rejected. */
-	audience: string | string[];
-	/**
-	 * Accepted `typ` header — `"at+jwt"` for RFC 9068 access tokens. An `application/`
-	 * prefix on either side is ignored when comparing. Pinning it is what keeps an
-	 * `id_token`, refresh token or logout token signed with the same key from passing.
-	 */
-	tokenType: string;
-}
-
-/**
- * Test-only shape: the token is decoded, never signature-verified. Its `exp` /
- * `nbf` claims are still enforced (#106). The acknowledgment is part of the
- * shape — and re-checked at construction time — so wiring the router directly
- * is not a way around the double opt-in `createApp` enforces.
- */
-export interface DecodingJwtConfig {
-	validate: false;
-	allowInsecureDecode: true;
-}
-
-/** JWT half of `VerifyRouterConfig`, discriminated on `validate`. */
-export type VerifyRouterJwtConfig = VerifyingJwtConfig | DecodingJwtConfig;
+import {
+	createTokenAuthenticator,
+	type VerifyRouterJwtConfig,
+} from "../jwt/tokenAuthenticator.mjs";
 
 /** Config for `createVerifyRouter`. The `jwt.key` type is library-specific and is narrowed at call-time. */
 export interface VerifyRouterConfig {
@@ -108,13 +73,6 @@ export interface DecisionResponse {
 	reason: DecisionReason;
 }
 
-/** True for a non-empty string or a non-empty array of non-empty strings. */
-function isPresent(value: string | string[] | undefined): boolean {
-	return Array.isArray(value)
-		? value.length > 0 && value.every((v) => typeof v === "string" && v !== "")
-		: typeof value === "string" && value !== "";
-}
-
 /** Error envelope shared by every non-decision response. */
 interface ErrorBody {
 	decision: "deny";
@@ -127,97 +85,6 @@ const errorBody = (code: string, message: string): ErrorBody => ({
 	code,
 	message,
 });
-
-/** Outcome of authenticating the caller: either the verified payload or the response to send. */
-type Authentication =
-	| { ok: true; payload: VerifierPayload }
-	| { ok: false; status: number; body: ErrorBody };
-
-/**
- * True when token verification could not be attempted or completed for reasons
- * unrelated to the presented token — the situation an operator must be able to
- * tell apart from a bad token (#107: a JWKS outage flips the whole fleet to
- * 401-deny while the verifier's own logs stay empty).
- *
- * Infrastructure side: a JWKS fetch timeout, a malformed JWKS document, a bare
- * `JOSEError` (`ERR_JOSE_GENERIC` — jose reserves the base class for the JWKS
- * fetch path: its only two throw sites are a non-200 JWKS response and a body
- * that fails to parse as JSON), or any non-jose error escaping `jwtVerify`
- * (fetch/DNS failures from the remote key getter, a broken key resolver).
- * Every subclass jose throws about the token itself is judged token-side —
- * deliberately including `JWKSNoMatchingKey`, because the `kid` that failed to
- * match is attacker-controllable and must not open an error-level log-flooding
- * channel; its `err.code` in the warn line still identifies a stale-JWKS
- * rotation problem.
- */
-function isVerificationUnavailable(cause: unknown): boolean {
-	if (!(cause instanceof errors.JOSEError)) {
-		return true;
-	}
-	return (
-		cause instanceof errors.JWKSTimeout ||
-		cause instanceof errors.JWKSInvalid ||
-		cause.code === "ERR_JOSE_GENERIC"
-	);
-}
-
-/**
- * `exp` / `nbf` checks for the decode-only path (#106). `decodeJwt` performs
- * no validation at all, so the route enforces the token's own lifetime with
- * `jwtVerify`'s semantics and error classes: reject a numeric `exp` in the
- * past or a numeric `nbf` in the future, reject a present non-numeric value
- * for any time claim (`iat` included — `jwtVerify` type-checks it
- * unconditionally), tolerate absence, zero clock tolerance. Skipping the
- * signature is an (acknowledged, test-only) trust decision about the issuer;
- * honouring an expired token is simply wrong in every mode.
- */
-function assertTimeClaims(payload: JWTPayload): void {
-	const now = Math.floor(Date.now() / 1000);
-	if (payload.iat !== undefined && typeof payload.iat !== "number") {
-		throw new errors.JWTClaimValidationFailed(
-			'"iat" claim must be a number',
-			payload,
-			"iat",
-			"invalid",
-		);
-	}
-	if (payload.nbf !== undefined) {
-		if (typeof payload.nbf !== "number") {
-			throw new errors.JWTClaimValidationFailed(
-				'"nbf" claim must be a number',
-				payload,
-				"nbf",
-				"invalid",
-			);
-		}
-		if (payload.nbf > now) {
-			throw new errors.JWTClaimValidationFailed(
-				'"nbf" claim timestamp check failed',
-				payload,
-				"nbf",
-				"check_failed",
-			);
-		}
-	}
-	if (payload.exp !== undefined) {
-		if (typeof payload.exp !== "number") {
-			throw new errors.JWTClaimValidationFailed(
-				'"exp" claim must be a number',
-				payload,
-				"exp",
-				"invalid",
-			);
-		}
-		if (payload.exp <= now) {
-			throw new errors.JWTExpired(
-				'"exp" claim timestamp check failed',
-				payload,
-				"exp",
-				"check_failed",
-			);
-		}
-	}
-}
 
 /** Outcome of validating one decision request: either the parsed entry or the reason it is unusable. */
 type ParsedDecisionRequest = { ok: true; request: DecisionRequest } | { ok: false; error: string };
@@ -268,102 +135,11 @@ function parseDecisionRequest(raw: unknown, label: string): ParsedDecisionReques
  * 500 for anything unexpected.
  */
 export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
-	const jwt = config.jwt;
 	const maxBatchSize = config.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
 	const logger = config.logger ?? consoleLogger;
-
-	// Fail at construction rather than accept tokens with an unchecked iss/aud/typ.
-	// A JavaScript caller can reach here with the fields missing even though the
-	// TypeScript shape requires them.
-	if (jwt.validate) {
-		if (!isPresent(jwt.issuer)) {
-			throw new Error(
-				"createVerifyRouter: jwt.issuer is required when jwt.validate is true (RFC 9068 §4)",
-			);
-		}
-		if (!isPresent(jwt.audience)) {
-			throw new Error(
-				"createVerifyRouter: jwt.audience is required when jwt.validate is true (RFC 9068 §4)",
-			);
-		}
-		if (!isPresent(jwt.tokenType)) {
-			throw new Error(
-				"createVerifyRouter: jwt.tokenType is required when jwt.validate is true (RFC 9068 §4)",
-			);
-		}
-	} else if (jwt.allowInsecureDecode !== true) {
-		// The double opt-in (#106) holds at this API boundary too: a JavaScript
-		// caller can reach here without the acknowledgment even though the
-		// TypeScript shape requires it.
-		throw new Error(
-			"createVerifyRouter: jwt.validate=false disables ALL signature verification (test-only); set jwt.allowInsecureDecode=true to acknowledge, or use a verifying config",
-		);
-	}
-
-	/** Extracts and verifies the bearer token. Shared by both endpoints. */
-	async function authenticate(req: express.Request): Promise<Authentication> {
-		const rawAuthHeader = req.get("authorization");
-		if (!rawAuthHeader) {
-			return {
-				ok: false,
-				status: 401,
-				body: errorBody("missing_token", "Authorization header is missing"),
-			};
-		}
-
-		const authHeader = rawAuthHeader.trim();
-		const spaceIndex = authHeader.indexOf(" ");
-		const scheme = spaceIndex > 0 ? authHeader.slice(0, spaceIndex) : authHeader;
-		const token = spaceIndex > 0 ? authHeader.slice(spaceIndex + 1).trim() : undefined;
-
-		if (scheme.toLowerCase() !== "bearer") {
-			return {
-				ok: false,
-				status: 401,
-				body: errorBody("unsupported_scheme", `Unsupported authorization scheme: ${scheme}`),
-			};
-		}
-		if (!token) {
-			return {
-				ok: false,
-				status: 401,
-				body: errorBody("missing_token", "Authorization header is missing"),
-			};
-		}
-
-		let decoded: JWTPayload;
-		try {
-			if (jwt.validate) {
-				// key is either a static key or a JWKS get-key function; both satisfy jwtVerify overloads
-				const result = await jwtVerify(token, jwt.key as Parameters<typeof jwtVerify>[1], {
-					algorithms: jwt.algorithms,
-					issuer: jwt.issuer,
-					audience: jwt.audience,
-					typ: jwt.tokenType,
-				});
-				decoded = result.payload;
-			} else {
-				decoded = decodeJwt(token);
-				assertTimeClaims(decoded);
-			}
-		} catch (cause) {
-			// Same 401 either way — the caller is unauthenticated regardless — but
-			// the log line is what lets the operator tell a provider outage from a
-			// bad token.
-			if (isVerificationUnavailable(cause)) {
-				logger.error({ err: cause }, "jwt_verification_unavailable");
-			} else {
-				logger.warn({ err: cause }, "jwt_token_rejected");
-			}
-			return {
-				ok: false,
-				status: 401,
-				body: errorBody("invalid_token", "Invalid token"),
-			};
-		}
-
-		return { ok: true, payload: { ...decoded, token, tokenType: scheme } };
-	}
+	// Constructing the authenticator runs assertVerifyRouterJwtConfig, so an
+	// invalid hand-built jwt config still fails here, at router construction.
+	const authenticator = createTokenAuthenticator(config.jwt, logger);
 
 	/** Runs the pipelines and the evaluator for one entry. */
 	async function decide(
@@ -395,9 +171,9 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 
 	router.post("/verify", async (req: express.Request, res: express.Response) => {
 		try {
-			const auth = await authenticate(req);
+			const auth = await authenticator.authenticate(req.get("authorization"));
 			if (!auth.ok) {
-				res.status(auth.status).json(auth.body);
+				res.status(401).json(errorBody(auth.code, auth.message));
 				return;
 			}
 
@@ -417,9 +193,9 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 
 	router.post("/verify/batch", async (req: express.Request, res: express.Response) => {
 		try {
-			const auth = await authenticate(req);
+			const auth = await authenticator.authenticate(req.get("authorization"));
 			if (!auth.ok) {
-				res.status(auth.status).json(auth.body);
+				res.status(401).json(errorBody(auth.code, auth.message));
 				return;
 			}
 


### PR DESCRIPTION
## Summary

`packages/server/src/routes/verify.mts` (477 lines) hosted the whole JWT domain — config union types, construction-time validation, a jose error taxonomy, a hand-rolled shadow of `jwtVerify`'s time-claim semantics, bearer parsing — alongside the actual HTTP route. Meanwhile the invariant *iss/aud/typ must be present when validating* (and the decode-only double opt-in) was enforced in three divergent places, one of which (`createApp`) had drifted to a bare falsy check that accepted `issuer: []` / `issuer: [""]` and never looked at `tokenType`.

- **New `packages/server/src/jwt/tokenAuthenticator.mts`** — the config union (`VerifyingJwtConfig` / `DecodingJwtConfig` / `VerifyRouterJwtConfig`), the exported construction guard `assertVerifyRouterJwtConfig` (covers both the RFC 9068 §4 presence invariant and the #106 double opt-in), `createTokenAuthenticator` (bearer parsing + verify/decode paths), `assertTimeClaims`, `isVerificationUnavailable`. The design-rationale comments moved with their code (the `JWKSNoMatchingKey` threat-model classification, the forced shadow of jose's time-claim semantics). The verifying path and the decode path are deliberately co-located, with a module-header comment and a comment at the branch point stating the coupling: any validation option threaded to `jwtVerify` must be considered for the decode branch too.
- **`routes/verify.mts` returns to HTTP concerns** (now ~250 lines): `parseDecisionRequest`, `decide`, `toResponse`, the handlers, and the 401/400/403/500 mapping. The authenticator reports `{ code, message }`; the route owns the status codes. It takes the raw `Authorization` header value, so the jwt module no longer imports express.
- **`createApp`'s two weak copies are gone**, replaced by one call to the exported guard.
- The zod schema's `superRefine` stays; the guard's doc comment records the division of labor (schema = schema-validated config files at parse time, reporting all issues with zod paths; guard = hand-built configs at the API boundary).

## createApp-copy decision: replaced with a guard call (not deleted)

The decision criterion was operator error-message quality. Deleting the copies outright would have worked functionally (the router `createApp` unconditionally calls re-validates strictly via the authenticator), but a hand-built-config boot failure would then say `jwt.issuer is required…` from an internal boundary — while the operator's config spells the key `oauth.jwt.issuer`. It would also have emitted the `jwt_validation_disabled` error log before the router threw on an unacknowledged decode config. So the guard takes a `{ caller, path }` context and `createApp` calls it once with `{ caller: "createApp", path: "oauth.jwt" }`: one implementation of the invariant, and boot failures still name the exact key the operator wrote — now including the drift cases the old copy waved through (`issuer: []`, `[""]`, missing `tokenType`).

## Behavior notes

- Wire behavior, statuses, bodies, and log events are unchanged (integration conformance suites pass untouched).
- Construction-failure message *wording* changed, as anticipated in #132: per-field messages (`createApp: oauth.jwt.issuer is required when oauth.jwt.validate is true (RFC 9068 §4)`) instead of the old combined `…issuer and oauth.jwt.audience are required…`; direct `createVerifyRouter` misuse now reports the `createTokenAuthenticator:` prefix. One test asserting the old combined wording was updated accordingly.
- For doubly-invalid hand-built configs, the invariant check now runs before key-resolver resolution inside `createApp`, so the guard's message wins over e.g. `secret is required for HS256`. Either way boot fails with an accurate message.

## Tests

- New `__tests__/tokenAuthenticator.test.mts` (19 tests): the guard's drift cases (`issuer: []`, `issuer: [""]`, missing/empty `tokenType`), empty-string / empty-array issuer & audience, the double opt-in (including a merely-truthy acknowledgment), the caller/path error context, guard-at-construction for `createTokenAuthenticator`, and bearer-parsing outcomes.
- `app.test.mts` gains the two createApp-boundary drift cases (`issuer: []`, missing `tokenType`).
- `pnpm run lint` ✅ · `pnpm run build` ✅ · `pnpm -r --if-present run typecheck` ✅ · `pnpm run test` ✅ — all 6 workspaces (core 53, builtins 419, server 152, create-app 65, templates/standalone 22, tests/integration 33 incl. the token-expiry / token-validation / decision-contract conformance suites).

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)