### PR TITLE
chore(standalone,create-app): harden the container build and generate a lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  # The standalone template pins its base image by digest. A digest never moves,
+  # which is the point — and also means it never picks up the CVE fixes that
+  # `node:24-alpine` rebuilds carry. This is the update path: Dependabot bumps
+  # tag and digest together, so the pin stays deliberate instead of stale.
+  - package-ecosystem: "docker"
+    directory: "/templates/standalone"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,24 @@ and version sections follow the release labeling policy in
   - A shared credential is a floor, not a ceiling: it does not replace network
     policy or mTLS between the enforcement layer and this service.
 
+- `@o3co/create-auth-policy-verifier` now generates `pnpm-lock.yaml` for the
+  project it scaffolds, and accepts `--no-lockfile` to skip it
+  ([#119](https://github.com/o3co/auth.policy-verifier/issues/119)). The
+  template's `Dockerfile` installs with `--frozen-lockfile`, which needs a
+  lockfile the template itself cannot ship: until the scaffolder has replaced
+  every `workspace:*` with a published version, the dependency set a lockfile
+  would pin does not exist. It is therefore resolved once, at scaffold time,
+  against the rewritten `package.json` (`pnpm install --lockfile-only
+  --ignore-workspace`) — commit the result.
+
+  Best-effort by design: it needs `pnpm` (or `corepack`) and a reachable
+  registry, and neither is guaranteed on the machine running the scaffolder.
+  Failure prints what to run and leaves the scaffold successful, because the
+  generated project is usable without a lockfile — it just cannot be built into
+  an image until `pnpm install` has been run once. `generateLockfile` is
+  exported alongside `scaffold` for programmatic use, and reports failure as a
+  result rather than throwing.
+
 ### Changed
 
 - **BREAKING**: `DotNotationResourceParser`
@@ -521,3 +539,62 @@ and version sections follow the release labeling policy in
   type-checked at all. Turning it on surfaced three pre-existing type errors in
   `tests/integration`, a package that has no build step and had therefore never
   been type-checked; they are fixed.
+- The standalone template's `Dockerfile` no longer rebuilds into a different
+  image each time, and now ships a health signal
+  ([#119](https://github.com/o3co/auth.policy-verifier/issues/119)).
+
+  - **Reproducible inputs**: the base image is pinned by digest
+    (`node:24-alpine@sha256:…`) rather than by a moving tag, global `corepack`
+    is pinned to a version instead of resolving to whatever is latest at build
+    time, and dependencies install with `pnpm install --frozen-lockfile` from a
+    committed `pnpm-lock.yaml` instead of re-resolving every range. The
+    lockfile is a required build input — a build without one fails at the
+    `COPY` rather than quietly resolving something new. Dependabot's `docker`
+    ecosystem now watches `templates/standalone`, so the digest is bumped
+    deliberately rather than left to rot.
+  - **Dependencies resolved once**: the runtime stage takes `node_modules` from
+    a `pnpm prune --prod` of the same tree the build used, instead of running a
+    second `pnpm install --prod`. A second install is a second resolution, and
+    therefore a second chance for the runtime image to contain something the
+    build never saw.
+  - **Non-root**: `pnpm install` and `pnpm run build` run as `node` in every
+    stage, matching the pattern auth.provider's template already uses.
+  - The builder stage copies `tsconfig*.json` rather than `tsconfig.json`
+    alone, so the `tsconfig.typecheck.json` the template now ships reaches the
+    image and `pnpm run typecheck` works in the test and develop stages.
+  - **`EXPOSE`** declares the port, derived from the same `HTTP_PORT` the app
+    reads.
+  - **`HEALTHCHECK`** probes `GET /healthcheck` — at the container's own
+    routable address, not `127.0.0.1`. Since [#108] made the config bind
+    loopback by default, a container that keeps that default is reachable from
+    nothing, yet a loopback probe passes anyway: it would report `healthy` for
+    a container no caller can reach. Probing the address the container is
+    reachable at asks the same question a caller does, so a missing
+    `HTTP_HOSTNAME=0.0.0.0` surfaces as `unhealthy` instead of being masked.
+    The probe follows `HTTP_PORT` and `HTTP_PATH_PREFIX`, and needs no
+    credential — `GET /healthcheck` is never gated by `http.callerAuth`.
+
+    The one shape this is wrong for is a sidecar sharing a network namespace
+    with its caller, where loopback is the correct bind; that deployment
+    overrides `healthcheck:` on the service, which keeps the restart-driving
+    signal honest for everyone else.
+
+### Fixed
+
+- `@o3co/create-auth-policy-verifier` scaffolded an **empty directory** whenever
+  it was run the documented way. Its template-copy filter excluded any path
+  containing a `node_modules` or `dist` segment, matched against the absolute
+  path — and the scaffolder itself lives under `node_modules` when installed by
+  `npm create` / `npx`, so the filter rejected every file of the template. It
+  only ever worked from a source checkout. The exclusion is now judged relative
+  to the template root, so build output inside the template is still skipped
+  while the template itself is copied. The same latent bug in
+  `create-app/scripts/copy-templates.mjs` was corrected too. Found while
+  verifying [#119](https://github.com/o3co/auth.policy-verifier/issues/119)'s
+  Docker build end to end.
+- The scaffolder's printed next steps said `npm install` for a project whose
+  `packageManager` is pnpm and whose lockfile is `pnpm-lock.yaml`; installing
+  with npm would have ignored that lockfile and written a `package-lock.json`
+  the image does not use. They now say `pnpm`.
+
+[#108]: https://github.com/o3co/auth.policy-verifier/issues/108

--- a/README.ja.md
+++ b/README.ja.md
@@ -345,8 +345,20 @@ pnpm -r test     # 全テスト実行
 npx @o3co/create-auth-policy-verifier my-verifier
 cd my-verifier
 docker build -t my-verifier .
-docker run -e OAUTH_JWT_SECRET=secret my-verifier
+docker run -p 3000:3000 \
+  -e HTTP_HOSTNAME=0.0.0.0 -e HTTP_CALLER_AUTH_TOKEN=<secret> \
+  -e OAUTH_JWT_SECRET=secret my-verifier
 ```
+
+スキャフォルダーが `pnpm-lock.yaml` を生成します。イメージは
+`--frozen-lockfile` でビルドするため、lockfile が無いとビルドできません。
+
+`HTTP_HOSTNAME=0.0.0.0` はポートに到達するために必須です — 設定は既定で
+loopback に bind し、コンテナの `HEALTHCHECK` はこれが未設定のとき
+`unhealthy` を報告します（取り繕いません）。ポートを公開することは同時に
+`HTTP_CALLER_AUTH_TOKEN` を必要にします: `/verify` は認可判断を返すため、
+資格情報なしで到達可能なポートは、そこへ経路を持つ誰にでも応答します。詳細は
+[`templates/standalone/README.ja.md`](templates/standalone/README.ja.md#docker)。
 
 ## 関連プロジェクト
 

--- a/README.md
+++ b/README.md
@@ -350,8 +350,21 @@ pnpm -r test     # test all packages
 npx @o3co/create-auth-policy-verifier my-verifier
 cd my-verifier
 docker build -t my-verifier .
-docker run -e OAUTH_JWT_SECRET=secret my-verifier
+docker run -p 3000:3000 \
+  -e HTTP_HOSTNAME=0.0.0.0 -e HTTP_CALLER_AUTH_TOKEN=<secret> \
+  -e OAUTH_JWT_SECRET=secret my-verifier
 ```
+
+The scaffolder generates `pnpm-lock.yaml`; the image builds with
+`--frozen-lockfile` and will not build without it.
+
+`HTTP_HOSTNAME=0.0.0.0` is required for the port to be reachable at all — the
+config binds loopback by default, and the container's `HEALTHCHECK` reports
+`unhealthy` when it is not set rather than pretending otherwise. Publishing the
+port is also what makes `HTTP_CALLER_AUTH_TOKEN` necessary: `/verify` answers
+with an authorization decision, so a reachable port with no credential answers
+anyone who can route to it. See
+[`templates/standalone/README.md`](templates/standalone/README.md#docker).
 
 ## Related Projects
 

--- a/create-app/README.ja.md
+++ b/create-app/README.ja.md
@@ -5,7 +5,7 @@ auth.policy-verifier 用の CLI スキャフォルダーです。組み込みテ
 ## 使い方
 
 ```sh
-npx @o3co/create-auth-policy-verifier <project-name> [--dir <dir-name>]
+npx @o3co/create-auth-policy-verifier <project-name> [--dir <dir-name>] [--no-lockfile]
 ```
 
 `<project-name>` はスコープ付き npm 名 (`@scope/pkg`) とスコープなしの名前 (`pkg`) のどちらでも指定できます。
@@ -15,8 +15,8 @@ npx @o3co/create-auth-policy-verifier <project-name> [--dir <dir-name>]
 ```sh
 npx @o3co/create-auth-policy-verifier my-verifier
 cd my-verifier
-npm install
-npm run debug
+pnpm install
+pnpm run debug
 ```
 
 スコープ付きの例（ディレクトリ名はパッケージ部分がデフォルト）:
@@ -24,8 +24,8 @@ npm run debug
 ```sh
 npx @o3co/create-auth-policy-verifier @my-org/auth.policy-verifier
 cd auth.policy-verifier
-npm install
-npm run debug
+pnpm install
+pnpm run debug
 ```
 
 `--dir` でディレクトリ名を明示指定:
@@ -42,7 +42,25 @@ cd verifier
 3. 生成先ディレクトリがすでに存在する場合はエラーを出力して終了する。
 4. `templates/standalone/` を生成先ディレクトリにコピーする（`node_modules/` と `dist/` は除外）。
 5. `package.json` を書き換える: `name` を `<project-name>` をそのまま設定し（スコープを保持）、`private` を削除し、`workspace:*` のバージョン参照を `templates/versions.json` の公開 semver バージョンに置き換える。
-6. 次のステップの手順を表示する。
+6. その依存セットを `pnpm-lock.yaml` に解決する（`pnpm install --lockfile-only --ignore-workspace`）。`--no-lockfile` 指定時は省略。
+7. 次のステップの手順を表示する。
+
+### 生成される `pnpm-lock.yaml`
+
+テンプレートの `Dockerfile` は `pnpm install --frozen-lockfile` でインストール
+するため、生成されたプロジェクトは lockfile が無いとそもそもビルドできません。
+これはテンプレートに同梱できません: 手順 5 が `workspace:*` を公開バージョンに
+置き換えるまで、lockfile が固定すべき依存セットは存在しないからです。そのため
+書き換え後の `package.json` に対してここで一度だけ解決します。**コミットして
+ください** — `docker build` を再現可能にしているのはこれです。
+
+手順 6 には `pnpm`（または `corepack`）と到達可能なレジストリが必要ですが、
+スキャフォルダーを実行するマシンにそれらがある保証はありません。したがって
+best-effort です: 失敗しても scaffold 自体は成功し、対処方法を表示します。
+lockfile が無くても生成されたプロジェクトは問題なく使えます — 一度
+`pnpm install` を実行するまでイメージにビルドできないだけです。手順そのものを
+省略するには `--no-lockfile` を指定します（オフラインでの scaffold や、
+後段でどのみちインストールするパイプライン向け）。
 
 ## バリデーションルール
 
@@ -72,6 +90,7 @@ cd verifier
 ├── docker-compose.yml
 ├── docker-compose.test.yml
 ├── package.json
+├── pnpm-lock.yaml          # scaffold 時に生成 — コミットすること
 └── tsconfig.json
 ```
 
@@ -86,7 +105,8 @@ import { scaffold, main } from "@o3co/create-auth-policy-verifier";
 | エクスポート | シグネチャ | 説明 |
 |---|---|---|
 | `scaffold` | `(targetDir: string, projectName: string): void` | テンプレートをコピーして `package.json` を書き換える |
-| `main` | `(): void` | CLI エントリポイント — `process.argv` を解析して `scaffold` を呼び出す |
+| `generateLockfile` | `(targetDir: string): LockfileResult` | scaffold 済みディレクトリで `pnpm-lock.yaml` を解決する。失敗は throw せず結果として返す |
+| `main` | `(): void` | CLI エントリポイント — `process.argv` を解析し `scaffold` → `generateLockfile` を呼び出す |
 
 ## 関連
 

--- a/create-app/README.md
+++ b/create-app/README.md
@@ -5,7 +5,7 @@ CLI scaffolder for auth.policy-verifier. Generates a new standalone server proje
 ## Usage
 
 ```sh
-npx @o3co/create-auth-policy-verifier <project-name> [--dir <dir-name>]
+npx @o3co/create-auth-policy-verifier <project-name> [--dir <dir-name>] [--no-lockfile]
 ```
 
 `<project-name>` may be either a scoped npm name (`@scope/pkg`) or an unscoped name (`pkg`).
@@ -15,8 +15,8 @@ Unscoped example:
 ```sh
 npx @o3co/create-auth-policy-verifier my-verifier
 cd my-verifier
-npm install
-npm run debug
+pnpm install
+pnpm run debug
 ```
 
 Scoped example (directory defaults to the package portion):
@@ -24,8 +24,8 @@ Scoped example (directory defaults to the package portion):
 ```sh
 npx @o3co/create-auth-policy-verifier @my-org/auth.policy-verifier
 cd auth.policy-verifier
-npm install
-npm run debug
+pnpm install
+pnpm run debug
 ```
 
 Override the directory name with `--dir`:
@@ -42,7 +42,25 @@ cd verifier
 3. Aborts with an error if the target directory already exists.
 4. Copies `templates/standalone/` to the target directory, excluding `node_modules/` and `dist/`.
 5. Rewrites `package.json`: sets `name` to `<project-name>` verbatim (scope-preserving), removes `private`, and replaces `workspace:*` dependency versions with published semver versions from `templates/versions.json`.
-6. Prints next-step instructions.
+6. Resolves that dependency set into `pnpm-lock.yaml` (`pnpm install --lockfile-only --ignore-workspace`), unless `--no-lockfile` was passed.
+7. Prints next-step instructions.
+
+### The generated `pnpm-lock.yaml`
+
+The template's `Dockerfile` installs with `pnpm install --frozen-lockfile`, so
+the generated project needs a lockfile to build at all. It cannot ship with the
+template: until step 5 has replaced every `workspace:*` with a published
+version, the dependency set the lockfile would have to pin does not exist. So
+it is resolved once, here, against the rewritten `package.json`. **Commit it** —
+it is what makes `docker build` reproducible.
+
+Step 6 needs `pnpm` (or `corepack`) and a reachable registry, and neither is
+guaranteed on the machine running the scaffolder. It is therefore best-effort:
+on failure the scaffold still succeeds and prints what to do, because the
+generated project is perfectly usable without a lockfile — it just cannot be
+built into an image until `pnpm install` has been run once. Pass
+`--no-lockfile` to skip the step outright (offline scaffolding, or a pipeline
+that installs later anyway).
 
 ## Validation Rules
 
@@ -72,6 +90,7 @@ The bundled template's `README.md` / `README.ja.md` still carry the upstream tit
 ├── docker-compose.yml
 ├── docker-compose.test.yml
 ├── package.json
+├── pnpm-lock.yaml          # Generated at scaffold time — commit it
 └── tsconfig.json
 ```
 
@@ -86,7 +105,8 @@ import { scaffold, main } from "@o3co/create-auth-policy-verifier";
 | Export | Signature | Description |
 |---|---|---|
 | `scaffold` | `(targetDir: string, projectName: string): void` | Copies the template and rewrites `package.json` |
-| `main` | `(): void` | CLI entry point — parses `process.argv` and calls `scaffold` |
+| `generateLockfile` | `(targetDir: string): LockfileResult` | Resolves `pnpm-lock.yaml` in an already-scaffolded directory; reports failure rather than throwing |
+| `main` | `(): void` | CLI entry point — parses `process.argv`, calls `scaffold`, then `generateLockfile` |
 
 ## See Also
 

--- a/create-app/scripts/copy-templates.mjs
+++ b/create-app/scripts/copy-templates.mjs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { cpSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, resolve, sep } from "node:path";
+import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -14,9 +14,14 @@ const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
 rmSync(dest, { recursive: true, force: true });
 cpSync(src, dest, {
 	recursive: true,
+	// Relative to `src`, not the absolute path: a checkout that happens to sit
+	// under a directory named node_modules or dist would otherwise match every
+	// entry and copy nothing. Same reasoning as isTemplateEntryIncluded in
+	// src/index.mts.
 	filter: (source) => {
-		const segments = source.split(sep);
-		return !segments.some((segment) => EXCLUDED_DIRS.has(segment));
+		const rel = relative(src, source);
+		if (rel === "") return true;
+		return !rel.split(sep).some((segment) => EXCLUDED_DIRS.has(segment));
 	},
 });
 

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -1,10 +1,31 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { isValidDirName, isValidProjectName, main, scaffold } from "../index.mjs";
+import {
+	generateLockfile,
+	isTemplateEntryIncluded,
+	isValidDirName,
+	isValidProjectName,
+	main,
+	scaffold,
+} from "../index.mjs";
+
+// generateLockfile shells out to a package manager. Every test in this file
+// drives that boundary through the mock: the suite must never touch the
+// network, and the monorepo's own template pins `workspace:*` placeholders
+// that no registry can resolve anyway.
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+vi.mock("node:child_process", () => ({ spawnSync: spawnSyncMock }));
+
+const enoent = (bin: string) => Object.assign(new Error(`spawn ${bin} ENOENT`), { code: "ENOENT" });
+
+beforeEach(() => {
+	spawnSyncMock.mockReset();
+	spawnSyncMock.mockReturnValue({ status: 0, signal: null });
+});
 
 describe("scaffold", () => {
 	let tempDir: string;
@@ -66,6 +87,109 @@ describe("scaffold", () => {
 
 		const pkg = JSON.parse(readFileSync(join(targetDir, "package.json"), "utf-8"));
 		expect(pkg.name).toBe("@piratis-blossoms/auth.policy-verifier");
+	});
+});
+
+describe("isTemplateEntryIncluded", () => {
+	// The scaffolder is installed under node_modules by `npm create` / npx, so
+	// every source path it copies from contains a "node_modules" segment. The
+	// exclusion has to be judged relative to the template root, or it rejects
+	// the entire template and the scaffold produces nothing.
+	const installed = "/home/u/.npm/_npx/abc/node_modules/@o3co/create-auth-policy-verifier";
+	const root = `${installed}/templates/standalone`;
+
+	it("includes template files when the install path contains node_modules", () => {
+		expect(isTemplateEntryIncluded(root, `${root}/package.json`)).toBe(true);
+		expect(isTemplateEntryIncluded(root, `${root}/src/main.mts`)).toBe(true);
+		expect(isTemplateEntryIncluded(root, `${root}/config/application.conf`)).toBe(true);
+	});
+
+	it("includes the template root itself", () => {
+		expect(isTemplateEntryIncluded(root, root)).toBe(true);
+	});
+
+	it("still excludes node_modules and dist inside the template", () => {
+		expect(isTemplateEntryIncluded(root, `${root}/node_modules`)).toBe(false);
+		expect(isTemplateEntryIncluded(root, `${root}/node_modules/express/index.js`)).toBe(false);
+		expect(isTemplateEntryIncluded(root, `${root}/dist`)).toBe(false);
+		expect(isTemplateEntryIncluded(root, `${root}/dist/main.mjs`)).toBe(false);
+	});
+
+	it("does not confuse a name that merely contains an excluded word", () => {
+		expect(isTemplateEntryIncluded(root, `${root}/src/dist-helpers.mts`)).toBe(true);
+	});
+});
+
+describe("generateLockfile", () => {
+	const LOCKFILE_ARGS = ["install", "--lockfile-only", "--ignore-workspace"];
+
+	it("resolves the dependency graph with pnpm in the target directory", () => {
+		const result = generateLockfile("/tmp/target");
+
+		expect(result.ok).toBe(true);
+		expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+		const [bin, args, options] = spawnSyncMock.mock.calls[0];
+		expect(bin).toBe("pnpm");
+		expect(args).toEqual(LOCKFILE_ARGS);
+		expect(options.cwd).toBe("/tmp/target");
+		// A scaffolded project must get its OWN lockfile even when the target
+		// directory happens to sit inside somebody else's pnpm workspace.
+		expect(args).toContain("--ignore-workspace");
+	});
+
+	it("falls back to corepack when pnpm is not on PATH", () => {
+		spawnSyncMock
+			.mockReturnValueOnce({ error: enoent("pnpm") })
+			.mockReturnValueOnce({ status: 0, signal: null });
+
+		const result = generateLockfile("/tmp/target");
+
+		expect(result.ok).toBe(true);
+		expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+		const [bin, args] = spawnSyncMock.mock.calls[1];
+		expect(bin).toBe("corepack");
+		expect(args).toEqual(["pnpm", ...LOCKFILE_ARGS]);
+	});
+
+	it("does not retry with corepack when pnpm ran and failed", () => {
+		// A non-zero exit means resolution failed (offline, private registry,
+		// unpublished version). Running the same resolution through a second
+		// launcher would fail identically and only doubles the wait.
+		spawnSyncMock.mockReturnValue({ status: 1, signal: null });
+
+		const result = generateLockfile("/tmp/target");
+
+		expect(result.ok).toBe(false);
+		expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not retry with corepack when launching pnpm failed for any other reason", () => {
+		// ENOENT is "this binary is not on PATH", which the next launcher can
+		// answer. EACCES is not: pnpm IS there and could not be executed, and
+		// retrying would both hide that and hand the operator the wrong
+		// instruction ("install pnpm") for a permissions problem.
+		spawnSyncMock.mockReturnValue({
+			error: Object.assign(new Error("spawn pnpm EACCES"), { code: "EACCES" }),
+		});
+
+		const result = generateLockfile("/tmp/target");
+
+		expect(result.ok).toBe(false);
+		expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.reason).toMatch(/EACCES/);
+	});
+
+	it("reports failure when no package manager can be launched", () => {
+		spawnSyncMock
+			.mockReturnValueOnce({ error: enoent("pnpm") })
+			.mockReturnValueOnce({ error: enoent("corepack") });
+
+		const result = generateLockfile("/tmp/target");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.reason).toMatch(/pnpm/);
 	});
 });
 
@@ -143,7 +267,7 @@ describe("main (argv parsing and directory derivation)", () => {
 		rmSync(workdir, { recursive: true, force: true });
 	});
 
-	const runMain = (args: string[]): { exitCode: number | null; stderr: string } => {
+	const runMain = (args: string[]): { exitCode: number | null; stderr: string; stdout: string } => {
 		process.argv = ["node", "cli", ...args];
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
 			throw new Error(`__exit__:${code ?? 0}`);
@@ -158,10 +282,11 @@ describe("main (argv parsing and directory derivation)", () => {
 			exitCode = m ? Number(m[1]) : null;
 		}
 		const stderr = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+		const stdout = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
 		exitSpy.mockRestore();
 		errSpy.mockRestore();
 		logSpy.mockRestore();
-		return { exitCode, stderr };
+		return { exitCode, stderr, stdout };
 	};
 
 	it("unscoped name: dir = name, pkg.name = name", () => {
@@ -239,5 +364,98 @@ describe("main (argv parsing and directory derivation)", () => {
 		const r = runMain(["foo"]);
 		expect(r.exitCode).toBe(1);
 		expect(r.stderr.length).toBeGreaterThan(0);
+	});
+});
+
+describe("main (scaffold-time lockfile)", () => {
+	let cwdBackup: string;
+	let workdir: string;
+	let argvBackup: string[];
+
+	beforeEach(() => {
+		cwdBackup = process.cwd();
+		workdir = mkdtempSync(join(tmpdir(), "create-policy-verifier-lock-"));
+		process.chdir(workdir);
+		argvBackup = process.argv;
+	});
+
+	afterEach(() => {
+		process.chdir(cwdBackup);
+		process.argv = argvBackup;
+		rmSync(workdir, { recursive: true, force: true });
+	});
+
+	const runMain = (args: string[]): { exitCode: number | null; stderr: string } => {
+		process.argv = ["node", "cli", ...args];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			throw new Error(`__exit__:${code ?? 0}`);
+		}) as never);
+		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		let exitCode: number | null = 0;
+		try {
+			main();
+		} catch (e) {
+			const m = /__exit__:(\d+)/.exec((e as Error).message);
+			exitCode = m ? Number(m[1]) : null;
+		}
+		const stderr = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+		exitSpy.mockRestore();
+		errSpy.mockRestore();
+		logSpy.mockRestore();
+		return { exitCode, stderr };
+	};
+
+	it("generates the lockfile in the scaffolded directory", () => {
+		// The Dockerfile installs with --frozen-lockfile, so the scaffold owes
+		// the new project a pnpm-lock.yaml it can commit.
+		const r = runMain(["my-verifier"]);
+
+		expect(r.exitCode).toBe(0);
+		expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+		const [, , options] = spawnSyncMock.mock.calls[0];
+		// realpath: main() derives the target from process.cwd(), and on macOS
+		// the temp directory reaches it through the /var -> /private/var symlink.
+		expect(options.cwd).toBe(join(realpathSync(workdir), "my-verifier"));
+	});
+
+	it("resolves against the rewritten package.json, not the template's", () => {
+		// scaffold() replaces every workspace:* with a published version. The
+		// lockfile has to be produced after that rewrite or it would pin
+		// specifiers that no registry serves.
+		let pkgAtSpawn: Record<string, unknown> | undefined;
+		spawnSyncMock.mockImplementation((_bin, _args, options) => {
+			pkgAtSpawn = JSON.parse(readFileSync(join(options.cwd as string, "package.json"), "utf-8"));
+			return { status: 0, signal: null };
+		});
+
+		expect(runMain(["my-verifier"]).exitCode).toBe(0);
+
+		const deps = (pkgAtSpawn?.dependencies ?? {}) as Record<string, string>;
+		expect(Object.keys(deps).length).toBeGreaterThan(0);
+		expect(Object.values(deps)).not.toContain("workspace:*");
+		expect(pkgAtSpawn?.name).toBe("my-verifier");
+	});
+
+	it("skips generation with --no-lockfile", () => {
+		const r = runMain(["my-verifier", "--no-lockfile"]);
+
+		expect(r.exitCode).toBe(0);
+		expect(existsSync(join(workdir, "my-verifier", "package.json"))).toBe(true);
+		expect(spawnSyncMock).not.toHaveBeenCalled();
+	});
+
+	it("warns but still succeeds when the lockfile cannot be generated", () => {
+		// Offline, private registry, no pnpm: the project is still usable, so
+		// the scaffold must not fail — but the operator has to be told, because
+		// `docker build` needs the lockfile.
+		spawnSyncMock.mockReturnValue({ status: 1, signal: null });
+
+		const r = runMain(["my-verifier"]);
+
+		expect(r.exitCode).toBe(0);
+		expect(existsSync(join(workdir, "my-verifier", "package.json"))).toBe(true);
+		expect(r.stderr).toMatch(/pnpm install/);
+		expect(r.stderr).toMatch(/pnpm-lock\.yaml/);
 	});
 });

--- a/create-app/src/index.mts
+++ b/create-app/src/index.mts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve, sep } from "node:path";
+import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -19,6 +20,25 @@ const getPackageVersions = (): Record<string, string> => {
 		return JSON.parse(readFileSync(versionFile, "utf-8"));
 	}
 	return {};
+};
+
+/** Directories that are build output inside the template, never scaffolded. */
+const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
+
+/**
+ * Decides whether one entry of the template tree is copied into a new project.
+ *
+ * The exclusion is judged on the path RELATIVE to the template root, which is
+ * the whole point: the scaffolder ships inside `node_modules` whenever it is
+ * run the documented way (`npm create`, `npx`), so every absolute source path
+ * it copies from contains a `node_modules` segment. Matching against the
+ * absolute path therefore rejected the entire template and produced an empty
+ * project directory — the scaffolder only ever worked from a source checkout.
+ */
+export const isTemplateEntryIncluded = (templatesDir: string, source: string): boolean => {
+	const rel = relative(templatesDir, source);
+	if (rel === "") return true;
+	return !rel.split(sep).some((segment) => EXCLUDED_DIRS.has(segment));
 };
 
 const UNSCOPED_NAME_RE = /^[a-z0-9][a-z0-9-._~]*$/;
@@ -53,13 +73,9 @@ export const scaffold = (targetDir: string, projectName: string): void => {
 	}
 
 	// Copy template to target
-	const EXCLUDED_DIRS = new Set(["node_modules", "dist"]);
 	cpSync(TEMPLATES_DIR, targetDir, {
 		recursive: true,
-		filter: (source) => {
-			const segments = source.split(sep);
-			return !segments.some((s) => EXCLUDED_DIRS.has(s));
-		},
+		filter: (source) => isTemplateEntryIncluded(TEMPLATES_DIR, source),
 	});
 
 	// Rewrite package.json
@@ -89,15 +105,90 @@ export const scaffold = (targetDir: string, projectName: string): void => {
 	writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 };
 
+/** Outcome of the scaffold-time lockfile generation. */
+export type LockfileResult =
+	| { readonly ok: true; readonly command: string }
+	| { readonly ok: false; readonly reason: string };
+
+/**
+ * Arguments that make pnpm resolve the dependency graph and write
+ * `pnpm-lock.yaml` without linking `node_modules` or running any lifecycle
+ * script. `--ignore-workspace` keeps the new project's lockfile its own even
+ * when the target directory happens to sit inside another pnpm workspace.
+ */
+const LOCKFILE_ARGS = ["install", "--lockfile-only", "--ignore-workspace"] as const;
+
+/**
+ * Launchers tried in order. `pnpm` on PATH is the common case; `corepack pnpm`
+ * covers a machine that only has Node, and honours the `packageManager` field
+ * the template ships.
+ *
+ * The fallback is narrow on purpose: it applies to `ENOENT` and nothing else,
+ * because `ENOENT` is the one failure that means "this binary is not here" and
+ * is therefore the only one a different launcher can answer. Any other launch
+ * error (`EACCES`, `EPERM`, …) says the binary IS there and could not be run,
+ * and a package manager that ran and exited non-zero has already reported that
+ * resolution failed — retrying either would hide the real cause behind
+ * "package manager missing" and hand the operator the wrong instruction.
+ */
+const LOCKFILE_LAUNCHERS: readonly (readonly string[])[] = [["pnpm"], ["corepack", "pnpm"]];
+
+/**
+ * Generates `pnpm-lock.yaml` inside an already-scaffolded `targetDir`.
+ *
+ * This is what makes the template's `pnpm install --frozen-lockfile` build
+ * possible: the lockfile cannot be shipped with the template, because the
+ * template's dependency set does not exist until `scaffold` has replaced every
+ * `workspace:*` with a published version. So it is resolved here, once, against
+ * the rewritten `package.json`, and the project commits the result.
+ *
+ * Best-effort by design: it needs a package manager and a reachable registry,
+ * and neither is guaranteed on the machine running the scaffolder. Failure is
+ * reported, never thrown — the generated project is perfectly usable without
+ * it, the operator just has to run `pnpm install` before `docker build`.
+ */
+export const generateLockfile = (targetDir: string): LockfileResult => {
+	const attempts: string[] = [];
+
+	for (const launcher of LOCKFILE_LAUNCHERS) {
+		const [bin, ...prefix] = launcher;
+		const args = [...prefix, ...LOCKFILE_ARGS];
+		const printable = [bin, ...args].join(" ");
+		const result = spawnSync(bin, args, {
+			cwd: targetDir,
+			stdio: "inherit",
+			shell: false,
+			env: { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+		});
+
+		if (result.error) {
+			attempts.push(`${printable}: ${result.error.message}`);
+			// Only "not on PATH" is worth asking a different launcher about.
+			if ((result.error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			break;
+		}
+		if (result.status === 0) return { ok: true, command: printable };
+
+		const how =
+			result.status === null ? `killed by signal ${result.signal}` : `exit code ${result.status}`;
+		attempts.push(`${printable}: ${how}`);
+		break;
+	}
+
+	return { ok: false, reason: attempts.join("; ") };
+};
+
 interface ParsedArgs {
 	projectName: string;
 	dir: string | undefined;
+	lockfile: boolean;
 }
 
 const parseArgs = (args: string[]): ParsedArgs => {
 	const positionals: string[] = [];
 	let dir: string | undefined;
 	let dirSeen = false;
+	let lockfile = true;
 
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i];
@@ -111,6 +202,8 @@ const parseArgs = (args: string[]): ParsedArgs => {
 			if (dirSeen) throw new Error("--dir specified more than once");
 			dir = a.slice("--dir=".length);
 			dirSeen = true;
+		} else if (a === "--no-lockfile") {
+			lockfile = false;
 		} else if (a.startsWith("-")) {
 			// Treats `--` and any --unknown as an unknown flag.
 			throw new Error(`unknown flag: ${a}`);
@@ -122,7 +215,7 @@ const parseArgs = (args: string[]): ParsedArgs => {
 	if (positionals.length === 0) throw new Error("missing <project-name>");
 	if (positionals.length > 1) throw new Error("too many positional arguments");
 
-	return { projectName: positionals[0], dir };
+	return { projectName: positionals[0], dir, lockfile };
 };
 
 const deriveDirName = (projectName: string, dir: string | undefined): string => {
@@ -153,11 +246,13 @@ export const main = (): void => {
 		parsed = parseArgs(args);
 	} catch (e) {
 		console.error(`Error: ${(e as Error).message}`);
-		console.error("Usage: @o3co/create-auth-policy-verifier <project-name> [--dir <dir-name>]");
+		console.error(
+			"Usage: @o3co/create-auth-policy-verifier <project-name> [--dir <dir-name>] [--no-lockfile]",
+		);
 		process.exit(1);
 	}
 
-	const { projectName, dir } = parsed;
+	const { projectName, dir, lockfile } = parsed;
 
 	if (!isValidProjectName(projectName)) {
 		console.error(
@@ -184,9 +279,27 @@ export const main = (): void => {
 	console.log(`Creating ${projectName}...`);
 	scaffold(targetDir, projectName);
 
+	let lockfileGenerated = false;
+	if (lockfile) {
+		console.log("\nResolving dependencies into pnpm-lock.yaml...");
+		const result = generateLockfile(targetDir);
+		lockfileGenerated = result.ok;
+		if (!result.ok) {
+			console.error(`\nWarning: could not generate pnpm-lock.yaml (${result.reason}).`);
+			console.error(
+				`Run 'pnpm install' in ${dirName} and commit pnpm-lock.yaml: the Dockerfile installs with --frozen-lockfile and will not build without it.`,
+			);
+		}
+	}
+
 	console.log(`\nDone! Created ${projectName} at ${targetDir}`);
+	if (lockfileGenerated) {
+		console.log(
+			"\nCommit pnpm-lock.yaml along with the rest: it is what makes 'docker build' reproducible.",
+		);
+	}
 	console.log(`\nNext steps:`);
 	console.log(`  cd ${dirName}`);
-	console.log("  npm install");
-	console.log("  npm run debug");
+	console.log("  pnpm install");
+	console.log("  pnpm run debug");
 };

--- a/templates/standalone/Dockerfile
+++ b/templates/standalone/Dockerfile
@@ -1,9 +1,18 @@
-FROM node:24-alpine AS node-base
+# The base image is pinned by digest, not just by tag: `node:24-alpine` is a
+# moving pointer, so the same source produced a different image on every
+# rebuild. The digest is the multi-arch index, so amd64 and arm64 both resolve
+# from it. Dependabot's `docker` ecosystem keeps the pair in step — bump the
+# tag and the digest together, never the tag alone.
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS node-base
 
 ENV HOME=/home/node
 
+# corepack is pinned too. `npm install -g corepack --force` resolved whatever
+# was latest at build time, which is a mutable dependency of every build. The
+# pnpm version itself comes from the `packageManager` field in package.json,
+# which corepack reads.
 RUN apk add --no-cache tini \
- && npm install -g corepack --force \
+ && npm install -g corepack@0.35.0 --force \
  && corepack enable
 
 WORKDIR /home/node
@@ -11,18 +20,44 @@ WORKDIR /home/node
 #############################################
 FROM node-base AS deps
 
-COPY package.json ./
+# pnpm-lock.yaml is a required build input: `create-auth-policy-verifier`
+# generates it at scaffold time and the project commits it. Without it this
+# COPY fails, which is the intended outcome — a build that silently re-resolves
+# every dependency range is the thing this file stopped doing.
+COPY --chown=node:node package.json pnpm-lock.yaml ./
 
-RUN pnpm install
+USER node
+
+# --frozen-lockfile: install exactly what the lockfile pins, and fail if
+# package.json and the lockfile disagree, rather than quietly rewriting it.
+RUN pnpm install --frozen-lockfile
 
 #############################################
 FROM deps AS builder
 
-COPY tsconfig.json ./
-COPY config/ ./config/
-COPY src/ ./src/
+# USER node inherited from deps stage; repeated here to make the builder
+# hardening invariant obvious in Dockerfile reviews.
+USER node
+
+# tsconfig*.json, not tsconfig.json: the template also ships
+# tsconfig.typecheck.json, which is what `pnpm run typecheck` reads. Copying the
+# whole set keeps the test and develop stages able to run it.
+COPY --chown=node:node tsconfig*.json ./
+COPY --chown=node:node config/ ./config/
+COPY --chown=node:node src/ ./src/
 
 RUN pnpm run build
+
+#############################################
+# Dependencies are resolved once, in `deps`. This stage drops the dev half of
+# that same tree instead of running a second `pnpm install --prod` in the
+# runtime stage: a second install is a second resolution, and therefore a
+# second chance for the runtime image to hold something the build never saw.
+FROM deps AS prod-deps
+
+USER node
+
+RUN pnpm prune --prod
 
 #############################################
 FROM node-base AS runtime
@@ -30,14 +65,43 @@ FROM node-base AS runtime
 ENV NODE_ENV=production
 
 COPY --from=deps /home/node/package.json /home/node/pnpm-lock.yaml ./
-
-RUN pnpm install --prod \
- && pnpm store prune
-
+COPY --from=prod-deps /home/node/node_modules/ ./node_modules/
 COPY --from=builder /home/node/dist/ ./dist/
 COPY --from=builder /home/node/config/ ./config/
 
 USER node
+
+ENV HTTP_PORT=3000
+EXPOSE ${HTTP_PORT}
+
+# Probes the container's own routable address, NOT 127.0.0.1 — deliberately.
+#
+# `application.conf` binds loopback by default (#108), because /verify answers
+# with an authorization decision and a reachable port is a decision oracle. A
+# container that keeps that default is reachable from nothing: the published
+# port never connects. A probe against 127.0.0.1 passes anyway — inside the
+# container loopback is exactly where the server is listening — so it would
+# report "healthy" for a container no caller can reach. That is the one failure
+# this check exists to catch, so it asks the same question a caller does:
+# "does the port answer at the address the container is reachable at?"
+#
+# `hostname -i` yields the container's IP; a v6 literal is bracketed for the
+# URL. `${HTTP_PATH_PREFIX}` keeps the probe on the mount point the server
+# actually used (`http.pathPrefix`), and `${HTTP_PORT}` keeps it on the
+# operator's port — the config reads `${?HTTP_PORT}`, so app.listen() and the
+# probe stay in sync. Shell form, so both expand at probe time.
+#
+# `GET /healthcheck` is never gated by `http.callerAuth`, so setting
+# HTTP_CALLER_AUTH_TOKEN does not require a credential here.
+#
+# The deployment where loopback is genuinely correct — a sidecar sharing a
+# network namespace with its caller — is the one shape this check is wrong for.
+# That deployment overrides `healthcheck:` per service, which keeps the
+# restart-driving signal honest for everyone else.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD addr="$(hostname -i | cut -d' ' -f1)"; \
+      case "$addr" in *:*) addr="[$addr]" ;; esac; \
+      wget -q -O /dev/null "http://${addr}:${HTTP_PORT}${HTTP_PATH_PREFIX%/}/healthcheck" || exit 1
 
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "dist/main.mjs"]

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -126,17 +126,63 @@ const app = await createApp({
 ```sh
 make build
 docker run \
+  -p 3000:3000 \
+  -e HTTP_HOSTNAME=0.0.0.0 \
+  -e HTTP_CALLER_AUTH_TOKEN=<secret> \
   -e OAUTH_JWT_SECRET=secret \
   -e OAUTH_JWT_ISSUER=https://issuer.example.com \
   -e OAUTH_JWT_AUDIENCE=https://api.example.com \
   auth-policy-verifier
 ```
 
+最初の 2 つは [信頼境界](#信頼境界) で述べた opt-in の組で、ポートを公開する
+こと自体が両方を必要にします:
+
+- `HTTP_HOSTNAME=0.0.0.0` — 設定は既定で loopback に bind しますが、コンテナ内
+  での loopback は「どこからも到達できない」を意味し、公開したポートは決して
+  繋がらないため。
+- `HTTP_CALLER_AUTH_TOKEN` — 同じ設定によって `/verify` がポートに到達できる
+  すべてのものから届く状態になり、`/verify` は認可判断を返すため。省略して
+  よいのは、ホストの外から公開ポートに到達できない場合だけです。
+
 Docker Compose でローカル開発する場合:
 
 ```sh
 make dev
 ```
+
+`docker-compose.yml` は `HTTP_HOSTNAME=0.0.0.0` を自身で設定し、任意の `.env`
+を読み込みます。資格情報は供給**しません** — `HTTP_CALLER_AUTH_TOKEN` はその
+`.env` に置いてください。
+
+### `pnpm-lock.yaml` はビルド入力
+
+同じソースからの 2 回のビルドが 2 つの異なるイメージを生まないようにするのが
+`pnpm install --frozen-lockfile` です。そのため `Dockerfile` は
+`pnpm-lock.yaml` を COPY し、無ければビルドは失敗します。
+`create-auth-policy-verifier` が scaffold 時に生成するので、コミットして
+ください。無い場合（オフラインでの scaffold、または `--no-lockfile`）は
+`pnpm install` を一度実行してその結果をコミットします。
+
+したがって依存更新は lockfile の変更です: `pnpm update` → commit → 再ビルド。
+ベースイメージを digest で固定しているのも同じ理由で、更新方法も同じ —
+tag と digest を意図的に一緒に上げます。
+
+### HEALTHCHECK が報告するもの
+
+コンテナの healthcheck は `127.0.0.1` ではなく、**コンテナ自身の到達可能
+アドレス**を probe します。これは意図的です。loopback に対する probe は、
+サーバーが loopback に bind していて誰も到達できない状態でも成功してしまい —
+外から見れば死んでいるコンテナを「healthy」と報告します。実際に到達可能な
+アドレスを叩けば呼び出し元と同じ問いになるため、`HTTP_HOSTNAME=0.0.0.0` の
+付け忘れは隠れずに `unhealthy` として現れます。
+
+`GET /healthcheck` は `http.callerAuth` で決してゲートされないので、probe に
+資格情報は不要です。`HTTP_PATH_PREFIX` と `HTTP_PORT` には追従します。
+
+例外は 1 つ、呼び出し元と network namespace を共有する sidecar 構成です。
+そこでは loopback bind が正しく、到達可能アドレスでは何も listen していま
+せん。そのサービスでは `healthcheck:` を override してください。
 
 ## 関連
 

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -127,17 +127,63 @@ Build the image and run the container:
 ```sh
 make build
 docker run \
+  -p 3000:3000 \
+  -e HTTP_HOSTNAME=0.0.0.0 \
+  -e HTTP_CALLER_AUTH_TOKEN=<secret> \
   -e OAUTH_JWT_SECRET=secret \
   -e OAUTH_JWT_ISSUER=https://issuer.example.com \
   -e OAUTH_JWT_AUDIENCE=https://api.example.com \
   auth-policy-verifier
 ```
 
+Those first two are the opt-in pair from [Trust boundary](#trust-boundary), and
+publishing the port is exactly what makes both necessary:
+
+- `HTTP_HOSTNAME=0.0.0.0` because the config binds loopback by default, and
+  inside a container that means reachable from nothing — the published port
+  would never connect.
+- `HTTP_CALLER_AUTH_TOKEN` because the same setting is what puts `/verify` in
+  reach of anything that can route to the port, and `/verify` answers with an
+  authorization decision. Dropping it is only safe when nothing outside the
+  host can reach the published port.
+
 For local development with Docker Compose:
 
 ```sh
 make dev
 ```
+
+`docker-compose.yml` sets `HTTP_HOSTNAME=0.0.0.0` itself and reads an optional
+`.env`. It does **not** supply the credential — put `HTTP_CALLER_AUTH_TOKEN` in
+that `.env`.
+
+### `pnpm-lock.yaml` is a build input
+
+`pnpm install --frozen-lockfile` is what keeps two builds of the same source
+from producing two different images, so `Dockerfile` copies `pnpm-lock.yaml`
+and the build fails without it. `create-auth-policy-verifier` generates the
+lockfile at scaffold time — commit it. If it is missing (scaffolded offline, or
+with `--no-lockfile`), run `pnpm install` once and commit the result.
+
+Dependency updates are therefore a lockfile change: run `pnpm update`, commit,
+rebuild. The base image is pinned by digest for the same reason and is bumped
+the same way — deliberately, tag and digest together.
+
+### What the HEALTHCHECK reports
+
+The container healthcheck probes the container's **own routable address**, not
+`127.0.0.1`. This is deliberate. A probe against loopback passes even when the
+server is bound to loopback and no caller can reach it — it would report
+"healthy" for a container that is, from outside, dead. Probing the address the
+container is actually reachable at asks the same question a caller does, so
+forgetting `HTTP_HOSTNAME=0.0.0.0` shows up as `unhealthy` instead of hiding.
+
+`GET /healthcheck` is never gated by `http.callerAuth`, so the probe needs no
+credential. It follows `HTTP_PATH_PREFIX` and `HTTP_PORT`.
+
+One deployment shape is the exception: a sidecar sharing a network namespace
+with its caller, where binding loopback is correct and the routable address has
+nothing listening on it. Override `healthcheck:` on that service.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

`templates/standalone/Dockerfile` resolved mutable dependency ranges on every build, pulled an unpinned base image and an unpinned global corepack, installed as root, and shipped no health signal. Rebuilding the same source could produce a different image, and the container had no way to say whether it was serving.

### 1. Pinned inputs, `--frozen-lockfile`

- **Base image by digest**: `node:24-alpine@sha256:d32cdf61…` — the multi-arch index digest, so amd64 and arm64 both resolve from it.
- **corepack pinned** to `0.35.0` instead of `npm install -g corepack --force` resolving to whatever was latest at build time. The pnpm version itself already comes from `packageManager` in `package.json`.
- **`pnpm install --frozen-lockfile`** from a committed `pnpm-lock.yaml`, which is now a *required* build input — a build without one fails at the `COPY` naming the file, rather than quietly resolving something new.
- **Dependencies resolved once**: the runtime stage takes `node_modules` from a `pnpm prune --prod` of the build's own tree instead of running a second `pnpm install --prod`. A second install is a second resolution, and therefore a second chance for the runtime image to hold something the build never saw.
- Added the **`docker` Dependabot ecosystem** for `/templates/standalone`. A digest never moves — which is the point, and also means it never picks up the CVE fixes `node:24-alpine` rebuilds carry. This gives the pin an update path so it stays deliberate rather than stale.

### 2. `HEALTHCHECK` + `EXPOSE`

`EXPOSE ${HTTP_PORT}` (default `3000`), and a `HEALTHCHECK` on `GET /healthcheck` — verified as the real path in `packages/server/src/app.mts` (`createHealthcheckRouter()` mounted at `config.http.pathPrefix`). The probe follows both `HTTP_PORT` and `HTTP_PATH_PREFIX`.

### 3. Non-root

Followed `auth.provider`'s template: `USER node` before `pnpm install` in `deps`, restated in `builder` to keep the invariant visible in review, and before the runtime install. Verified `USER=node` / `uid=1000` in the built image, and in the `test` and `develop` stages.

## The lockfile decision

**The scaffold can produce a lockfile, but only at scaffold time — not at template-authoring time.** The template's `package.json` carries `workspace:*` for the three `@o3co/auth.policy-verifier.*` packages, and `scaffold()` replaces each with a published `^x.y.z`. Until that rewrite happens, the dependency set a lockfile would have to pin *does not exist*. A lockfile committed under `templates/standalone/` would pin `link:` workspace entries, and `--frozen-lockfile` would reject it against the rewritten manifest. Generating one at release time is also impossible: it would have to reference package versions that only exist after `pnpm publish` in the same workflow run.

So `create-app` now runs `pnpm install --lockfile-only --ignore-workspace` in the target directory, immediately after the `package.json` rewrite, and the project commits the result. `--ignore-workspace` keeps the new project's lockfile its own when the target sits inside somebody else's pnpm workspace.

**It is best-effort, deliberately.** It needs a package manager and a reachable registry, and neither is guaranteed on the machine running the scaffolder. On failure the scaffold still succeeds and prints what to run — the generated project is perfectly usable without a lockfile, it just cannot be built into an image until `pnpm install` has been run once. `pnpm` on PATH is tried first, then `corepack pnpm`; the fallback applies to a *launch* failure (ENOENT) only, since a package manager that ran and exited non-zero has already reported that resolution failed. `--no-lockfile` skips the step outright for offline scaffolding.

## Healthcheck vs. bind — the failure mode from #108 / #143

The flagged trap is real, and I reproduced it. **The check probes the container's own routable address (`hostname -i`), not `127.0.0.1`.**

Two containers from the same image, both running:

| | bind | reachable from host | naive `wget http://127.0.0.1:3000/healthcheck` | this HEALTHCHECK |
|---|---|---|---|---|
| A | `HTTP_HOSTNAME=0.0.0.0` | `200` | PASS | **PASS** |
| B | default (loopback, per #108) | no answer | **PASS — the lie** | **FAIL** |

```
B: naive probe            -> PASS (this is the lie)
B: this HEALTHCHECK       -> wget: can't connect to remote host (172.17.0.4): Connection refused
```

Docker's own status agrees: `A(0.0.0.0)=healthy  B(loopback)=unhealthy`, `FailingStreak: 3`.

Probing the address the container is actually reachable at asks the same question a caller does, so forgetting `HTTP_HOSTNAME=0.0.0.0` surfaces as `unhealthy` instead of being masked.

**The one shape this is wrong for**, stated plainly rather than hidden: a sidecar sharing a network namespace with its caller, where loopback *is* the correct bind and the routable address has nothing listening. That deployment overrides `healthcheck:` on its service — which is the right trade, because it keeps the restart-driving signal honest for the far more common published-port case. This is written into the Dockerfile comment and both template READMEs.

An IPv6 literal from `hostname -i` is bracketed for the URL; a trailing `/` on `HTTP_PATH_PREFIX` is stripped.

**`http.callerAuth` gate: confirmed not applied to the healthcheck.** Verified in code (`app.mts` mounts `createHealthcheckRouter()` *before* `createCallerAuthMiddleware`) and at runtime with `HTTP_CALLER_AUTH_TOKEN` set:

```
GET  /api/healthcheck  (no credential) -> 200
POST /api/verify       (no credential) -> 401 caller_unauthenticated
POST /api/verify       (credential)    -> past the gate (missing_token)
```

## Bug found while verifying: the scaffolder produced an empty directory

Building the image end to end required scaffolding a project the documented way, which is how this surfaced. `scaffold()`'s copy filter excluded any path containing a `node_modules` or `dist` segment — matched against the **absolute** path. The scaffolder itself lives under `node_modules` whenever installed by `npm create` / `npx`, so the filter rejected *every file of the template* and produced an empty directory. Confirmed against the published `@o3co/create-auth-policy-verifier@0.3.1`:

```
ENOENT: no such file or directory, open '.../my-verifier/package.json'
```

It only ever worked from a source checkout. The exclusion is now judged relative to the template root, so build output inside the template is still skipped while the template itself is copied. The same latent bug in `create-app/scripts/copy-templates.mjs` was corrected too. This is in scope because `#119`'s premise — "the pinned build breaks for every new project" — is moot if no new project is ever produced.

Also: the printed next steps said `npm install` for a project whose `packageManager` is pnpm and whose lockfile is `pnpm-lock.yaml`; npm would have ignored that lockfile and written a `package-lock.json` the image does not use.

## What I built and verified

Everything below ran against **this branch's actual template**, not the released one. Because the branch's template source targets unreleased package APIs (`builtinKeyResolversModule`, the `logger` option, `http.callerAuth`), I published the locally-built `core` / `builtins` / `server` to a throwaway local registry and pointed the project's three deps at those tarball URLs, so the lockfile is self-contained and the container resolves them without any registry configuration. The `Dockerfile` under test is the committed file, byte for byte.

- **Scaffold**: ran the packed `create-app` installed **under `node_modules`** (the shape that used to copy nothing) → complete 22-file tree, plus a generated `pnpm-lock.yaml`.
- **`docker build --no-cache --target runtime`** → **success**. `pnpm prune --prod` removed the dev half cleanly (`Lockfile is up to date, resolution step is skipped`).
- **All targets build**: `deps`, `builder`, `prod-deps`, `runtime`, `test`, `develop`. `test` and `develop` both run as `node`.
- **Image metadata**: `ExposedPorts {"3000/tcp":{}}`, `User=node`, `Healthcheck` present with `30s/3s/10s/3`.
- **Container runs and serves**: `/healthcheck` → `200`; `POST /verify` with a real HS256 `at+jwt` (iss/aud/exp/iat) returned a full decision payload with rule-by-rule `reason` — so the pruned runtime image has everything it needs.
- **Health signal**: healthy/unhealthy exactly as tabled above, via `docker inspect`.
- **Missing lockfile** fails loudly: `"/pnpm-lock.yaml": not found`.
- `pnpm run lint` clean; `pnpm run build`; `pnpm -r run typecheck`; full `pnpm run test` — core 62, builtins 474, server 356, integration 51, standalone 30, create-app 77 (all green). No `--coverage`.

TDD per AGENTS.md: the create-app tests were written first and watched fail (8 failing, then 4 more for the `node_modules` bug) before either implementation.

## Notes for reviewers

- **The umbrella E2E is unaffected** — `o3co/auth` builds `tests/dockerfiles/policy-verifier.Dockerfile`, its own file, not this template. Worth noting separately that its compose healthcheck is `wget http://127.0.0.1:3000/healthcheck`, i.e. exactly the probe this PR argues lies; that is a different repo and out of scope here.
- `templates/standalone` in the monorepo still cannot be `docker build`-ed directly, and never could — its `workspace:*` deps do not resolve outside the workspace. The Dockerfile is built from a scaffolded project. No regression, but it is why the verification above goes through `create-app`.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — review round 1, rebased onto develop

**Rebased onto `f722ca4`** (picked up #143/#144/#146/#147/#149). One CHANGELOG conflict, both sides kept.

All three Copilot findings fixed:

1. **`generateLockfile` retry narrowed to `ENOENT`.** It was retrying with the corepack launcher on *any* `spawnSync` error, contradicting its own comment. `ENOENT` is the only launch error a different launcher can answer; `EACCES`/`EPERM` mean pnpm is there and could not be run, and retrying hid that behind "package manager missing". Now breaks out and reports the real error, with a test asserting EACCES does not fall through.
2 & 3. **`HTTP_CALLER_AUTH_TOKEN` is in the `docker run` snippet** in both `templates/standalone/README.md` and `README.ja.md`, explained as the opt-in pair from *Trust boundary* — publishing the port is what makes both necessary. Re-reading the surrounding prose for the same shape found **a second instance**: "For local development with Docker Compose (which sets both)" was false — compose sets `HTTP_HOSTNAME` and reads an optional `.env`, it does not supply the credential. Corrected in both languages. The root `README.md`/`README.ja.md` snippets had the same exposure and now set the token too.

**Rebase-driven fix found by re-verifying, not by text merge**: #149 added `tsconfig.typecheck.json` per package, and the template ships one. The builder stage copied `tsconfig.json` alone, so it never reached the image and `pnpm run typecheck` would fail in the `test`/`develop` stages. Now `COPY tsconfig*.json`. Confirmed the file really is in the packed create-app tarball and lands in the scaffold, and that `pnpm run typecheck` passes *inside* the built `test` stage.

### Re-verified after the rebase

Rebuilt the whole chain, this time publishing the **real `pnpm pack` tarballs** (not a hand-staged `dist/`), since #149 changed what ships — confirmed no packed `dist/` contains `__tests__`.

- Scaffolded from the packed create-app installed **under `node_modules`** → complete tree incl. `tsconfig.typecheck.json`.
- `docker build --no-cache --target runtime` → success; all six targets (`deps`, `builder`, `prod-deps`, `runtime`, `test`, `develop`) build.
- `USER=node`, `ExposedPorts {"3000/tcp":{}}`, `HTTP_PORT=3000`, healthcheck present.
- Three containers from one image:

| | bind | host probe | Docker health |
|---|---|---|---|
| A `HTTP_HOSTNAME=0.0.0.0` | `0.0.0.0:3000` | `/healthcheck` → 200 | **healthy** |
| B default (loopback) | `127.0.0.1:3000` | no answer | **unhealthy** (`FailingStreak: 3`, `Connection refused`) |
| C `+HTTP_PATH_PREFIX=/api` `+HTTP_CALLER_AUTH_TOKEN` | `0.0.0.0:3000` | `/api/healthcheck` → 200, `/api/verify` → 401 without cred, past the gate with it | **healthy** |

  The lie, side by side inside B: naive `wget http://127.0.0.1:3000/healthcheck` → **PASS**; this HEALTHCHECK → **FAIL** (`can't connect to remote host (172.17.0.4)`). C being healthy is the positive control: prefix followed, and the caller-auth gate does not cover the probe.
- Real HS256 `at+jwt` through the pruned runtime image → full engine decision returned.
- `pnpm lint`, `pnpm -r run build`, `pnpm run typecheck` (all 6 packages), full `pnpm run test` — core 62, builtins 474, server 417, integration 51, standalone 30, create-app 78. All green, no `--coverage`.
