### PR TITLE
fix(builtins)!: match scopes exactly instead of normalizing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ and version sections follow the release labeling policy in
 
 ### Changed
 
+- **BREAKING**: `HasScope` (`@o3co/auth.policy-verifier.builtins`) now matches
+  scopes exactly instead of normalizing them
+  ([#116](https://github.com/o3co/auth.policy-verifier/issues/116)). The old
+  matcher lowercased both sides, rewrote a bare granted scope to `read:<scope>`,
+  and destructured on `:` so that everything after the second segment was
+  dropped — each of which could satisfy a requirement the issuer never granted.
+  OAuth 2.0 scope values are case-sensitive opaque strings (RFC 6749 §3.3).
+  - **Case**: matching is now case-sensitive. `read:PROJECT` no longer satisfies
+    a `read:project` requirement (old: matched → new: denied).
+  - **Multi-colon**: a scope is no longer split at `:`. `read:project:restricted`
+    no longer satisfies `read:project` (old: matched, silently widening a
+    deliberately narrowed grant → new: denied), and `read:project:restricted`
+    now satisfies its own identical requirement (old: never matched, because the
+    granted value was truncated to `read:project` before comparison → new:
+    matched).
+  - **Bare-scope rewrite**: a granted scope containing no `:` is now compared
+    literally. It is no longer rewritten to `read:<scope>` unless the new
+    `allowBareScopeRewrite` option is explicitly enabled (default `false`).
+    Even when enabled, only a scope with no `:` is rewritten — a value such as
+    `project:restricted` is never re-interpreted.
+  - **Migration** — a deployment whose issuer emits bare resource names
+    (`project` rather than `read:project`) must opt back in, or every such token
+    starts being denied:
+    - HOCON: `{ collector = "ResourceActionScopeRuleCollector", allowBareScopeRewrite = true }`
+    - TypeScript: `new ResourceActionScopeRuleCollector({ allowBareScopeRewrite: true })`
+      or `new HasScope(scope, { allowBareScopeRewrite: true })`
+    - A deployment whose issuer emits `{action}:{resourceType}` scopes in the
+      exact case the policy requires needs no change.
+  - A non-string entry in `ATTR_SCOPES` now denies instead of throwing a
+    `TypeError` (which surfaced as a 500 rather than a decision).
 - **BREAKING**: the `reason` payload of `POST /verify` and `POST /verify/batch`
   responses (and the `RuleGroupOutcome` type in
   `@o3co/auth.policy-verifier.core`) now reports each rule group honestly

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -59,13 +59,15 @@ new HasPermission(permission: string)
 ### HasScope
 
 ```ts
-new HasScope(scope: string)
+new HasScope(scope: string, options?: { allowBareScopeRewrite?: boolean })
 ```
 
 - `ruleType`: `"scope"`、`code`: `"invalid_scope"`
 - `ATTR_SCOPES` を確認します。
-- `ATTR_SCOPES` 内のプレフィックスなし scope 文字列（例: `"resource"`）は、比較前に `"read:resource"` へ正規化されます。
-- 正規化後に大文字・小文字を区別しない完全一致で比較します。
+- 比較は**大文字・小文字を区別する完全一致**です。OAuth 2.0 の scope 値は大文字・小文字を区別する不透明な文字列であるため（[RFC 6749 §3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3)）、`read:PROJECT` は `read:project` を満たしません。
+- `:` を 2 つ以上含む scope はそれ自体が 1 つの値であり、2 つ目の `:` 以降が切り捨てられることはありません。`read:project:restricted` は `read:project` を満たさず（意図的に絞り込まれた grant が広い方へ吸収されてはならない）、`read:project` も `read:project:restricted` を満たしません。
+- `allowBareScopeRewrite`（既定 `false`）を有効にすると、プレフィックスなしの scope `"resource"` を、そのままの値に加えて `"read:resource"` としても扱います。書き換え対象は `:` を **1 つも含まない** scope のみで、`"project:restricted"` は書き換えません（どのセグメントが action かは判別不能であり、推測は過剰付与になるため）。issuer がプレフィックスなしのリソース名を発行する場合以外は無効のままにしてください。
+- `ATTR_SCOPES` 内の文字列以外の要素は、一致もせず例外も投げません。
 
 ### AttrMatchRule
 
@@ -185,10 +187,13 @@ new AttrPairCompare({ a: string, op: "lt" | "le" | "gt" | "ge", b: string, group
 | `ResourceActionScopeRuleCollector` | `"<action>:<resource.resourceType>"` | `[HasScope(...)]` |
 
 `ResourceActionPermissionRuleCollector` にコンストラクタ引数はありません。
-`ResourceActionScopeRuleCollector` は `{ scopeless?: "deny" | "skip" }` を受け取ります (既定は `"deny"`)。既定では
-リクエストごとに必ず `HasScope` ルールを生成するため、`scope` claim を持たないトークンはこのルールに落ちます。
-`"skip"` は scopeless トークンに対してルールを生成しませんが、ルールが 1 つも集まらないリクエストは deny されるため、
-別のルールグループが認可を担うパイプラインでのみ使ってください。
+`ResourceActionScopeRuleCollector` は `{ scopeless?: "deny" | "skip", allowBareScopeRewrite?: boolean }` を受け取ります。
+
+- `scopeless`（既定 `"deny"`）: 既定ではリクエストごとに必ず `HasScope` ルールを生成するため、`scope` claim を持たない
+  トークンはこのルールに落ちます。`"skip"` は scopeless トークンに対してルールを生成しませんが、ルールが 1 つも集まらない
+  リクエストは deny されるため、別のルールグループが認可を担うパイプラインでのみ使ってください。
+- `allowBareScopeRewrite`（既定 `false`）: [`HasScope`](#hasscope) へそのまま渡されます。issuer が `{action}:{resourceType}`
+  形式（`read:project`）ではなくプレフィックスなしのリソース名（`project`）を発行する場合にのみ `true` にしてください。
 
 ## Resource Parser
 

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -59,13 +59,15 @@ new HasPermission(permission: string)
 ### HasScope
 
 ```ts
-new HasScope(scope: string)
+new HasScope(scope: string, options?: { allowBareScopeRewrite?: boolean })
 ```
 
 - `ruleType`: `"scope"`, `code`: `"invalid_scope"`
 - Checks `ATTR_SCOPES`.
-- A bare scope string `"resource"` in `ATTR_SCOPES` is normalized to `"read:resource"` before comparison.
-- Matching is case-insensitive exact match after normalization.
+- Matching is **exact and case-sensitive**. OAuth 2.0 scope values are case-sensitive opaque strings ([RFC 6749 §3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3)), so `read:PROJECT` does not satisfy `read:project`.
+- A scope containing more than one `:` is a value in its own right — nothing is split off at the second `:`. `read:project:restricted` does not satisfy `read:project` (a deliberately narrowed grant must not collapse into the broader one), and `read:project` does not satisfy `read:project:restricted`.
+- `allowBareScopeRewrite` (default `false`) opts in to treating a bare granted scope `"resource"` as `"read:resource"` as well as literally. Only a scope with **no** `:` is ever rewritten; `"project:restricted"` is left alone, because which segment is the action is unknowable and guessing over-grants. Leave it off unless your issuer emits bare resource names.
+- Non-string entries in `ATTR_SCOPES` never match and never throw.
 
 ### AttrMatchRule
 
@@ -185,10 +187,13 @@ All attribute comparison rules follow the same grouping semantics described for 
 | `ResourceActionScopeRuleCollector` | `"<action>:<resource.resourceType>"` | `[HasScope(...)]` |
 
 `ResourceActionPermissionRuleCollector` takes no constructor arguments.
-`ResourceActionScopeRuleCollector` accepts `{ scopeless?: "deny" | "skip" }` (default `"deny"`): it emits the
-`HasScope` rule for every request, so a token carrying no `scope` claim fails it. `"skip"` emits no rule for a
-scopeless token — only use it in a pipeline where another rule group authorizes the request, since a request
-that collects no rule at all is denied.
+`ResourceActionScopeRuleCollector` accepts `{ scopeless?: "deny" | "skip", allowBareScopeRewrite?: boolean }`.
+
+- `scopeless` (default `"deny"`): it emits the `HasScope` rule for every request, so a token carrying no `scope`
+  claim fails it. `"skip"` emits no rule for a scopeless token — only use it in a pipeline where another rule
+  group authorizes the request, since a request that collects no rule at all is denied.
+- `allowBareScopeRewrite` (default `false`): forwarded to [`HasScope`](#hasscope). Set it to `true` only if your
+  issuer emits bare resource names (`project`) rather than `{action}:{resourceType}` scopes (`read:project`).
 
 ## Resource Parser
 

--- a/packages/builtins/src/__tests__/rules/HasScope.test.mts
+++ b/packages/builtins/src/__tests__/rules/HasScope.test.mts
@@ -5,50 +5,144 @@ import type { Attributes } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { HasScope } from "#/rules/HasScope.mjs";
 
+const withScopes = (...scopes: unknown[]): Attributes => new Map([["scopes", scopes]]);
+
 describe("HasScope", () => {
 	it("passes when scope matches exactly", () => {
 		const rule = new HasScope("read:user");
-		const attrs: Attributes = new Map([["scopes", ["read:user"]]]);
-		expect(rule.verify(attrs)).toBe(true);
+		expect(rule.verify(withScopes("read:user"))).toBe(true);
 	});
 
 	it("fails when scope does not match", () => {
 		const rule = new HasScope("write:user");
-		const attrs: Attributes = new Map([["scopes", ["read:user"]]]);
-		expect(rule.verify(attrs)).toBe(false);
+		expect(rule.verify(withScopes("read:user"))).toBe(false);
 	});
 
-	it("normalizes scope without action to read:{resource}", () => {
+	it("passes when one of several granted scopes matches", () => {
 		const rule = new HasScope("read:user");
-		const attrs: Attributes = new Map([["scopes", ["user"]]]);
-		expect(rule.verify(attrs)).toBe(true);
-	});
-
-	it("is case insensitive", () => {
-		const rule = new HasScope("READ:User");
-		const attrs: Attributes = new Map([["scopes", ["read:user"]]]);
-		expect(rule.verify(attrs)).toBe(true);
+		expect(rule.verify(withScopes("write:document", "read:user", "read:project"))).toBe(true);
 	});
 
 	it("fails when scopes are empty", () => {
 		const rule = new HasScope("read:user");
-		const attrs: Attributes = new Map([["scopes", []]]);
-		expect(rule.verify(attrs)).toBe(false);
+		expect(rule.verify(withScopes())).toBe(false);
 	});
 
 	it("fails when scopes key is missing", () => {
 		const rule = new HasScope("read:user");
-		const attrs: Attributes = new Map();
-		expect(rule.verify(attrs)).toBe(false);
+		expect(rule.verify(new Map())).toBe(false);
 	});
 
 	it("has ruleType 'scope'", () => {
-		const rule = new HasScope("read:user");
-		expect(rule.ruleType).toBe("scope");
+		expect(new HasScope("read:user").ruleType).toBe("scope");
 	});
 
 	it("has code 'invalid_scope'", () => {
-		const rule = new HasScope("read:user");
-		expect(rule.code).toBe("invalid_scope");
+		expect(new HasScope("read:user").code).toBe("invalid_scope");
+	});
+
+	// RFC 6749 §3.3 — scope values are case-sensitive, opaque strings. Folding
+	// case makes a differently-cased scope satisfy a requirement the issuer never
+	// granted, which silently over-grants.
+	describe("case sensitivity", () => {
+		it("rejects a granted scope that differs only by case", () => {
+			const rule = new HasScope("read:project");
+			expect(rule.verify(withScopes("read:PROJECT"))).toBe(false);
+		});
+
+		it("rejects a granted scope whose action differs only by case", () => {
+			const rule = new HasScope("read:project");
+			expect(rule.verify(withScopes("READ:project"))).toBe(false);
+		});
+
+		it("rejects a required scope that differs only by case from the granted one", () => {
+			const rule = new HasScope("READ:User");
+			expect(rule.verify(withScopes("read:user"))).toBe(false);
+		});
+
+		it("matches a mixed-case scope against an identically-cased requirement", () => {
+			const rule = new HasScope("read:Project");
+			expect(rule.verify(withScopes("read:Project"))).toBe(true);
+		});
+	});
+
+	// A scope carrying more than one ":" must never be split down to its first
+	// two segments: "read:project:restricted" is a narrower grant than
+	// "read:project" and collapsing it treats the narrow one as the broad one.
+	describe("multi-colon scopes", () => {
+		it("does not let a narrower multi-colon scope satisfy the broader requirement", () => {
+			const rule = new HasScope("read:project");
+			expect(rule.verify(withScopes("read:project:restricted"))).toBe(false);
+		});
+
+		it("does not let a broader scope satisfy a multi-colon requirement", () => {
+			const rule = new HasScope("read:project:restricted");
+			expect(rule.verify(withScopes("read:project"))).toBe(false);
+		});
+
+		it("matches a multi-colon scope against an identical requirement", () => {
+			const rule = new HasScope("read:project:restricted");
+			expect(rule.verify(withScopes("read:project:restricted"))).toBe(true);
+		});
+
+		it("does not match a multi-colon scope against a differently-ordered requirement", () => {
+			const rule = new HasScope("read:restricted:project");
+			expect(rule.verify(withScopes("read:project:restricted"))).toBe(false);
+		});
+	});
+
+	describe("bare-scope rewrite (opt-in)", () => {
+		it("does not rewrite a bare granted scope by default", () => {
+			const rule = new HasScope("read:user");
+			expect(rule.verify(withScopes("user"))).toBe(false);
+		});
+
+		it("does not rewrite a bare granted scope when explicitly disabled", () => {
+			const rule = new HasScope("read:user", { allowBareScopeRewrite: false });
+			expect(rule.verify(withScopes("user"))).toBe(false);
+		});
+
+		it("rewrites a bare granted scope to read:<scope> when opted in", () => {
+			const rule = new HasScope("read:user", { allowBareScopeRewrite: true });
+			expect(rule.verify(withScopes("user"))).toBe(true);
+		});
+
+		it("only ever rewrites to the read action when opted in", () => {
+			const rule = new HasScope("write:user", { allowBareScopeRewrite: true });
+			expect(rule.verify(withScopes("user"))).toBe(false);
+		});
+
+		it("stays case-sensitive when the rewrite is opted in", () => {
+			const rule = new HasScope("read:user", { allowBareScopeRewrite: true });
+			expect(rule.verify(withScopes("User"))).toBe(false);
+		});
+
+		it("never rewrites a granted scope that already contains a colon", () => {
+			// "project:restricted" must not be guessed into "read:project:restricted";
+			// which segment is the action is unknowable, and guessing over-grants.
+			const rule = new HasScope("read:project:restricted", { allowBareScopeRewrite: true });
+			expect(rule.verify(withScopes("project:restricted"))).toBe(false);
+		});
+
+		it("still matches exactly when the rewrite is opted in", () => {
+			const rule = new HasScope("read:user", { allowBareScopeRewrite: true });
+			expect(rule.verify(withScopes("read:user"))).toBe(true);
+		});
+	});
+
+	// ATTR_SCOPES is written by collectors into an untyped `Attributes` map. A
+	// project-side collector that writes a non-string must deny, not throw: a
+	// thrown TypeError surfaces as a 500 instead of a decision.
+	describe("malformed attribute values", () => {
+		it("ignores non-string entries instead of throwing", () => {
+			const rule = new HasScope("read:user");
+			expect(() => rule.verify(withScopes(42, null, undefined, { s: "read:user" }))).not.toThrow();
+			expect(rule.verify(withScopes(42, null, undefined, { s: "read:user" }))).toBe(false);
+		});
+
+		it("still finds a matching string among non-string entries", () => {
+			const rule = new HasScope("read:user");
+			expect(rule.verify(withScopes(42, "read:user"))).toBe(true);
+		});
 	});
 });

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
@@ -108,5 +108,18 @@ describe("ResourceActionScopeRuleCollector", () => {
 					} as unknown as { allowBareScopeRewrite: boolean }),
 			).toThrow(/allowBareScopeRewrite/);
 		});
+
+		it("rejects an explicit null allowBareScopeRewrite rather than treating it as unset", () => {
+			expect(
+				() =>
+					new ResourceActionScopeRuleCollector({
+						allowBareScopeRewrite: null,
+					} as unknown as { allowBareScopeRewrite: boolean }),
+			).toThrow(/allowBareScopeRewrite/);
+		});
+
+		it("accepts an omitted allowBareScopeRewrite", () => {
+			expect(() => new ResourceActionScopeRuleCollector({ scopeless: "deny" })).not.toThrow();
+		});
 	});
 });

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
@@ -81,4 +81,32 @@ describe("ResourceActionScopeRuleCollector", () => {
 		const rules = await collector.collect(makeContext("document", "read", ""));
 		expect(rules).toHaveLength(1);
 	});
+
+	describe("allowBareScopeRewrite", () => {
+		it("does not rewrite a bare granted scope by default", async () => {
+			const rules = await collector.collect(makeContext("document", "read", "document"));
+			expect(rules[0].verify(new Map([["scopes", ["document"]]]))).toBe(false);
+		});
+
+		it("passes the opt-in through to the HasScope rule", async () => {
+			const rewriting = new ResourceActionScopeRuleCollector({ allowBareScopeRewrite: true });
+			const rules = await rewriting.collect(makeContext("document", "read", "document"));
+			expect(rules[0].verify(new Map([["scopes", ["document"]]]))).toBe(true);
+		});
+
+		it("keeps matching case-sensitive when the rewrite is opted in", async () => {
+			const rewriting = new ResourceActionScopeRuleCollector({ allowBareScopeRewrite: true });
+			const rules = await rewriting.collect(makeContext("document", "read", "Document"));
+			expect(rules[0].verify(new Map([["scopes", ["Document"]]]))).toBe(false);
+		});
+
+		it("rejects a non-boolean allowBareScopeRewrite at construction time", () => {
+			expect(
+				() =>
+					new ResourceActionScopeRuleCollector({
+						allowBareScopeRewrite: "yes",
+					} as unknown as { allowBareScopeRewrite: boolean }),
+			).toThrow(/allowBareScopeRewrite/);
+		});
+	});
 });

--- a/packages/builtins/src/index.mts
+++ b/packages/builtins/src/index.mts
@@ -36,4 +36,4 @@ export {
 	type ScopelessPolicy,
 } from "./rules/collectors/ResourceActionScopeRuleCollector.mjs";
 export { HasPermission } from "./rules/HasPermission.mjs";
-export { HasScope } from "./rules/HasScope.mjs";
+export { HasScope, type HasScopeOptions } from "./rules/HasScope.mjs";

--- a/packages/builtins/src/rules/HasScope.mts
+++ b/packages/builtins/src/rules/HasScope.mts
@@ -4,33 +4,78 @@
 import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 
+/** Options accepted by `HasScope`. */
+export interface HasScopeOptions {
+	/**
+	 * Opt in to treating a bare granted scope (one containing no `:`) as
+	 * `read:<scope>` in addition to its literal value. Defaults to `false`.
+	 *
+	 * This exists only for deployments whose issuer emits bare resource names
+	 * and that relied on the rewrite before it became opt-in. It is off by
+	 * default because the rewrite invents an action the issuer never wrote:
+	 * a token granted `project` is silently promoted to `read:project`.
+	 */
+	allowBareScopeRewrite?: boolean;
+}
+
 /**
- * Rule that passes when the token carries a scope matching the required
- * `perm:resource` form (case-insensitive). A granted scope written as a single
- * token (no `:`) is treated as `read:<token>`, matching OAuth2 conventions
- * where bare resource names imply read access.
+ * Rule that passes when the token carries the required scope.
+ *
+ * ## Matching
+ *
+ * Comparison is an **exact, case-sensitive string equality** against each value
+ * in `ATTR_SCOPES`. OAuth 2.0 scope values are case-sensitive opaque strings
+ * (RFC 6749 §3.3), so the verifier compares what the issuer wrote rather than a
+ * normalized form of it:
+ *
+ * - `read:PROJECT` does **not** satisfy a `read:project` requirement.
+ * - `read:project:restricted` is a value in its own right. It does not satisfy
+ *   `read:project`, and `read:project` does not satisfy it. Nothing is split
+ *   off at the second `:`; a scope the issuer deliberately narrowed must not
+ *   collapse into the broader one.
+ *
+ * ## Bare-scope rewrite
+ *
+ * A granted scope carrying no `:` is compared literally unless
+ * `{ allowBareScopeRewrite: true }` is passed, in which case it also matches
+ * `read:<scope>`. Even then, only a scope with **no** `:` is ever rewritten —
+ * a value such as `project:restricted` is left alone, because which of its
+ * segments is the action is unknowable and guessing would over-grant.
+ *
+ * Non-string entries in `ATTR_SCOPES` never match and never throw: the map is
+ * untyped, and a malformed value must produce a denial, not a crash.
  */
 export class HasScope implements Rule {
 	readonly ruleType = "scope";
 	readonly code = "invalid_scope";
 	readonly message: string;
 
-	constructor(private scope: string) {
+	private readonly allowBareScopeRewrite: boolean;
+
+	constructor(
+		private scope: string,
+		options?: HasScopeOptions,
+	) {
 		this.message = `Token does not have required scope: ${scope}`;
+		this.allowBareScopeRewrite = options?.allowBareScopeRewrite ?? false;
 	}
 
 	verify(attrs: Attributes): boolean {
-		const scopes = (attrs.get(ATTR_SCOPES) as string[] | undefined) ?? [];
-		return scopes.some((s) => this.matchScopes(s, this.scope));
+		const scopes = (attrs.get(ATTR_SCOPES) as unknown[] | undefined) ?? [];
+		if (!Array.isArray(scopes)) return false;
+		return scopes.some((s) => typeof s === "string" && this.matchScope(s, this.scope));
 	}
 
-	private matchScopes(scope: string, required: string): boolean {
-		scope = scope.toLowerCase();
-		required = required.toLowerCase();
+	private matchScope(granted: string, required: string): boolean {
+		if (granted === required) return true;
 
-		const parts = scope.split(":");
-		const [perm, resource] = parts.length === 1 ? ["read", parts[0]] : parts;
+		// The rewrite applies to bare scopes only. A granted scope that already
+		// contains ":" is never re-interpreted: splitting it to guess an action
+		// is what let "read:project:restricted" pass as "read:project".
+		if (this.allowBareScopeRewrite && !granted.includes(":")) {
+			return `read:${granted}` === required;
+		}
 
-		return required === `${perm}:${resource}`;
+		return false;
 	}
 }

--- a/packages/builtins/src/rules/HasScope.mts
+++ b/packages/builtins/src/rules/HasScope.mts
@@ -61,7 +61,7 @@ export class HasScope implements Rule {
 	}
 
 	verify(attrs: Attributes): boolean {
-		const scopes = (attrs.get(ATTR_SCOPES) as unknown[] | undefined) ?? [];
+		const scopes: unknown = attrs.get(ATTR_SCOPES);
 		if (!Array.isArray(scopes)) return false;
 		return scopes.some((s) => typeof s === "string" && this.matchScope(s, this.scope));
 	}

--- a/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
@@ -17,6 +17,12 @@ export interface ResourceActionScopeRuleCollectorConfig {
 	 * scope group out of AND-evaluation.
 	 */
 	scopeless?: ScopelessPolicy;
+	/**
+	 * Forwarded to `HasScope`. `false` (default) compares granted scopes
+	 * literally; `true` additionally treats a bare granted scope `x` as
+	 * `read:x`. See `HasScopeOptions.allowBareScopeRewrite`.
+	 */
+	allowBareScopeRewrite?: boolean;
 }
 
 /**
@@ -30,6 +36,13 @@ export interface ResourceActionScopeRuleCollectorConfig {
  * (other collectors, resource-owner policy, etc.). This collector enforces the
  * ceiling only: it produces a `HasScope` rule for the requested
  * `{action}:{resourceType}`, which must be satisfied by the token's scopes.
+ *
+ * ## Matching
+ *
+ * The emitted `HasScope` compares scopes exactly and case-sensitively. An
+ * issuer that emits bare resource names (`project` rather than `read:project`)
+ * must opt in with `{ allowBareScopeRewrite: true }`; without it a bare scope
+ * satisfies nothing of the `{action}:{resourceType}` form.
  *
  * ## Behavior for scopeless tokens
  *
@@ -51,6 +64,7 @@ export interface ResourceActionScopeRuleCollectorConfig {
  */
 export class ResourceActionScopeRuleCollector implements RuleCollector {
 	private readonly scopeless: ScopelessPolicy;
+	private readonly allowBareScopeRewrite: boolean;
 
 	constructor(config?: ResourceActionScopeRuleCollectorConfig) {
 		const scopeless = config?.scopeless ?? "deny";
@@ -60,6 +74,14 @@ export class ResourceActionScopeRuleCollector implements RuleCollector {
 			);
 		}
 		this.scopeless = scopeless;
+
+		const allowBareScopeRewrite = config?.allowBareScopeRewrite ?? false;
+		if (typeof allowBareScopeRewrite !== "boolean") {
+			throw new Error(
+				`ResourceActionScopeRuleCollector: allowBareScopeRewrite must be a boolean, got "${allowBareScopeRewrite}"`,
+			);
+		}
+		this.allowBareScopeRewrite = allowBareScopeRewrite;
 	}
 
 	async collect(context: CollectorContext): Promise<Rule[]> {
@@ -67,6 +89,6 @@ export class ResourceActionScopeRuleCollector implements RuleCollector {
 			return [];
 		}
 		const scope = `${context.action}:${context.resource.resourceType}`;
-		return [new HasScope(scope)];
+		return [new HasScope(scope, { allowBareScopeRewrite: this.allowBareScopeRewrite })];
 	}
 }

--- a/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
+++ b/packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts
@@ -75,13 +75,16 @@ export class ResourceActionScopeRuleCollector implements RuleCollector {
 		}
 		this.scopeless = scopeless;
 
-		const allowBareScopeRewrite = config?.allowBareScopeRewrite ?? false;
-		if (typeof allowBareScopeRewrite !== "boolean") {
+		// Validate the raw value before defaulting: `?? false` alone would treat an
+		// explicit `null` as "unset" and silently accept a misconfiguration. Only
+		// an absent key may fall back to the default.
+		const rawRewrite: unknown = config?.allowBareScopeRewrite;
+		if (rawRewrite !== undefined && typeof rawRewrite !== "boolean") {
 			throw new Error(
-				`ResourceActionScopeRuleCollector: allowBareScopeRewrite must be a boolean, got "${allowBareScopeRewrite}"`,
+				`ResourceActionScopeRuleCollector: allowBareScopeRewrite must be a boolean, got "${rawRewrite}"`,
 			);
 		}
-		this.allowBareScopeRewrite = allowBareScopeRewrite;
+		this.allowBareScopeRewrite = rawRewrite ?? false;
 	}
 
 	async collect(context: CollectorContext): Promise<Rule[]> {

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -59,6 +59,12 @@ rule {
   onEmptyRuleSet = "deny"
   onEmptyRuleSet = ${?RULE_ON_EMPTY_RULE_SET}
   collectors = [
+    # Scope matching is exact and case-sensitive (RFC 6749 §3.3): the token must
+    # carry "<action>:<resourceType>" verbatim. If your issuer emits bare resource
+    # names ("document") instead ("read:document"), opt into the rewrite
+    # explicitly — it is off by default because it invents an action the issuer
+    # never wrote:
+    #   { collector = "ResourceActionScopeRuleCollector", allowBareScopeRewrite = true }
     { collector = "ResourceActionScopeRuleCollector" }
     { collector = "ResourceActionPermissionRuleCollector" }
   ]

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -159,6 +159,71 @@ describe("standalone smoke", () => {
 		expect(res.body.decisions[0].subject).toBe("user-1");
 	});
 
+	it("POST /verify with a differently-cased scope returns 403 (deny)", async () => {
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: baseConfig,
+			modules: [builtinCollectorsModule, builtinKeyResolversModule],
+		});
+
+		// Scope values are case-sensitive opaque strings (RFC 6749 §3.3), so
+		// "read:DOCUMENT" must not satisfy the required "read:document".
+		const token = await signToken({ scope: "read:DOCUMENT" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "document", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+	});
+
+	it("POST /verify with a bare scope returns 403 unless the rewrite is opted into", async () => {
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: baseConfig,
+			modules: [builtinCollectorsModule, builtinKeyResolversModule],
+		});
+
+		// A bare "document" is not rewritten to "read:document" by default.
+		const token = await signToken({ scope: "document" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "document", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+	});
+
+	it("POST /verify allows a bare scope once allowBareScopeRewrite is configured", async () => {
+		// Proves the opt-in survives the config schema and reaches the collector,
+		// which is the only path a deployment has to re-enable the old rewrite.
+		const rewritingConfig = AppConfigSchema.parse({
+			oauth: { jwt: { secret: JWT_SECRET, validate: true, issuer: ISSUER, audience: AUDIENCE } },
+			attribute: { collectors: [{ collector: "PayloadScopeCollector" }] },
+			rule: {
+				collectors: [
+					{ collector: "ResourceActionScopeRuleCollector", allowBareScopeRewrite: true },
+				],
+			},
+		});
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: rewritingConfig,
+			modules: [builtinCollectorsModule, builtinKeyResolversModule],
+		});
+
+		const token = await signToken({ scope: "document" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "document", action: "read" });
+
+		expect(res.status).toBe(200);
+		expect(res.body.decision).toBe("allow");
+	});
+
 	it("POST /verify with insufficient scope returns 403 (deny)", async () => {
 		const app = await createApp({
 			pathResolver: (s: string) => s,

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -40,12 +40,21 @@ async function signToken(payload: Record<string, unknown>): Promise<string> {
 		.sign(secretKey);
 }
 
+// Shared by every config below so a change to the jwt wire keys has one place
+// to land rather than drifting between the base config and the variants.
+const JWT_CONFIG = {
+	secret: JWT_SECRET,
+	mode: "verify",
+	issuer: ISSUER,
+	audience: AUDIENCE,
+} as const;
+
 // Config mirrors the structure of application.conf, using the same builtin registry keys.
 // PayloadScopeCollector extracts scopes from the JWT "scope" claim.
 // ResourceActionScopeRuleCollector requires scope "<action>:<resourceType>" to be present.
 // DotNotationResourceParser is the default and matches the omitted resource.parser in application.conf.
 const baseConfig = AppConfigSchema.parse({
-	oauth: { jwt: { secret: JWT_SECRET, mode: "verify", issuer: ISSUER, audience: AUDIENCE } },
+	oauth: { jwt: JWT_CONFIG },
 	attribute: {
 		collectors: [
 			{ collector: "PayloadScopeCollector" },
@@ -200,7 +209,7 @@ describe("standalone smoke", () => {
 		// Proves the opt-in survives the config schema and reaches the collector,
 		// which is the only path a deployment has to re-enable the old rewrite.
 		const rewritingConfig = AppConfigSchema.parse({
-			oauth: { jwt: { secret: JWT_SECRET, validate: true, issuer: ISSUER, audience: AUDIENCE } },
+			oauth: { jwt: JWT_CONFIG },
 			attribute: { collectors: [{ collector: "PayloadScopeCollector" }] },
 			rule: {
 				collectors: [


### PR DESCRIPTION
## Summary

`HasScope` did not compare scopes — it normalized them first, three different ways, and each normalization could satisfy a requirement the issuer never granted. OAuth 2.0 scope values are case-sensitive opaque strings ([RFC 6749 §3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3)), so the rule now compares what the issuer actually wrote.

**BREAKING** — pre-1.0 (0.x), taken deliberately to stabilize the matching semantics before 1.0.

## The three semantics changes

| | Old | New |
| --- | --- | --- |
| **Case** | `read:PROJECT` satisfied `read:project` (both sides lowercased) | Case-sensitive; `read:PROJECT` is denied |
| **Multi-colon** | `scope.split(":")` destructured to two parts, dropping the rest: `read:project:restricted` satisfied `read:project` — a deliberately narrowed grant collapsed into the broader one. The same truncation meant `read:project:restricted` never satisfied *its own* requirement either. | Never split. It matches only an identical value — so the over-grant is closed **and** the narrow scope now matches its own rule |
| **Bare scope** | A granted `project` was always rewritten to `read:project` | Compared literally; rewrite is opt-in |

## Opt-in flag

**`allowBareScopeRewrite`** — default `false`.

- HOCON: `{ collector = "ResourceActionScopeRuleCollector", allowBareScopeRewrite = true }`
- TypeScript: `new ResourceActionScopeRuleCollector({ allowBareScopeRewrite: true })`, or `new HasScope(scope, { allowBareScopeRewrite: true })`

Even when enabled, only a scope containing **no** `:` is rewritten. `project:restricted` is left alone — which segment is the action is unknowable, and guessing is exactly what caused the truncation over-grant. The collector validates the flag is a boolean at construction time, alongside the existing `scopeless` check.

Also: a non-string entry in `ATTR_SCOPES` now denies instead of throwing `TypeError: scope.toLowerCase is not a function`, which surfaced as a 500 rather than a decision.

## Effect on the shipped standalone config

`templates/standalone/config/application.conf` configures `ResourceActionScopeRuleCollector` with no options, so it picks up the new defaults. **What it grants narrows** for any deployment whose issuer emits bare resource names (`document`) or scopes cased differently from `{action}:{resourceType}` — those tokens now get denied and must set `allowBareScopeRewrite = true` (case differences have no opt-out and must be fixed at the issuer). A deployment whose issuer emits exact `read:document`-style scopes is unaffected. The config now carries a comment pointing at the opt-in.

Note this config is separately known to be broken by #113 (it enables `ResourceActionPermissionRuleCollector` with no permission supplier, so it denies everything as shipped). **This PR does not touch that** and does not fix or worsen it — the smoke tests here, like the existing ones, exercise a scope-only config.

## Tests

TDD per AGENTS.md — tests written first and watched fail. 13 unit tests failed against the old implementation (one per defect, including the `TypeError`), plus 2 of the 3 new smoke tests; the third guards the config-passthrough path.

- `HasScope.test.mts` — restructured into `case sensitivity`, `multi-colon scopes`, `bare-scope rewrite (opt-in)`, `malformed attribute values`
- `ResourceActionScopeRuleCollector.test.mts` — flag passthrough, default-off, boolean validation (incl. rejecting an explicit `null`)
- `smoke.test.mts` — end-to-end through `AppConfigSchema` → `createApp`, proving the opt-in survives config parsing (the only path a deployment has to re-enable the rewrite)

Full suite across every workspace, `pnpm lint`, and `pnpm -r run build` all green (rebased onto develop after #139):

```
create-app           65 passed
packages/core        59 passed
packages/builtins   441 passed  (+22)
packages/server     166 passed
templates/standalone 27 passed  (+3)
tests/integration    35 passed
                    793 passed, 0 failed
```

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
