### PR TITLE
fix(ci): drop the core-only publish gate from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,24 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
+      # docs/release-policy.md R2/R6: a release is cut by renaming
+      # `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` and tagging that commit.
+      # Checked here, before anything is built or published, so a tag pushed at
+      # an unstamped CHANGELOG fails while it is still free to delete the tag.
+      - name: Verify tag and CHANGELOG
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          if ! printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::tag must be vX.Y.Z (optionally with a -prerelease suffix); got '${TAG}'"
+            exit 1
+          fi
+          if ! grep -qF -- "## [${VERSION}]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Per docs/release-policy.md R2, rename '## [Unreleased]' to '## [${VERSION}] - YYYY-MM-DD', commit, and tag that commit."
+            exit 1
+          fi
+
       - name: Get pnpm store path
         id: pnpm-store
         shell: bash
@@ -32,6 +50,10 @@ jobs:
           key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-store-
 
+      # Every workspace package carries the placeholder version `0.0.0`; the tag
+      # is the only source of the real one (AGENTS.md, Release Process). The
+      # private packages are stamped too, harmlessly — pnpm rewrites the
+      # `workspace:*` ranges between them to this exact version on publish.
       - name: Set version from tag
         run: pnpm -r exec pnpm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version --no-commit-hooks
 
@@ -46,27 +68,27 @@ jobs:
           draft: true
           generate_release_notes: true
 
-      - name: Check if already published
-        id: npm_check
-        shell: bash
-        run: |
-          PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
-          set +e
-          OUTPUT="$(npm view "@o3co/auth.policy-verifier.core@${PACKAGE_VERSION}" version 2>&1)"
-          STATUS=$?
-          set -e
-          if [ "$STATUS" -eq 0 ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif printf '%s\n' "$OUTPUT" | grep -qE 'E404|404 Not Found'; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "npm view failed unexpectedly:" >&2
-            printf '%s\n' "$OUTPUT" >&2
-            exit "$STATUS"
-          fi
-
+      # `pnpm -r publish` decides package by package: it asks the registry about
+      # each publishable workspace package and skips the ones already at this
+      # version. Rerunning a tag therefore republishes exactly the packages that
+      # are missing, which is what makes a half-finished publish recoverable —
+      # and is why there is deliberately no upfront "is this version already
+      # out?" gate in front of this step.
+      #
+      # The gate this replaces asked npm about one package
+      # (@o3co/auth.policy-verifier.core) and skipped the whole step when it
+      # answered. Publishing this workspace is four independent registry writes
+      # — .core, .builtins, .server and create-auth-policy-verifier — so if core
+      # landed and any of the other three failed (npm outage, per-package
+      # trusted-publisher drift), the gate turned every retag into a no-op and
+      # the missing packages could never be published at that version at all.
+      # auth.provider hit exactly this on its v0.5.0 cut (5 of 9 packages
+      # published, retag skipped the rest) and removed the gate for the same
+      # reason: o3co/auth.provider#111.
+      #
+      # templates/standalone and tests/integration are `private: true`, so pnpm
+      # never offers them to the registry.
       - name: Publish packages
-        if: steps.npm_check.outputs.skip != 'true'
         run: pnpm -r publish --access public --no-git-checks --provenance
 
       - name: Publish GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,44 @@ jobs:
       # Checked here, before anything is built or published, so a tag pushed at
       # an unstamped CHANGELOG fails while it is still free to delete the tag.
       - name: Verify tag and CHANGELOG
+        id: release
         shell: bash
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          VERSION="${TAG#v}"
-          if ! printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
-            echo "::error::tag must be vX.Y.Z (optionally with a -prerelease suffix); got '${TAG}'"
+
+          # SemVer 2.0.0 §2 (numeric identifiers carry no leading zeros) and §9
+          # (prerelease is dot-separated identifiers of [0-9A-Za-z-], so a hyphen
+          # inside one is legal: `1.2.3-rc-1` and `1.2.3-0.3.7` are valid).
+          CORE='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+          IDENT='(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
+          PRERELEASE="(-${IDENT}(\.${IDENT})*)?"
+
+          # §10 build metadata is valid SemVer but is refused for a *tag*, on
+          # purpose: npm ignores it when comparing versions, so `v1.2.3+a` and
+          # `v1.2.3+b` are one npm version and the second tag could only ever
+          # be a no-op republish — while the CHANGELOG heading and the
+          # `pnpm version` stamp would both carry a `+build` string that no
+          # consumer of the registry ever sees. Called out separately from the
+          # shape error so the reason reaches whoever pushed the tag.
+          if printf '%s' "$TAG" | grep -qE "^v${CORE}${PRERELEASE}\+"; then
+            echo "::error::tag '${TAG}' carries SemVer build metadata. npm ignores '+…' for version precedence, so it cannot distinguish two releases; drop it, or move the distinction into a prerelease identifier (v1.2.3-build.5)."
             exit 1
           fi
+          if ! printf '%s' "$TAG" | grep -qE "^v${CORE}${PRERELEASE}$"; then
+            echo "::error::tag must be 'v' + a SemVer version, e.g. v1.2.3 or v1.2.3-rc.1; got '${TAG}'"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
           if ! grep -qF -- "## [${VERSION}]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Per docs/release-policy.md R2, rename '## [Unreleased]' to '## [${VERSION}] - YYYY-MM-DD', commit, and tag that commit."
             exit 1
           fi
+
+          # The one place the tag is parsed. Later steps read this output
+          # instead of re-deriving the version from GITHUB_REF, so the tag
+          # grammar cannot drift between two copies of the same expression.
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Get pnpm store path
         id: pnpm-store
@@ -54,8 +80,14 @@ jobs:
       # is the only source of the real one (AGENTS.md, Release Process). The
       # private packages are stamped too, harmlessly — pnpm rewrites the
       # `workspace:*` ranges between them to this exact version on publish.
+      #
+      # The version comes from the step that validated the tag, not from a
+      # second `${GITHUB_REF#refs/tags/v}` here, and travels through env rather
+      # than being interpolated into the script body.
       - name: Set version from tag
-        run: pnpm -r exec pnpm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version --no-commit-hooks
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: pnpm -r exec pnpm version "$VERSION" --no-git-tag-version --no-commit-hooks
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,17 +72,20 @@ Releases are triggered by pushing a `v*` tag to GitHub. There is no manual publi
 
 ### Flow
 
-1. Create and push a version tag: `git tag v0.2.1 && git push origin v0.2.1`
-2. GitHub Actions (`release.yml`) is triggered by the `v*` tag push
-3. The workflow rewrites every package's `package.json` `version` to match the tag (via `pnpm -r exec pnpm version`), builds, typechecks, tests, then runs `pnpm -r publish --access public --provenance` across the monorepo
-4. A GitHub Release is published with auto-generated notes
+1. Cut the CHANGELOG: rename `## [Unreleased]` to `## [0.2.1] - YYYY-MM-DD` and commit (see `docs/release-policy.md` R2/R6 for the full pre-tag audit)
+2. Create and push a version tag on that commit: `git tag v0.2.1 && git push origin v0.2.1`
+3. GitHub Actions (`release.yml`) is triggered by the `v*` tag push
+4. The workflow checks the tag shape and that `CHANGELOG.md` has a section for it, rewrites every package's `package.json` `version` to match the tag (via `pnpm -r exec pnpm version`), builds, typechecks, tests, then runs `pnpm -r publish --access public --provenance` across the monorepo
+5. A GitHub Release is published with auto-generated notes
 
 ### Implications
 
 - **All packages share a single version** derived from the tag. Do not set per-package versions in `package.json` manually; the workflow overwrites them.
 - **`package.json` `version` is effectively a placeholder** (`0.0.0`). It exists because npm requires the field, but the real version comes from the tag at publish time.
-- **Idempotent re-runs:** if a given version already exists on npm, the workflow skips publishing and only (re)publishes the GitHub Release.
-- **Tag format must be `vX.Y.Z`** (leading `v`). The workflow strips the `v` prefix when computing the npm version.
+- **The published set is four packages**: `@o3co/auth.policy-verifier.core`, `.builtins`, `.server` and `@o3co/create-auth-policy-verifier`. `templates/standalone` and `tests/integration` are `private: true` and are stamped with the version but never published.
+- **Idempotent re-runs, per package:** `pnpm -r publish` skips each package that is already on the registry at this version and publishes the rest. Rerunning a tag after a publish that failed partway through therefore publishes exactly the packages that are missing — there is no whole-job "already published" short-circuit, and re-adding one would make a partial publish unrecoverable (see the comment in `release.yml`).
+- **The CHANGELOG must be cut before the tag.** The workflow refuses to publish a tag whose version has no `## [X.Y.Z]` section in `CHANGELOG.md`.
+- **Tag format must be `vX.Y.Z`** (leading `v`, optional `-prerelease` suffix). The workflow strips the `v` prefix when computing the npm version and rejects anything else.
 
 ### For Agents / Contributors
 
@@ -90,7 +93,8 @@ When asked to "release 0.2.1" or similar:
 
 1. Ensure all changes are merged to `main` (releases are cut from `main`, not feature branches)
 2. Verify the change set warrants the requested version bump (breaking change → major, feature → minor, fix → patch)
-3. Propose the tag command to the user; do not push tags without explicit user approval (tag push is irreversible from an npm-publish perspective once the workflow succeeds)
+3. Run the release-cut audit in `docs/release-policy.md` R6 and land the CHANGELOG rename (`## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`) first — the workflow refuses a tag whose version has no CHANGELOG section
+4. Propose the tag command to the user; do not push tags without explicit user approval (tag push is irreversible from an npm-publish perspective once the workflow succeeds)
 4. After the tag is pushed, watch the Actions run: `gh run watch` or `gh run list --workflow=release.yml`
 
 Do not edit `package.json` `version` fields as part of a release PR — the workflow handles versioning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Releases are triggered by pushing a `v*` tag to GitHub. There is no manual publi
 - **The published set is four packages**: `@o3co/auth.policy-verifier.core`, `.builtins`, `.server` and `@o3co/create-auth-policy-verifier`. `templates/standalone` and `tests/integration` are `private: true` and are stamped with the version but never published.
 - **Idempotent re-runs, per package:** `pnpm -r publish` skips each package that is already on the registry at this version and publishes the rest. Rerunning a tag after a publish that failed partway through therefore publishes exactly the packages that are missing — there is no whole-job "already published" short-circuit, and re-adding one would make a partial publish unrecoverable (see the comment in `release.yml`).
 - **The CHANGELOG must be cut before the tag.** The workflow refuses to publish a tag whose version has no `## [X.Y.Z]` section in `CHANGELOG.md`.
-- **Tag format must be `vX.Y.Z`** (leading `v`, optional `-prerelease` suffix). The workflow strips the `v` prefix when computing the npm version and rejects anything else.
+- **Tag format must be `v` + a SemVer 2.0.0 version**, prerelease identifiers included (`v1.2.3`, `v1.2.3-rc.1`, `v1.2.3-rc-1`, `v1.2.3-0.3.7`). SemVer build metadata (`v1.2.3+build.5`) is rejected on purpose: npm ignores it for version precedence, so two such tags are one npm version, and the CHANGELOG heading the tag must match would not be the version consumers see. The workflow strips the `v` when computing the npm version — that one parse is the only one, and the later steps consume its output rather than re-deriving it from `GITHUB_REF`.
 
 ### For Agents / Contributors
 
@@ -95,7 +95,7 @@ When asked to "release 0.2.1" or similar:
 2. Verify the change set warrants the requested version bump (breaking change → major, feature → minor, fix → patch)
 3. Run the release-cut audit in `docs/release-policy.md` R6 and land the CHANGELOG rename (`## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`) first — the workflow refuses a tag whose version has no CHANGELOG section
 4. Propose the tag command to the user; do not push tags without explicit user approval (tag push is irreversible from an npm-publish perspective once the workflow succeeds)
-4. After the tag is pushed, watch the Actions run: `gh run watch` or `gh run list --workflow=release.yml`
+5. After the tag is pushed, watch the Actions run: `gh run watch` or `gh run list --workflow=release.yml`
 
 Do not edit `package.json` `version` fields as part of a release PR — the workflow handles versioning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,3 +273,21 @@ and version sections follow the release labeling policy in
   `allowInsecureDecode: true`) is unchanged; only the wire config and the
   wire-to-internal mapping changed. Decode-only deployments still boot with the
   `jwt_validation_disabled` event logged at error level.
+
+- The release workflow no longer gates the whole publish on one package
+  ([#120](https://github.com/o3co/auth.policy-verifier/issues/120)). It used to
+  ask npm whether `@o3co/auth.policy-verifier.core` was already at the tag's
+  version and, if so, skip publishing entirely. Publishing this workspace is
+  four independent registry writes — `.core`, `.builtins`, `.server` and
+  `@o3co/create-auth-policy-verifier` — so a run that published core and then
+  failed on another package left that version half-released, and every retag
+  from then on hit the gate, did nothing, and never published the missing
+  packages. `pnpm -r publish` already skips per package what is already on the
+  registry, so the gate is now gone: rerunning a tag publishes exactly the
+  packages that are missing. `auth.provider` removed the same gate for the same
+  reason in [o3co/auth.provider#111](https://github.com/o3co/auth.provider/pull/111).
+
+  The workflow also now refuses a tag that is not `vX.Y.Z`, or whose version has
+  no `## [X.Y.Z]` section in this file, before it builds or publishes anything —
+  the CHANGELOG cut required by [`docs/release-policy.md`](docs/release-policy.md)
+  R2/R6 is now checked rather than assumed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,7 +287,11 @@ and version sections follow the release labeling policy in
   packages that are missing. `auth.provider` removed the same gate for the same
   reason in [o3co/auth.provider#111](https://github.com/o3co/auth.provider/pull/111).
 
-  The workflow also now refuses a tag that is not `vX.Y.Z`, or whose version has
-  no `## [X.Y.Z]` section in this file, before it builds or publishes anything —
-  the CHANGELOG cut required by [`docs/release-policy.md`](docs/release-policy.md)
-  R2/R6 is now checked rather than assumed.
+  The workflow also now refuses a tag that is not `v` + a SemVer version, or
+  whose version has no `## [X.Y.Z]` section in this file, before it builds or
+  publishes anything — the CHANGELOG cut required by
+  [`docs/release-policy.md`](docs/release-policy.md) R2/R6 is now checked rather
+  than assumed. Prerelease tags are accepted in full SemVer form
+  (`v1.2.3-rc.1`, `v1.2.3-rc-1`, `v1.2.3-0.3.7`); build metadata
+  (`v1.2.3+build.5`) is refused, because npm ignores `+…` when comparing
+  versions and two such tags would be one registry version.


### PR DESCRIPTION
Closes #120

## The trap

`release.yml` had a `Check if already published` step that ran `npm view @o3co/auth.policy-verifier.core@<tag version>` and set `skip=true` if it answered, gating the single `Publish packages` step on `skip != 'true'`.

Publishing this workspace is **four independent registry writes** — `@o3co/auth.policy-verifier.core`, `.builtins`, `.server` and `@o3co/create-auth-policy-verifier`. The gate treated one of them as a proxy for all four. If a run published core and then failed on any of the other three (npm outage, per-package trusted-publisher drift, a transient 5xx), that version was left half-released — and from then on every retag hit the gate, skipped the publish step entirely, and re-published only the GitHub Release. The missing packages could never be published at that version by the workflow at all; the only exits were a manual `npm publish` from a laptop (no provenance) or burning the version and cutting a new one.

## How the provider fixed it

`auth.provider` hit this for real on its `v0.5.0` cut: 5 of 9 packages published, 4 failed at npm 404 from trusted-publisher config drift on one package, and once that was fixed the retag hit the core-only short-circuit and never retried the 4 missing ones. o3co/auth.provider#111 deleted the gate outright rather than broadening it, on the grounds that `pnpm -r publish` already asks the registry per package and skips the ones that are on it. So the check was redundant on the happy path and fatal on the recovery path. Removing it gives:

- fresh tag → everything publishes
- retag with N of M already published → pnpm skips the N, publishes the M-N
- retag with everything published → pnpm skips everything, no error

## What was adapted here

- **Package count and names.** The provider's comment is written for its 9 packages; ours names the four this repo actually publishes and states why the check can't be "fixed" by querying more of them.
- **Private workspaces.** This repo has two (`templates/standalone`, `tests/integration`) that the provider's layout doesn't mirror; the comment records that pnpm never offers them to the registry, so "four writes" is the whole surface. Verified against `pnpm list -r --depth -1` rather than assumed.
- **`create-app` is outside `packages/*`.** `@o3co/create-auth-policy-verifier` lives at the repo root, so it is easy to overlook when reasoning about "the packages"; it is named explicitly in the comment and in AGENTS.md.

## Release-policy consistency (also in scope per #120's neighbours)

`docs/release-policy.md` R2/R6 says a release is cut by renaming `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD` and tagging *that* commit. The workflow assumed this rather than checking it. Added a `Verify tag and CHANGELOG` step that runs immediately after checkout — before any build, version stamp or publish — and fails if:

- the tag is not `vX.Y.Z` (an optional `-prerelease` suffix is allowed). The trigger is `tags: ['v*']`, so `v1.2` or `vfoo` used to reach `pnpm version` and fail late, after a build.
- `CHANGELOG.md` has no `## [X.Y.Z]` section for the tag.

Failing here is cheap: deleting and re-pushing a tag is free until something has been published under it.

AGENTS.md's Release Process section is updated to match — its "if a given version already exists on npm, the workflow skips publishing" bullet described exactly the behaviour being removed. It now describes the per-package skip, names the four published packages and two private ones, and puts the CHANGELOG cut ahead of the tag push in both the Flow and the agent checklist.

## Validation

Can't run a real release, so:

- **YAML parses** (`yaml.safe_load`); job graph re-inspected after the edit — 14 steps, no remaining `if:` conditions, publish is unconditional.
- **The guard step's script was extracted from the parsed YAML and executed** against CHANGELOG fixtures: `v0.2.1` with a matching section passes; `v0.3.0` without one fails with the R2 instructions; `v1.2`, `vfoo`, `vv0.2.1` and a bare `0.2.1` fail the tag-shape check; `v0.2.1-rc.1` passes once its section exists.
- **Publish surface confirmed** with `pnpm list -r --depth -1 --json`: 4 publishable, 3 private (root, standalone, integration-tests).
- **Every pnpm script the workflow calls exists**: `build`, `test` at the root; `pnpm -r exec pnpm version` and `pnpm -r publish` are pnpm builtins.
- `pnpm install --frozen-lockfile`, `pnpm run lint` (123 files, clean), `pnpm run build`, `pnpm run test` — all green (core 8 files, builtins 474 tests, server 314, standalone 30, integration 35, create-app 65).

## Two stale things noticed, not changed

1. **`pnpm -r --if-present run typecheck` is a no-op.** No workspace package defines a `typecheck` script — `pnpm -r --if-present run typecheck` prints `Scope: 6 of 7 workspace projects` and does nothing. It is dead in `ci.yml` too. Left alone deliberately: removing it from `release.yml` only would leave the two workflows inconsistent, and the honest fix (add real `typecheck` scripts, or drop the step from both) is a separate change.
2. **`make audit` is broken.** The Makefile's `audit` target runs `pnpm run audit`, and the root `package.json` has no `audit` script. Out of scope here, but it will fail for anyone who runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
