### PR TITLE
fix(builtins,core,server)!: refuse ambiguous resource strings instead of repairing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,73 @@ and version sections follow the release labeling policy in
 
 ### Changed
 
+- **BREAKING**: `DotNotationResourceParser`
+  (`@o3co/auth.policy-verifier.builtins`) now validates a canonical grammar and
+  refuses what it used to repair
+  ([#117](https://github.com/o3co/auth.policy-verifier/issues/117)). The derived
+  `resourceType` is the authorization namespace —
+  `ResourceActionScopeRuleCollector` turns it into the `{action}:{resourceType}`
+  scope that must be granted — so two distinct resources that parsed to the same
+  type were authorized identically, and a caller could reach resource A through a
+  grant written for resource B. This is [#116](https://github.com/o3co/auth.policy-verifier/issues/116)'s
+  principle applied one layer earlier: stop silently rewriting authorization
+  identifiers, on the resource side as well as the scope side.
+
+  The accepted grammar:
+
+  ```text
+  resource = segment *( "." segment )
+  segment  = type [ ":" id ]
+  type     = 1*tchar
+  id       = 1*tchar
+  tchar    = %x21 / %x23-2D / %x2F-39 / %x3B-5B / %x5D-7E
+             ; RFC 6749 NQCHAR less "." and ":"
+             ; i.e. printable ASCII except space, `"`, `\`, "." and ":"
+  ```
+
+  - **Separator preserved**: `resourceType` is now the segment types joined with
+    `.` instead of `_`. `"project:1.member:2"` derives `project.member`, not
+    `project_member`. The old join collapsed the nested type `a.b` and the flat
+    type literally named `a_b` onto one string; `.` is now reserved as the
+    separator and cannot occur inside a type, so distinct type sequences produce
+    distinct types. `_` is an ordinary type character.
+  - **Empty segments refused**: `""`, `a..b`, `.a`, `a.`, `a:` and `:1` now
+    throw. `a..b` used to parse, landing in whatever namespace the empty types
+    produced.
+  - **Extra `:` components refused, not truncated**: `a:1:2` used to be read as
+    `a:1` with the tail silently dropped, widening a deliberately narrowed
+    identifier. It now throws.
+  - **Whitespace refused, not trimmed**: `"  project:1  "` and `"project : 1"`
+    now throw. Trimming made them one resource for scope rules while
+    `ResourceActionPermissionRuleCollector`, which reads `raw`, still saw two.
+  - Characters outside the grammar (non-ASCII, `"`, `\`, control characters) are
+    refused: a type that cannot appear in an OAuth scope value is a type no
+    issuer could grant.
+  - **Migration** — a deployment whose config or callers name resources whose
+    derived types collide under the old join must rename one side before
+    upgrading, because the two now authorize separately:
+    - Scope grants and policy referring to a nested type must be rewritten from
+      `<action>:a_b` to `<action>:a.b`. A grant of `read:project_member` no
+      longer authorizes the resource `project:1.member:2`; that resource now
+      requires `read:project.member`. A resource whose type is genuinely the
+      single flat segment `project_member` is unaffected.
+    - Resource strings sent by callers must be canonical: no surrounding or
+      inner whitespace, no empty segments, at most one `:` per segment. A caller
+      that was sending `"project : 1"` and relying on the trim must send
+      `"project:1"`.
+    - An id that needs `.` or `:` must be encoded (percent-encoding round-trips
+      through the grammar) or handled by a `ResourceParser` written for that
+      syntax.
+  - New `ResourceParseError` exported from `@o3co/auth.policy-verifier.core`,
+    carrying the refused string (`raw`) and the reason (`detail`). Any
+    `ResourceParser` should raise it for input outside its syntax.
+  - `POST /verify` and `POST /verify/batch` answer **400 `invalid_request`** for
+    a `resource` the parser refuses — the caller's syntax error, not a server
+    fault — instead of 500, and no longer log it as `verify_internal_error`, so
+    a client looping on a typo cannot manufacture an incident. The batch
+    endpoint validates every entry's resource before deciding any of them, and
+    names the offending index. Any other throw from a parser still surfaces as
+    500.
 - **BREAKING**: `HasScope` (`@o3co/auth.policy-verifier.builtins`) now matches
   scopes exactly instead of normalizing them
   ([#116](https://github.com/o3co/auth.policy-verifier/issues/116)). The old

--- a/README.ja.md
+++ b/README.ja.md
@@ -239,9 +239,20 @@ verify {
 
 ```text
 "project:1"               → resourceType: "project",         resourceId: "1"
-"project:1.member:2"      → resourceType: "project_member",  resourceId: "2"
-"project:1.member"        → resourceType: "project_member",  resourceId: undefined
+"project:1.member:2"      → resourceType: "project.member",  resourceId: "2"
+"project:1.member"        → resourceType: "project.member",  resourceId: undefined
+"project_member:2"        → resourceType: "project_member",  resourceId: "2"
 ```
+
+文法は `segment *( "." segment )`、`segment = type [ ":" id ]` で、type / id は RFC 6749 `NQCHAR` から
+`.` と `:` を除いた文字（空白・`"`・`\`・`.`・`:` を除く印字可能 ASCII）の 1 文字以上です。
+`resourceType` はセグメントの type を `.` で結合したもの — 区切り文字を保持するため、ネストした type `a.b` と
+`a_b` という名前のフラットな type は区別されたままになります。
+
+それ以外は修復せず `400 invalid_request` で拒否します: 空セグメント (`a..b`)、セグメント内の 2 つ目の `:`
+(`a:1:2` を `a:1` に切り詰めない)、前後および内部の空白 (`  a:1  ` を trim しない)。`resourceType` は
+scope ルールが使う認可の名前空間なので、不正な入力を推測して補完するパーサーは、別のリソース向けに
+発行された grant を呼び出し側に与えてしまいます。
 
 ## auth.provider との接続
 

--- a/README.md
+++ b/README.md
@@ -244,9 +244,20 @@ verify {
 
 ```text
 "project:1"               → resourceType: "project",         resourceId: "1"
-"project:1.member:2"      → resourceType: "project_member",  resourceId: "2"
-"project:1.member"        → resourceType: "project_member",  resourceId: undefined
+"project:1.member:2"      → resourceType: "project.member",  resourceId: "2"
+"project:1.member"        → resourceType: "project.member",  resourceId: undefined
+"project_member:2"        → resourceType: "project_member",  resourceId: "2"
 ```
+
+The grammar is `segment *( "." segment )` where `segment = type [ ":" id ]`, and a type or id is one
+or more characters of RFC 6749 `NQCHAR` less `.` and `:` (printable ASCII except space, `"`, `\`,
+`.` and `:`). `resourceType` is the segment types joined with `.` — the separator is preserved, so
+the nested type `a.b` and the flat type named `a_b` stay distinct.
+
+Anything else is refused with `400 invalid_request` rather than repaired: empty segments (`a..b`),
+a second `:` in a segment (`a:1:2` is not truncated to `a:1`), and surrounding or inner whitespace
+(`  a:1  ` is not trimmed). `resourceType` is the authorization namespace the scope rules use, so a
+parser that guessed at malformed input could hand a caller a grant written for a different resource.
 
 ## Connecting to auth.provider
 

--- a/packages/builtins/README.ja.md
+++ b/packages/builtins/README.ja.md
@@ -205,13 +205,46 @@ new AttrPairCompare({ a: string, op: "lt" | "le" | "gt" | "ge", b: string, group
 new DotNotationResourceParser()
 ```
 
-入力形式: `"<type>[:<id>].<type>[:<id>]..."`
+文法:
 
-例: `"foo.bar:123"` → `{ raw: "foo.bar:123", resourceType: "foo_bar", resourceId: "123" }`
+```text
+resource = segment *( "." segment )
+segment  = type [ ":" id ]
+type     = 1*tchar
+id       = 1*tchar
+tchar    = %x21 / %x23-2D / %x2F-39 / %x3B-5B / %x5D-7E
+           ; RFC 6749 NQCHAR から "." と ":" を除いたもの
+           ; すなわち、空白・`"`・`\`・`.`・`:` を除く印字可能 ASCII
+```
+
+例: `"foo.bar:123"` → `{ raw: "foo.bar:123", resourceType: "foo.bar", resourceId: "123" }`
 
 - セグメントは `.` で分割されます。各セグメントには `:id` を含めることができます。
-- `resourceType` はセグメントの type を `_` で結合した文字列です。
+- `resourceType` はセグメントの type を `.` で結合した文字列です。区切り文字は書き換えず、そのまま保持されます。
 - `resourceId` は最後のセグメントの id です（存在する場合）。
+- `raw` は入力そのままです。
+
+文法に合わない入力は `ResourceParseError`（`@o3co/auth.policy-verifier.core`）を送出します。パーサーが入力を
+修復することはありません。サーバーはそのリクエストを decision ではなく `400 invalid_request` として返します。
+拒否される例:
+
+| 入力 | 理由 |
+| --- | --- |
+| `""`, `a..b`, `.a`, `a.` | 空セグメント — すべてのセグメントに type が必要 |
+| `a:`, `:1` | type または id が空 |
+| `a:1:2` | セグメント内に `:` が 2 個以上 — 末尾を切り捨てず拒否する |
+| `  a:1  `, `a : 1` | 空白 — trim せず拒否する |
+| `プロジェクト`, `a"b`, `a\b` | OAuth scope 値が持てない文字 |
+
+`resourceType` は認可の名前空間です。`ResourceActionScopeRuleCollector` はこれを
+`{action}:{resourceType}` scope に変換し、その scope が付与されていることを要求します。つまり同じ type に
+パースされる 2 つの異なるリソースは同一に認可されてしまうため、そうならないように文法を設計しています。
+`.` を区切り文字として予約することで、ネストした type `a.b` と `a_b` という名前のフラットな type が
+区別されます（以前はどちらも `a_b` でした）。これは [`HasScope`](#hasscope) が scope 値に対して適用しているのと
+同じ原則です — 書かれたものをそのまま比較し、意図を正規化して推測しない。
+
+`.` や `:`、あるいは許可集合外の文字を必要とする id は、呼び出し側でエンコードする（percent-encoding は
+この文法をそのまま通ります）か、その構文向けに書かれた `ResourceParser` で扱ってください。
 
 ## builtinCollectorsModule
 

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -205,13 +205,48 @@ Parses a dot-notation string into a `Resource`.
 new DotNotationResourceParser()
 ```
 
-Input format: `"<type>[:<id>].<type>[:<id>]..."`
+Grammar:
 
-Example: `"foo.bar:123"` → `{ raw: "foo.bar:123", resourceType: "foo_bar", resourceId: "123" }`
+```text
+resource = segment *( "." segment )
+segment  = type [ ":" id ]
+type     = 1*tchar
+id       = 1*tchar
+tchar    = %x21 / %x23-2D / %x2F-39 / %x3B-5B / %x5D-7E
+           ; RFC 6749 NQCHAR less "." and ":"
+           ; i.e. printable ASCII except space, `"`, `\`, `.` and `:`
+```
+
+Example: `"foo.bar:123"` → `{ raw: "foo.bar:123", resourceType: "foo.bar", resourceId: "123" }`
 
 - Segments are split by `.`. Each segment may include `:id`.
-- `resourceType` is the segment types joined with `_`.
+- `resourceType` is the segment types joined with `.` — the separator is preserved, not rewritten.
 - `resourceId` is the id of the last segment, if present.
+- `raw` is the input verbatim.
+
+Anything the grammar does not accept raises `ResourceParseError`
+(from `@o3co/auth.policy-verifier.core`); the parser never repairs its input. The server answers
+such a request `400 invalid_request`, not a decision. Refused, among others:
+
+| Input | Why |
+| --- | --- |
+| `""`, `a..b`, `.a`, `a.` | an empty segment — every segment needs a type |
+| `a:`, `:1` | an empty type or id |
+| `a:1:2` | more than one `:` in a segment — the tail is refused, not truncated away |
+| `  a:1  `, `a : 1` | whitespace — it is refused, not trimmed |
+| `プロジェクト`, `a"b`, `a\b` | a character no OAuth scope value may carry |
+
+`resourceType` is the authorization namespace: `ResourceActionScopeRuleCollector` turns it into the
+`{action}:{resourceType}` scope that must be granted. Two distinct resources that parse to the same
+type are therefore authorized identically, so the grammar is built to make that impossible —
+`.` is reserved as the separator, which keeps the nested type `a.b` distinct from the flat type
+literally named `a_b` (both were `a_b` before). This is the same principle
+[`HasScope`](#hasscope) applies to scope values: compare what was written, never a normalized guess
+at what was meant.
+
+An id that needs `.`, `:` or a character outside the set must be encoded by the caller
+(percent-encoding round-trips through this grammar) or handled by a `ResourceParser` written for
+that syntax.
 
 ## builtinCollectorsModule
 

--- a/packages/builtins/src/__tests__/resource/DotNotationResourceParser.test.mts
+++ b/packages/builtins/src/__tests__/resource/DotNotationResourceParser.test.mts
@@ -1,43 +1,151 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ResourceParseError } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { DotNotationResourceParser } from "#/resource/DotNotationResourceParser.mjs";
 
 describe("DotNotationResourceParser", () => {
 	const parser = new DotNotationResourceParser();
 
-	it("parses simple type:id", () => {
-		const r = parser.parse("project:1");
-		expect(r.raw).toBe("project:1");
-		expect(r.resourceType).toBe("project");
-		expect(r.resourceId).toBe("1");
+	describe("accepted grammar", () => {
+		it("parses simple type:id", () => {
+			const r = parser.parse("project:1");
+			expect(r.raw).toBe("project:1");
+			expect(r.resourceType).toBe("project");
+			expect(r.resourceId).toBe("1");
+		});
+
+		it("parses type-only (no id)", () => {
+			const r = parser.parse("user");
+			expect(r.raw).toBe("user");
+			expect(r.resourceType).toBe("user");
+			expect(r.resourceId).toBeUndefined();
+		});
+
+		it("keeps the dot as the segment separator in the derived type", () => {
+			const r = parser.parse("project:1.member:2");
+			expect(r.raw).toBe("project:1.member:2");
+			expect(r.resourceType).toBe("project.member");
+			expect(r.resourceId).toBe("2");
+		});
+
+		it("parses nested type:id.type (last has no id)", () => {
+			const r = parser.parse("project:1.member");
+			expect(r.raw).toBe("project:1.member");
+			expect(r.resourceType).toBe("project.member");
+			expect(r.resourceId).toBeUndefined();
+		});
+
+		it("takes the id from the last segment only", () => {
+			expect(parser.parse("org:1.project:2.document:3").resourceId).toBe("3");
+			expect(parser.parse("org:1.project:2.document").resourceId).toBeUndefined();
+		});
+
+		it("treats _ as an ordinary type character, not a separator", () => {
+			const r = parser.parse("project_member:2");
+			expect(r.resourceType).toBe("project_member");
+			expect(r.resourceId).toBe("2");
+		});
+
+		it("accepts the punctuation an opaque id tends to carry", () => {
+			// A UUID, a slug and a percent-encoded value all stay intact.
+			expect(parser.parse("doc:3f1a-9c2e").resourceId).toBe("3f1a-9c2e");
+			expect(parser.parse("doc:a_b~c").resourceId).toBe("a_b~c");
+			expect(parser.parse("doc:did%3Aexample%3A123").resourceId).toBe("did%3Aexample%3A123");
+		});
+
+		it("returns raw verbatim", () => {
+			expect(parser.parse("Org:A.Project:B").raw).toBe("Org:A.Project:B");
+		});
+
+		it("is case-preserving, like the scope it derives", () => {
+			expect(parser.parse("Project:1").resourceType).toBe("Project");
+			expect(parser.parse("project:1").resourceType).toBe("project");
+		});
 	});
 
-	it("parses type-only (no id)", () => {
-		const r = parser.parse("user");
-		expect(r.raw).toBe("user");
-		expect(r.resourceType).toBe("user");
-		expect(r.resourceId).toBeUndefined();
+	describe("distinct resources never collide into one type", () => {
+		// The regression this grammar exists for: the derived resourceType is what
+		// scope rules authorize, so two distinct resource strings that produce the
+		// same type are authorized identically.
+		it("keeps a flat type named with _ apart from a nested type", () => {
+			expect(parser.parse("a.b").resourceType).toBe("a.b");
+			expect(parser.parse("a_b").resourceType).toBe("a_b");
+			expect(parser.parse("a.b").resourceType).not.toBe(parser.parse("a_b").resourceType);
+		});
+
+		it("maps every distinct type sequence to a distinct type string", () => {
+			const inputs = ["a.b", "a_b", "a.b.c", "a_b.c", "a.b_c", "a_b_c", "a", "a-b", "a.b.c.d"];
+			const types = inputs.map((raw) => parser.parse(raw).resourceType);
+
+			// Under the old `_` join, "a.b"/"a_b", "a.b.c"/"a_b.c"/"a.b_c"/"a_b_c"
+			// all collapsed onto one string. The join character is now reserved.
+			expect(new Set(types).size).toBe(inputs.length);
+		});
+
+		it("derives the type from segment types only, never from ids", () => {
+			// Ids identify the instance; the type is what is authorized. Two
+			// instances of one type share a type — that is the point — but no id
+			// content can change which type a string lands in.
+			expect(parser.parse("project:1.member:2").resourceType).toBe("project.member");
+			expect(parser.parse("project:x_y.member:z").resourceType).toBe("project.member");
+		});
 	});
 
-	it("parses nested type:id.type:id", () => {
-		const r = parser.parse("project:1.member:2");
-		expect(r.raw).toBe("project:1.member:2");
-		expect(r.resourceType).toBe("project_member");
-		expect(r.resourceId).toBe("2");
-	});
+	describe("rejected input", () => {
+		const rejected: ReadonlyArray<readonly [string, string]> = [
+			["", "the empty string"],
+			["a..b", "an empty inner segment"],
+			[".a", "an empty leading segment"],
+			["a.", "an empty trailing segment"],
+			[".", "nothing but a separator"],
+			[":1", "an empty type"],
+			["a:1.:2", "an empty type in a later segment"],
+			["a:", "an empty id"],
+			["a:1.b:", "an empty id in the last segment"],
+			["a:1:2", "a second colon in one segment"],
+			["a:1:2:3", "several extra colons"],
+			["a.b:1:2", "an extra colon in a later segment"],
+			["  project:1  ", "surrounding whitespace"],
+			["project : 1", "whitespace around the colon"],
+			["project:1 . member:2", "whitespace around the separator"],
+			["project member", "an inner space"],
+			["project\t:1", "a tab"],
+			["project\n", "a newline"],
+			['a"b', "a double quote, which no OAuth scope value may carry"],
+			["a\\b", "a backslash, which no OAuth scope value may carry"],
+			["プロジェクト", "a non-ASCII type"],
+			["doc:é", "a non-ASCII id"],
+			["a\u0000b", "a NUL"],
+		];
 
-	it("parses nested type:id.type (last has no id)", () => {
-		const r = parser.parse("project:1.member");
-		expect(r.raw).toBe("project:1.member");
-		expect(r.resourceType).toBe("project_member");
-		expect(r.resourceId).toBeUndefined();
-	});
+		for (const [raw, why] of rejected) {
+			it(`refuses ${why}: ${JSON.stringify(raw)}`, () => {
+				expect(() => parser.parse(raw)).toThrow(ResourceParseError);
+			});
+		}
 
-	it("trims whitespace", () => {
-		const r = parser.parse("  project : 1 . member : 2  ");
-		expect(r.resourceType).toBe("project_member");
-		expect(r.resourceId).toBe("2");
+		it("refuses rather than truncating an extra colon component", () => {
+			// The old parser destructured on ":" and dropped everything past the
+			// second part, so "a:1:2" silently became the resource "a:1".
+			expect(() => parser.parse("a:1:2")).toThrow(ResourceParseError);
+		});
+
+		it("names the offending string verbatim on the error", () => {
+			try {
+				parser.parse("a..b");
+				expect.unreachable("expected a ResourceParseError");
+			} catch (error) {
+				expect(error).toBeInstanceOf(ResourceParseError);
+				expect((error as ResourceParseError).raw).toBe("a..b");
+				expect((error as ResourceParseError).message).toContain('"a..b"');
+			}
+		});
+
+		it("says which segment was at fault", () => {
+			expect(() => parser.parse("a.b..d")).toThrow(/segment 3/);
+			expect(() => parser.parse("a:1:2")).toThrow(/segment 1/);
+		});
 	});
 });

--- a/packages/builtins/src/resource/DotNotationResourceParser.mts
+++ b/packages/builtins/src/resource/DotNotationResourceParser.mts
@@ -2,26 +2,118 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Resource, ResourceParser } from "@o3co/auth.policy-verifier.core";
+import { ResourceParseError } from "@o3co/auth.policy-verifier.core";
+
+/**
+ * Characters a segment type or id may carry.
+ *
+ * The set is RFC 6749 §3.3 `NQCHAR` (`%x21 / %x23-5B / %x5D-7E` — printable
+ * ASCII minus space, `"` and `\`) less the two structural characters `.` and
+ * `:`. Anchoring it there is not arbitrary: `resourceType` is concatenated into
+ * the `{action}:{resourceType}` scope that `ResourceActionScopeRuleCollector`
+ * requires, so a type that cannot appear in a scope value is a type no issuer
+ * could ever grant.
+ */
+const SEGMENT_TOKEN = /^[\x21\x23-\x2D\x2F-\x39\x3B-\x5B\x5D-\x7E]+$/;
+
+/** One `type[:id]` segment after validation. */
+interface Segment {
+	type: string;
+	id?: string;
+}
 
 /**
  * Resource parser for dot-separated, colon-qualified identifiers such as
- * `"org:123.project:abc.document:42"`. Each dot segment is `type[:id]`; the
- * resulting `resourceType` concatenates all segment types with `_`, and
- * `resourceId` is the id of the last segment (if any).
+ * `"org:123.project:abc.document:42"`.
+ *
+ * ## Grammar
+ *
+ * ```text
+ * resource = segment *( "." segment )
+ * segment  = type [ ":" id ]
+ * type     = 1*tchar
+ * id       = 1*tchar
+ * tchar    = %x21 / %x23-2D / %x2F-39 / %x3B-5B / %x5D-7E
+ *            ; RFC 6749 NQCHAR less "." and ":"
+ * ```
+ *
+ * `resourceType` is the segment types joined with `.`; `resourceId` is the id
+ * of the last segment, if it has one. Anything the grammar does not accept
+ * raises a {@link ResourceParseError} — the parser never repairs its input.
+ *
+ * ## Why nothing is rewritten
+ *
+ * `resourceType` is the authorization namespace: scope rules authorize it, so
+ * two distinct resources that parse to the same type are authorized
+ * identically, and a caller can reach resource A through a grant written for
+ * resource B. Every rewrite the parser could perform is a way for that to
+ * happen, so it performs none:
+ *
+ * - **The `.` separator is preserved.** Joining types with `_` collapsed the
+ *   nested type `a.b` and the flat type literally named `a_b` onto one string.
+ *   `.` is reserved as the separator and cannot occur inside a type, so the
+ *   sequence of types round-trips: distinct type sequences are distinct
+ *   `resourceType`s. `_` is now an ordinary type character.
+ * - **Empty segments are refused.** `a..b` used to parse, and every input with
+ *   a repeated `.` landed in whatever namespace the empty types produced.
+ * - **Extra `:` components are refused, not truncated.** `a:1:2` used to be
+ *   read as `a:1` with the tail silently dropped, so a deliberately narrowed
+ *   identifier widened into the broader one.
+ * - **Whitespace is refused, not trimmed.** Trimming made `project : 1` and
+ *   `project:1` one resource for scope rules while
+ *   `ResourceActionPermissionRuleCollector`, which reads `raw`, still saw two.
+ *
+ * This is the same principle `HasScope` applies to scope values: compare what
+ * was written, never a normalized guess at what was meant.
+ *
+ * An id that needs `.`, `:` or a character outside the set must be encoded by
+ * the caller (percent-encoding round-trips through this grammar) or handled by
+ * a `ResourceParser` written for that syntax.
  */
 export class DotNotationResourceParser implements ResourceParser {
 	parse(raw: string): Resource {
-		const segments = raw
-			.trim()
-			.split(".")
-			.map((part) => {
-				const [type, id] = part.split(":").map((s) => s.trim());
-				return { type, id: id || undefined };
-			});
+		const segments = raw.split(".").map((segment, index) => parseSegment(raw, segment, index + 1));
 
-		const resourceType = segments.map((s) => s.type).join("_");
-		const resourceId = segments[segments.length - 1].id;
+		return {
+			raw,
+			// Safe because `.` cannot occur inside a type: the join is injective
+			// over the sequence of types.
+			resourceType: segments.map((segment) => segment.type).join("."),
+			// `split` always yields at least one element, so there is a last segment.
+			resourceId: segments[segments.length - 1].id,
+		};
+	}
+}
 
-		return { raw, resourceType, resourceId };
+/** Validates one `type[:id]` segment, or explains why it is not one. */
+function parseSegment(raw: string, segment: string, position: number): Segment {
+	const parts = segment.split(":");
+	if (parts.length > 2) {
+		throw new ResourceParseError(
+			raw,
+			`segment ${position} has more than one ":"; a segment is "type" or "type:id"`,
+		);
+	}
+
+	const [type, id] = parts;
+	assertToken(raw, type, position, "type");
+	if (id !== undefined) {
+		assertToken(raw, id, position, "id");
+	}
+
+	return id === undefined ? { type } : { type, id };
+}
+
+/** Rejects an empty or out-of-grammar type/id, naming which part of which segment. */
+function assertToken(raw: string, value: string, position: number, part: "type" | "id"): void {
+	if (value === "") {
+		throw new ResourceParseError(raw, `segment ${position} has an empty ${part}`);
+	}
+	if (!SEGMENT_TOKEN.test(value)) {
+		throw new ResourceParseError(
+			raw,
+			`segment ${position} ${part} carries a character outside the allowed set ` +
+				`(printable ASCII except space, '"', "\\", "." and ":")`,
+		);
 	}
 }

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -97,7 +97,8 @@ interface ModuleContext {
 | 型 | 説明 |
 | --- | --- |
 | `Resource` | `{ raw: string; resourceType: string; resourceId?: string }` — パース済みリソース |
-| `ResourceParser` | `parse(raw: string): Resource` — 生のリソース文字列を `Resource` に変換する |
+| `ResourceParser` | `parse(raw: string): Resource` — 生のリソース文字列を `Resource` に変換する。パース対象の構文に合わない文字列には `ResourceParseError` を送出する |
+| `ResourceParseError` | `raw`（拒否した文字列）と `detail`（理由）を持つ `Error` サブクラス。サーバーエラーではなく**リクエスト**エラーであり、トランスポート層は 400 系で応答する。クラスとして export されるため `instanceof` で絞り込める |
 | `CollectorContext` | 各コレクターに渡される入力: `payload`、`resource`、`action`、省略可能な `headers` と `requestContext` |
 | `Attributes` | `Map<string, unknown>` — サブジェクト属性のバッグ |
 | `AttributeCollector` | `collect(context: CollectorContext): Promise<Attributes>` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -91,7 +91,8 @@ A module registers collector, parser, and key resolver factories into the provid
 | Type | Description |
 | --- | --- |
 | `Resource` | `{ raw: string; resourceType: string; resourceId?: string }` — parsed resource |
-| `ResourceParser` | `parse(raw: string): Resource` — converts a raw resource string into a `Resource` |
+| `ResourceParser` | `parse(raw: string): Resource` — converts a raw resource string into a `Resource`; throws `ResourceParseError` when the string is not in the syntax it parses |
+| `ResourceParseError` | `Error` subclass carrying `raw` (the refused string) and `detail` (why). A **request** error, not a server error — the transport layer answers it 400-class. Exported as a class, so `instanceof` narrows it |
 | `CollectorContext` | Input passed to every collector: `payload`, `resource`, `action`, optional `headers` and `requestContext` |
 | `Attributes` | `Map<string, unknown>` — subject attribute bag |
 | `AttributeCollector` | `collect(context: CollectorContext): Promise<Attributes>` |

--- a/packages/core/src/__tests__/errors.test.mts
+++ b/packages/core/src/__tests__/errors.test.mts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { ResourceParseError } from "../errors.mjs";
+
+describe("ResourceParseError", () => {
+	it("is an Error carrying the rejected string and the reason", () => {
+		const error = new ResourceParseError("a..b", "segment 2 is empty; every segment needs a type");
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("ResourceParseError");
+		expect(error.raw).toBe("a..b");
+		expect(error.detail).toBe("segment 2 is empty; every segment needs a type");
+	});
+
+	it("names both the rejected string and the reason in its message", () => {
+		const error = new ResourceParseError("a..b", "segment 2 is empty");
+
+		expect(error.message).toBe('Invalid resource string "a..b": segment 2 is empty');
+	});
+
+	it("is distinguishable from an unrelated error, so a caller can map it to a 400", () => {
+		expect(new ResourceParseError("x", "y")).toBeInstanceOf(ResourceParseError);
+		expect(new Error("boom")).not.toBeInstanceOf(ResourceParseError);
+	});
+});

--- a/packages/core/src/errors.mts
+++ b/packages/core/src/errors.mts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Raised by a {@link ResourceParser} when the resource string does not belong
+ * to the syntax it parses.
+ *
+ * A parser that cannot read its input has two options: guess, or refuse.
+ * Guessing is what makes distinct resources collide into one authorization
+ * namespace — the derived `resourceType` is what scope rules authorize, so a
+ * parser that silently repairs its input can hand a caller a grant that was
+ * written for a different resource. Refusing keeps the failure at the edge,
+ * where it is a malformed request rather than a wrong decision.
+ *
+ * This is a **request** error, not a server error: the transport layer should
+ * answer it as a 400-class response naming the offending string, the same as
+ * any other unusable field of the request body.
+ */
+export class ResourceParseError extends Error {
+	constructor(
+		/** The resource string that was refused, verbatim. */
+		readonly raw: string,
+		/** Why it was refused, phrased for the caller who sent it. */
+		readonly detail: string,
+	) {
+		super(`Invalid resource string "${raw}": ${detail}`);
+		this.name = "ResourceParseError";
+	}
+}

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { AttributePipeline } from "./AttributePipeline.mjs";
+export { ResourceParseError } from "./errors.mjs";
 export type { EvaluateOptions } from "./evaluate.mjs";
 export { evaluate } from "./evaluate.mjs";
 export {

--- a/packages/server/README.ja.md
+++ b/packages/server/README.ja.md
@@ -180,6 +180,21 @@ HTTP/1.1 403 Forbidden
 付きません）として明示されます。
 `code` / `message` は従来どおり最初に失敗したグループから取ります。
 
+**レスポンス — 不正なリクエスト**
+
+```http
+HTTP/1.1 400 Bad Request
+
+{ "decision": "deny", "code": "invalid_request", "message": "<message>" }
+```
+
+`resource` / `action` が欠落・空・文字列でない場合、`context` がオブジェクトでない場合、および `resource` が
+設定された `ResourceParser` に拒否される文字列だった場合に返します。後者はサーバー側の障害ではなく呼び出し側の
+構文エラーなので、500 ではなく 400 で応答し、`verify_internal_error` としてもログしません。
+`DotNotationResourceParser` では空セグメント (`a..b`)、セグメント内の 2 つ目の `:` (`a:1:2`)、空白 (`  a:1  `)
+が該当します。文法は [builtins README](../builtins/README.ja.md#dotnotationresourceparser) を参照してください。
+ボディの検証は decision の前に行われるため、ここで拒否されたリクエストは 1 件も評価されません。
+
 **レスポンス — 予期しないエラー**
 
 ```http
@@ -219,9 +234,10 @@ HTTP/1.1 200 OK
 
 エントリはリクエスト順で返り、それぞれ `POST /verify` が同じ入力に返すのと同じオブジェクトです。
 ステータスはバッチが**判定できたか**を表し、判定結果そのものではありません — 全件 deny でも `200` で、
-呼び出し側が各エントリを読みます。`decisions` が無い / 空 / `verify.maxBatchSize` 超過 / 不正なエントリを
-含む場合は `400 invalid_request`（メッセージが該当 index を示します）、トークンが検証できない場合は
-`401` でバッチ全体を拒否します。
+呼び出し側が各エントリを読みます。`decisions` が無い / 空 / `verify.maxBatchSize` 超過 / 不正なエントリ
+（`resource` がパーサーに拒否されたものを含む）を含む場合は `400 invalid_request`（メッセージが該当 index を
+示します）、トークンが検証できない場合は `401` でバッチ全体を拒否します。バッチは 1 件も判定する前に全件を
+検証するため、1 件の不正なエントリは部分的な回答ではなくリクエスト全体の拒否になります。
 
 ## 使い方
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -174,6 +174,22 @@ HTTP/1.1 403 Forbidden
 
 `reason.groups` lists every rule group in evaluation order — `passed`, plus `evaluated`: every rule that actually ran in that group, in order. A failing group ran (and lists) every alternative; a passing group stops at its first passing rule, so `evaluated` ends with it after any alternatives that were tried and failed, and `satisfiedBy` — present only on a passing group, absent on a failing one — names that deciding rule explicitly. `code` / `message` come from the first failing group, as before.
 
+**Response — malformed request**
+
+```http
+HTTP/1.1 400 Bad Request
+
+{ "decision": "deny", "code": "invalid_request", "message": "<message>" }
+```
+
+Returned when `resource` or `action` is missing, empty or not a string, when `context` is not an
+object, and when `resource` is a string the configured `ResourceParser` refuses — a syntax error in
+the caller's request, not a server fault, so it is answered 400 rather than 500 and is not logged as
+`verify_internal_error`. For `DotNotationResourceParser` that covers empty segments (`a..b`), a
+second `:` in a segment (`a:1:2`), and whitespace (`  a:1  `); see the
+[builtins README](../builtins/README.md#dotnotationresourceparser) for the grammar. The body is
+validated before any decision is made, so nothing is evaluated for a request that is refused here.
+
 **Response — unexpected error**
 
 ```http
@@ -211,7 +227,7 @@ HTTP/1.1 200 OK
 { "decisions": [ { ... }, { ... } ] }
 ```
 
-Entries come back in request order, each the same object `POST /verify` would have answered for it. The status reports whether the batch was **decided**, not what it decided — a batch of denials is still `200`, and the caller reads each entry. `400 invalid_request` when `decisions` is absent, empty, over `verify.maxBatchSize`, or carries a malformed entry (the message names the index); `401` rejects the whole batch when the token does not verify.
+Entries come back in request order, each the same object `POST /verify` would have answered for it. The status reports whether the batch was **decided**, not what it decided — a batch of denials is still `200`, and the caller reads each entry. `400 invalid_request` when `decisions` is absent, empty, over `verify.maxBatchSize`, or carries a malformed entry — including one whose `resource` the parser refuses — with the message naming the index; `401` rejects the whole batch when the token does not verify. The whole batch is validated before any of it is decided, so one bad entry refuses the request rather than yielding a partial answer.
 
 ## Usage Example
 

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -497,6 +497,66 @@ describe("POST /verify — request body validation (#18)", () => {
 	});
 });
 
+describe("POST /verify — resource the parser refuses (#117)", () => {
+	const app = createTestApp();
+
+	async function makeRequest(body: Record<string, unknown>) {
+		const token = await signHS256Token({ scope: "read:project" });
+		return request(app).post("/verify").set("Authorization", `Bearer ${token}`).send(body);
+	}
+
+	// A resource string outside the parser's grammar is a malformed request, the
+	// same class as a missing `action` — not a server fault. Answering 500 would
+	// both mislead the caller and page the operator over somebody's typo.
+	const refused = ["a..b", "a:1:2", ".project", "project.", "  project:1  ", "project : 1"];
+
+	for (const resource of refused) {
+		it(`returns 400 invalid_request for ${JSON.stringify(resource)}`, async () => {
+			const res = await makeRequest({ resource, action: "read" });
+
+			expect(res.status).toBe(400);
+			expect(res.body.code).toBe("invalid_request");
+			expect(res.body.decision).toBe("deny");
+		});
+	}
+
+	it("names the offending resource string in the message", async () => {
+		const res = await makeRequest({ resource: "a..b", action: "read" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.message).toContain("a..b");
+	});
+
+	it("still answers 500 when the parser fails for an unrelated reason", async () => {
+		// Only a ResourceParseError means "the caller's string is malformed".
+		// Any other throw is a bug in the parser and must stay a 500, not be
+		// re-labelled as the caller's fault.
+		const brokenParser: ResourceParser = {
+			parse() {
+				throw new Error("parser store exploded");
+			},
+		};
+		const brokenApp = createTestApp(brokenParser);
+		const token = await signHS256Token({ scope: "read:project" });
+
+		const res = await request(brokenApp)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(500);
+		expect(res.body.code).toBe("internal_error");
+	});
+
+	it("rejects an unauthenticated request before parsing the resource", async () => {
+		// 401 outranks 400: an anonymous caller learns nothing about the grammar.
+		const res = await request(app).post("/verify").send({ resource: "a..b", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("missing_token");
+	});
+});
+
 describe("POST /verify — RFC 9068 §4 token validation (#105)", () => {
 	const app = createTestApp();
 
@@ -954,5 +1014,26 @@ describe("POST /verify/batch (#124)", () => {
 
 		expect(res.status).toBe(401);
 		expect(res.body.code).toBe("invalid_token");
+	});
+
+	it("returns 400 naming the index whose resource the parser refuses (#117)", async () => {
+		const token = await signHS256Token({ sub: "user-1", scope: "read:project" });
+		const res = await request(app)
+			.post("/verify/batch")
+			.set("Authorization", `Bearer ${token}`)
+			.send({
+				decisions: [
+					{ resource: "project:1", action: "read" },
+					{ resource: "a..b", action: "read" },
+					{ resource: "project:3", action: "read" },
+				],
+			});
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+		expect(res.body.message).toContain("decisions[1]");
+		// The whole batch is refused before any of it is decided, exactly as for
+		// a structurally malformed entry — not a partial answer.
+		expect(res.body.decisions).toBeUndefined();
 	});
 });

--- a/packages/server/src/__tests__/verifyLogging.test.mts
+++ b/packages/server/src/__tests__/verifyLogging.test.mts
@@ -343,6 +343,24 @@ describe("verify router failure logging: default sink and quiet paths", () => {
 		expect(events).toHaveLength(0);
 	});
 
+	it("logs nothing when the parser refuses the caller's resource string (#117)", async () => {
+		// `verify_internal_error` is a page-the-operator event. A resource string
+		// outside the parser's grammar is the caller's mistake, answered 400, and
+		// must not enter that channel — otherwise a client looping on a typo
+		// manufactures an incident.
+		const { events, logger } = captureEvents();
+		const app = createTestApp({ logger });
+		const token = await signToken({ scope: "read:project" });
+
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "a..b", action: "read" });
+
+		expect(res.status).toBe(400);
+		expect(events).toHaveLength(0);
+	});
+
 	it("logs nothing for a request that never presented a token", async () => {
 		// Absent/garbled Authorization headers are plain client errors: no
 		// verification was attempted, so there is nothing to distinguish.

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -9,6 +9,8 @@ import {
 	type EvaluateOptions,
 	type EventLogger,
 	evaluate,
+	type Resource,
+	ResourceParseError,
 	type ResourceParser,
 	type RulePipeline,
 	type VerifierPayload,
@@ -86,14 +88,31 @@ const errorBody = (code: string, message: string): ErrorBody => ({
 	message,
 });
 
+/** One validated entry: the request as sent, plus its resource already parsed. */
+interface ValidatedDecisionRequest {
+	request: DecisionRequest;
+	resource: Resource;
+}
+
 /** Outcome of validating one decision request: either the parsed entry or the reason it is unusable. */
-type ParsedDecisionRequest = { ok: true; request: DecisionRequest } | { ok: false; error: string };
+type ParsedDecisionRequest =
+	| { ok: true; entry: ValidatedDecisionRequest }
+	| { ok: false; error: string };
 
 /**
  * Validates one entry of a decision request. Returns the entry or the reason it
  * is unusable, phrased with `label` so a batch can name the offending index.
+ *
+ * The resource string is parsed here rather than at decision time: a string the
+ * parser refuses is a malformed request, not a server fault, and it belongs
+ * with the other body validation so a batch names the offending index and no
+ * entry is decided before the whole batch is known to be usable.
  */
-function parseDecisionRequest(raw: unknown, label: string): ParsedDecisionRequest {
+function parseDecisionRequest(
+	raw: unknown,
+	label: string,
+	resourceParser: ResourceParser,
+): ParsedDecisionRequest {
 	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
 		return { ok: false, error: `${label} must be an object` };
 	}
@@ -112,9 +131,26 @@ function parseDecisionRequest(raw: unknown, label: string): ParsedDecisionReques
 	) {
 		return { ok: false, error: `${label}.context must be an object` };
 	}
+
+	let parsedResource: Resource;
+	try {
+		parsedResource = resourceParser.parse(resource);
+	} catch (cause) {
+		// Only a ResourceParseError means "the caller's string is malformed".
+		// Anything else is a fault in the parser and must keep surfacing as a 500.
+		if (!(cause instanceof ResourceParseError)) throw cause;
+		return {
+			ok: false,
+			error: `${label}.resource is not a valid resource string "${cause.raw}": ${cause.detail}`,
+		};
+	}
+
 	return {
 		ok: true,
-		request: { resource, action, context: context as Record<string, unknown> | undefined },
+		entry: {
+			request: { resource, action, context: context as Record<string, unknown> | undefined },
+			resource: parsedResource,
+		},
 	};
 }
 
@@ -131,8 +167,10 @@ function parseDecisionRequest(raw: unknown, label: string): ParsedDecisionReques
  * denials is still 200 — the caller reads each entry. Filtering a list of N
  * resources is one round trip rather than N.
  *
- * Both answer 400 for a malformed body, 401 for authentication failures, and
- * 500 for anything unexpected.
+ * Both answer 400 for a malformed body — including a `resource` the configured
+ * `ResourceParser` refuses, which is the caller's syntax error rather than a
+ * server fault — 401 for authentication failures, and 500 for anything
+ * unexpected.
  */
 export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	const maxBatchSize = config.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
@@ -141,13 +179,12 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	// invalid hand-built jwt config still fails here, at router construction.
 	const authenticator = createTokenAuthenticator(config.jwt, logger);
 
-	/** Runs the pipelines and the evaluator for one entry. */
+	/** Runs the pipelines and the evaluator for one already-validated entry. */
 	async function decide(
 		req: express.Request,
 		payload: VerifierPayload,
-		entry: DecisionRequest,
+		{ request: entry, resource }: ValidatedDecisionRequest,
 	): Promise<DecisionResponse> {
-		const resource = config.resourceParser.parse(entry.resource);
 		const requestId = req.get("x-request-id");
 		const headers = requestId ? { "x-request-id": requestId } : undefined;
 		const context = {
@@ -177,13 +214,13 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				return;
 			}
 
-			const parsed = parseDecisionRequest(req.body, "body");
+			const parsed = parseDecisionRequest(req.body, "body", config.resourceParser);
 			if (!parsed.ok) {
 				res.status(400).json(errorBody("invalid_request", parsed.error));
 				return;
 			}
 
-			const decision = await decide(req, auth.payload, parsed.request);
+			const decision = await decide(req, auth.payload, parsed.entry);
 			res.status(decision.decision === "deny" ? 403 : 200).json(decision);
 		} catch (cause) {
 			logger.error({ err: cause, endpoint: "/verify" }, "verify_internal_error");
@@ -218,14 +255,14 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 
 			// Validate the whole batch before deciding any of it: a caller that sent
 			// one malformed entry gets told which, rather than a partial answer.
-			const entries: DecisionRequest[] = [];
+			const entries: ValidatedDecisionRequest[] = [];
 			for (const [index, item] of raw.entries()) {
-				const parsed = parseDecisionRequest(item, `decisions[${index}]`);
+				const parsed = parseDecisionRequest(item, `decisions[${index}]`, config.resourceParser);
 				if (!parsed.ok) {
 					res.status(400).json(errorBody("invalid_request", parsed.error));
 					return;
 				}
-				entries.push(parsed.request);
+				entries.push(parsed.entry);
 			}
 
 			const decisions = await Promise.all(entries.map((entry) => decide(req, auth.payload, entry)));

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -55,7 +55,11 @@ OAUTH_JWT_SECRET=your-secret \
 - `ResourceActionScopeRuleCollector` — リソース/アクションをスコープルールと照合する
 - `ResourceActionPermissionRuleCollector` — リソース/アクションをパーミッションルールと照合する
 
-使用されるリソースパーサーは `DotNotationResourceParser` です。
+使用されるリソースパーサーは `DotNotationResourceParser` です。`segment *( "." segment )`
+（`segment = type [ ":" id ]`）を受け付け、セグメントの type を `.` で結合して `resourceType` を導出します
+— つまり `"project:1.member:2"` は type `project.member`、id `2` です。この文法から外れたリソース文字列
+（`a..b` のような空セグメント、`a:1:2` のような 2 つ目の `:`、前後の空白）は `400 invalid_request` になります。
+`resourceType` は scope ルールが認可する対象そのものなので、修復せず拒否します。
 
 ## カスタムモジュールの追加
 

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -55,7 +55,12 @@ The following collectors are registered via `builtinCollectorsModule`:
 - `ResourceActionScopeRuleCollector` — matches resource/action against scope rules
 - `ResourceActionPermissionRuleCollector` — matches resource/action against permission rules
 
-The resource parser in use is `DotNotationResourceParser`.
+The resource parser in use is `DotNotationResourceParser`. It accepts
+`segment *( "." segment )` where `segment = type [ ":" id ]`, and derives `resourceType` by joining
+the segment types with `.` — so `"project:1.member:2"` is type `project.member`, id `2`. A resource
+string outside that grammar (an empty segment such as `a..b`, a second `:` such as `a:1:2`, or
+surrounding whitespace) is answered `400 invalid_request`; it is refused rather than repaired,
+because `resourceType` is what the scope rules authorize.
 
 ## Adding Custom Modules
 

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -70,6 +70,23 @@ rule {
   ]
 }
 
+resource {
+  # How the request's `resource` string is turned into the resourceType that the
+  # scope rules above authorize. DotNotationResourceParser reads
+  # `type[:id]` segments separated by ".", and joins the segment types with "."
+  # — "project:1.member:2" is type "project.member", id "2". The separator is
+  # kept rather than rewritten to "_", so the nested type "a.b" and a flat type
+  # literally named "a_b" are two different namespaces.
+  #
+  # Strings outside that grammar are answered 400 invalid_request, never
+  # repaired: an empty segment ("a..b"), a second ":" in one segment ("a:1:2",
+  # which is refused rather than read as "a:1"), whitespace ("  a:1  " is not
+  # trimmed), and any character an OAuth scope value cannot carry. If your
+  # callers send resource strings in some other syntax, register your own
+  # ResourceParser rather than relying on this one to interpret them.
+  parser = "DotNotationResourceParser"
+}
+
 verify {
   # Cap on `POST /verify/batch` entries. The batch endpoint exists so filtering
   # a list of N resources costs one round trip instead of N; the cap keeps one


### PR DESCRIPTION
## Summary

`DotNotationResourceParser` derived `resourceType` by joining segment types with `_`, so the nested type `a.b` and the flat type literally named `a_b` collapsed onto one string. `resourceType` is the authorization namespace — `ResourceActionScopeRuleCollector` turns it into the `{action}:{resourceType}` scope that must be granted — so two distinct resources parsed to one type and were authorized identically: a caller could reach resource A through a grant written for resource B.

The parser now validates a canonical grammar and refuses what it used to repair. This is [#116](https://github.com/o3co/auth.policy-verifier/issues/116) / #140's principle applied one layer earlier: stop silently rewriting authorization identifiers, on the resource side as well as the scope side.

## The new grammar

```text
resource = segment *( "." segment )
segment  = type [ ":" id ]
type     = 1*tchar
id       = 1*tchar
tchar    = %x21 / %x23-2D / %x2F-39 / %x3B-5B / %x5D-7E
           ; RFC 6749 NQCHAR less "." and ":"
           ; i.e. printable ASCII except space, `"`, `\`, "." and ":"
```

`resourceType` is the segment types joined with `.`; `resourceId` is the id of the last segment; `raw` is the input verbatim. Anything else raises `ResourceParseError`.

The charset is anchored to RFC 6749 §3.3 `NQCHAR` on purpose rather than picked arbitrarily: `resourceType` is concatenated into the scope the collector requires, so a type that cannot appear in a scope value is a type no issuer could ever grant.

| Input | Before | Now |
|---|---|---|
| `project:1.member:2` | type `project_member` | type `project.member` |
| `project_member:2` | type `project_member` | type `project_member` |
| `a..b` | type `a__b`, parsed | refused |
| `a:1:2` | type `a`, id `1` (tail dropped) | refused |
| `  project : 1  ` | type `project`, id `1` | refused |
| `""` | type `""`, parsed | refused |

## Collision analysis

The old `_` join was not injective over the sequence of segment types, because `_` was both a legal type character and the join character. `a.b` (two segments) and `a_b` (one segment) are distinct resources with distinct meanings, and both produced `a_b`; so did every `a_b.c` / `a.b_c` / `a_b_c` family. A grant of `read:a_b` authorized all of them.

Preserving `.` fixes it at the source rather than papering over it: `.` is reserved as the separator and the grammar forbids it inside a type, so the join is injective — distinct type sequences give distinct `resourceType`s, and a type containing `_` is now unambiguously one flat segment. A test asserts this over a family of inputs that previously collapsed.

The other two rewrites were the same bug in smaller form. Truncating the extra `:` component made a deliberately narrowed identifier widen into the broader one — exactly what #140 removed from `HasScope`. Trimming whitespace made `project : 1` and `project:1` one resource for scope rules while `ResourceActionPermissionRuleCollector`, which reads `resource.raw`, still saw two — the same string authorized under two different namespaces depending on which collector looked at it.

### What the `_` rewrite was actually for

Verified before removing it: nothing downstream consumes the rewritten shape. `resourceType` has exactly one consumer, `ResourceActionScopeRuleCollector`, which interpolates it into `${action}:${resourceType}`; the permission collector reads `raw` instead. No test, config, or template referenced a `_`-joined type. The join existed only to flatten nested types into a scope-safe token, and `.` (0x2E) is a valid RFC 6749 `scope-token` character, so the derived scope stays well-formed without it. Nothing needed adjusting downstream.

## Refusal path

Refusal is signalled with a new `ResourceParseError` exported from `@o3co/auth.policy-verifier.core` (carrying `raw` and `detail`), which the verify router maps to **400 `invalid_request`** on both `/verify` and `/verify/batch`.

Parsing moved from decision time into request validation, alongside the existing body checks. That gives three properties: the batch names the offending index; the whole batch is refused before any of it is decided, rather than a partial answer; and a malformed resource is answered 400 instead of 500 and is **not** logged as `verify_internal_error` — a client looping on a typo must not manufacture an incident. Any other throw from a parser still surfaces as 500, so a genuine parser bug is not re-labelled as the caller's fault.

## Test results

TDD throughout: `ResourceParseError` (RED: module missing) → parser grammar (RED: 31 failing) → router 400 mapping (RED: 9 failing) → GREEN at each step.

```
create-app          65 passed
packages/core       62 passed  (+3 new: ResourceParseError)
packages/builtins  474 passed  (+33 new: grammar, collisions, refusals)
packages/server    177 passed  (+11 new: 400 mapping, batch index, quiet log)
templates/standalone 27 passed
tests/integration   35 passed
```

`pnpm lint` clean, `pnpm -r run build` clean.

## Judgment calls

- **Whitespace is refused rather than trimmed**, which goes one step past the issue's three bullets. It is the same class of defect — a silent rewrite that maps two distinct strings into one authorization namespace — and leaving it in would have kept `raw` and `resourceType` disagreeing about how many resources exist. Flagging it as the one scope decision worth a second opinion.
- **Extra `:` is refused rather than "definitively handled"** (the issue allowed either). Reading `a:1:2` as id `1:2` would also be unambiguous, but refusing keeps segments uniform and leaves the door open to widening later; widening a grammar is compatible, narrowing one is not. An id needing `.` or `:` can be percent-encoded — that round-trips through this grammar — or handled by a purpose-written `ResourceParser`.
- **`ResourceParseError` lives in core, not builtins**, because the verify router must recognize it to answer 400 and `packages/server` depends only on core. It is part of the transport-neutral `ResourceParser` contract, which fits the core vocabulary rule in AGENTS.md.
- **`templates/standalone/config/application.conf` gained an explicit `resource { parser = ... }` block.** It restates the existing default, but the grammar is now something an operator must know, and the config file is where they will look. Disjoint from #141, which touches only the `oauth.jwt` block of that file.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
