### PR TITLE
ci: gate dependency advisories and publish readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,27 @@ jobs:
           restore-keys: pnpm-store-
 
       - run: pnpm install --frozen-lockfile
+
+      # `pnpm audit --prod --audit-level=low`. Runs before lint/build so a known
+      # advisory in a shipped dependency fails fast and is not buried under a
+      # test log. `--prod` scopes it to what consumers actually install; the
+      # `--audit-level=low` floor is deliberate — this is an authorization
+      # service, and a "low" DoS in the request-parsing path is not cosmetic.
+      #
+      # Same entry point as `make audit`, so a contributor reproduces this
+      # locally with one command instead of re-deriving the flags.
+      - run: pnpm run audit
+
       - run: pnpm run lint
       - run: pnpm run build
-      - run: pnpm -r --if-present run typecheck
+
+      # Real work, not a no-op: every workspace package defines `typecheck`
+      # (`tsc --noEmit -p tsconfig.typecheck.json`, or plain `tsc --noEmit` for
+      # tests/integration, which emits nothing anyway). It covers `src/**/*`
+      # *including* `__tests__` — which the build deliberately no longer does,
+      # since compiled tests must not reach a published tarball. Without this
+      # step nothing would type-check test files at all.
+      - run: pnpm run typecheck
 
       # Every workspace, including the ones with no `test:coverage` script:
       # templates/standalone, tests/integration and create-app. The coverage
@@ -69,3 +87,234 @@ jobs:
           flags: server
           disable_search: true
           fail_ci_if_error: false
+
+  # Simulates the post-publish state: tarball every package `pnpm -r publish`
+  # would offer to the registry, then build the scaffold a consumer actually
+  # receives against those tarballs instead of the `workspace:*` links a local
+  # build resolves. Catches the class of defect where the template references a
+  # symbol that is not in the published tarball — invisible in the workspace,
+  # where `src/` is right there, and only observable after the tag is pushed.
+  publish-readiness:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+
+      - name: Pack every publishable workspace package
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The publish surface is read back from pnpm rather than matched
+          # against a name pattern. `pnpm -r publish` offers exactly the
+          # workspace projects that are not `private`, so asking pnpm for that
+          # list is the only way this job cannot silently drift from it — a
+          # glob like `@o3co/auth.policy-verifier.*` would quietly miss
+          # `@o3co/create-auth-policy-verifier`, which lives outside
+          # `packages/` and does not share the prefix.
+          #
+          # Today that resolves to four: .core, .builtins, .server and
+          # @o3co/create-auth-policy-verifier. templates/standalone and
+          # tests/integration are `private: true` and are never offered.
+          #
+          # `pnpm pack`, not `npm pack`: npm pack leaves `workspace:*` ranges in
+          # the tarball's package.json, which `npm install` in the scratch dir
+          # below cannot resolve (EUNSUPPORTEDPROTOCOL). pnpm pack rewrites them
+          # to the resolved version (0.0.0 here).
+          mkdir -p /tmp/tarballs
+          pnpm list -r --depth -1 --json > /tmp/workspace.json
+          node -e '
+            const fs = require("fs");
+            const projects = JSON.parse(fs.readFileSync("/tmp/workspace.json", "utf8"));
+            for (const p of projects) {
+              if (p.private) continue;
+              if (p.path === process.cwd()) continue;
+              console.log(p.path);
+            }
+          ' > /tmp/publishable.txt
+          echo "publishable workspace packages: $(wc -l < /tmp/publishable.txt)"
+          while read -r dir; do
+            [ -n "$dir" ] || continue
+            echo "packing $(node -p "require('${dir}/package.json').name")"
+            ( cd "$dir" && pnpm pack --pack-destination /tmp/tarballs >/dev/null )
+          done < /tmp/publishable.txt
+          ls -la /tmp/tarballs
+
+      - name: Assert the packed set is the whole publish surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Guards the loop above: if a pack silently failed, or a new
+          # publishable package appeared that the loop did not reach, the
+          # later assertions would pass vacuously over a short tarball set.
+          node -e '
+            const fs = require("fs");
+            const { execSync } = require("child_process");
+            const dir = "/tmp/tarballs";
+            const projects = JSON.parse(fs.readFileSync("/tmp/workspace.json", "utf8"));
+            const expected = new Set(
+              projects.filter((p) => !p.private && p.path !== process.cwd()).map((p) => p.name),
+            );
+            const packed = new Set(
+              fs.readdirSync(dir).filter((f) => f.endsWith(".tgz")).map((f) =>
+                JSON.parse(execSync(`tar -xzOf ${dir}/${f} package/package.json`).toString()).name,
+              ),
+            );
+            const missing = [...expected].filter((n) => !packed.has(n));
+            const extra = [...packed].filter((n) => !expected.has(n));
+            if (missing.length || extra.length) {
+              if (missing.length) console.error("::error::not packed: " + missing.join(", "));
+              if (extra.length) console.error("::error::packed but not publishable: " + extra.join(", "));
+              process.exit(1);
+            }
+            console.log(`OK: packed exactly the ${packed.size} publishable packages:`);
+            for (const n of [...packed].sort()) console.log(`  - ${n}`);
+          '
+
+      - name: Assert no compiled tests in published tarballs
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Compiled test artifacts must not ship. The scope is `dist/__tests__/`
+          # only — `package/templates/standalone/src/__tests__/` in the
+          # create-app tarball is consumer-facing scaffold source and MUST stay
+          # shipped, so a bare `__tests__` match would be wrong here.
+          FAILED=0
+          for tgz in /tmp/tarballs/*.tgz; do
+            HITS=$(tar -tzf "$tgz" | grep -E '/dist/.*__tests__' || true)
+            if [ -n "$HITS" ]; then
+              echo "::error::$tgz contains __tests__ artifacts in dist/:"
+              echo "$HITS"
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" -eq 1 ]; then
+            echo "Each package's tsconfig.json excludes src/**/__tests__/** so the build does not emit them; tsconfig.typecheck.json still type-checks them."
+            exit 1
+          fi
+          echo "OK: no __tests__ artifacts in any published tarball's dist/"
+
+      - name: Assert no '#/' subpath imports in published tarballs
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Per AGENTS.md "Module Resolution": `#/*` resolves through each
+          # package's own `imports` map, and under the `development` condition
+          # that is `./src/*` — which no tarball ships. Node applies
+          # `--conditions` to every package on the graph, not just the root, so
+          # a `#/` specifier surviving into dist/ breaks any consumer running
+          # under Vitest or `tsx watch`. The workspace cannot see this (src is
+          # right there); it only breaks after publish.
+          FAILED=0
+          for tgz in /tmp/tarballs/*.tgz; do
+            for f in $(tar -tzf "$tgz" | grep -E '^package/dist/.*\.(mjs|d\.mts)$' || true); do
+              HITS=$(tar -xzOf "$tgz" "$f" | grep -nE '(from|import|require)[[:space:]]*\(?[[:space:]]*["'"'"']#/' || true)
+              if [ -n "$HITS" ]; then
+                echo "::error::$tgz: $f keeps a '#/' subpath import:"
+                echo "$HITS"
+                FAILED=1
+              fi
+            done
+          done
+          if [ "$FAILED" -eq 1 ]; then
+            echo "Shipped source must use a relative specifier (../…) — see AGENTS.md \"Module Resolution\"."
+            exit 1
+          fi
+          echo "OK: no '#/' subpath imports in any published tarball's dist/"
+
+      - name: Assert the scaffolder pins every workspace dep it ships
+        shell: bash
+        run: |
+          set -euo pipefail
+          # create-app rewrites the template's `workspace:*` ranges using the
+          # `versions.json` that copy-templates.mjs bakes in at prebuild time.
+          # A workspace package added to the template but not to that script's
+          # `versions` map makes `scaffold()` throw for every user. Checked
+          # against the tarball, so it is the shipped pair that is compared.
+          CREATE_APP_TGZ=$(ls /tmp/tarballs/o3co-create-auth-policy-verifier-*.tgz)
+          node -e '
+            const { execSync } = require("child_process");
+            const tgz = process.argv[1];
+            const read = (p) => execSync(`tar -xzOf ${tgz} ${p}`).toString();
+            const versions = JSON.parse(read("package/templates/versions.json"));
+            const tmplPkg = JSON.parse(read("package/templates/standalone/package.json"));
+            const missing = [];
+            for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+              for (const [name, spec] of Object.entries(tmplPkg[section] ?? {})) {
+                if (spec === "workspace:*" && !(name in versions)) missing.push(`${section}: ${name}`);
+              }
+            }
+            if (missing.length) {
+              console.error("::error::templates/versions.json does not pin every workspace dep the shipped template declares:");
+              for (const m of missing) console.error(`  - ${m}`);
+              console.error("Fix: add the package to the `versions` map in create-app/scripts/copy-templates.mjs");
+              process.exit(1);
+            }
+            console.log(`OK: versions.json pins all ${Object.keys(versions).length} workspace deps the shipped template declares`);
+          ' "$CREATE_APP_TGZ"
+
+      - name: Build the shipped scaffold against packed tarballs
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Build the template *out of the create-app tarball*, not out of
+          # templates/standalone. The in-repo template's tsconfig.json still
+          # `extends ../../tsconfig.base.json`; copy-templates.mjs inlines that
+          # base when it stages the shipped copy, so only the tarball's copy is
+          # self-contained — and it is the copy consumers actually get. This
+          # also puts the create-app tarball's own contents under test.
+          SCRATCH=$(mktemp -d)
+          CREATE_APP_TGZ=$(ls /tmp/tarballs/o3co-create-auth-policy-verifier-*.tgz)
+          tar -xzf "$CREATE_APP_TGZ" -C "$SCRATCH"
+          pushd "$SCRATCH/package/templates/standalone" >/dev/null
+          # Rewrite the `workspace:*` direct deps to file: tarball URLs, and add
+          # an `overrides` block pinning every packed package. The overrides are
+          # what force *transitive* workspace deps (server -> core) to resolve
+          # from /tmp/tarballs instead of the public registry, where version
+          # 0.0.0 does not exist.
+          node -e '
+            const fs = require("fs");
+            const path = require("path");
+            const { execSync } = require("child_process");
+            const dir = process.argv[1];
+            const map = new Map();
+            for (const f of fs.readdirSync(dir).filter((f) => f.endsWith(".tgz"))) {
+              const full = path.join(dir, f);
+              const name = JSON.parse(execSync(`tar -xzOf ${full} package/package.json`).toString()).name;
+              map.set(name, "file:" + full);
+            }
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            for (const section of ["dependencies", "peerDependencies", "devDependencies"]) {
+              if (!pkg[section]) continue;
+              for (const name of Object.keys(pkg[section])) {
+                if (map.has(name)) pkg[section][name] = map.get(name);
+              }
+            }
+            pkg.overrides = pkg.overrides ?? {};
+            for (const [name, spec] of map) pkg.overrides[name] = spec;
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+          ' /tmp/tarballs
+          # npm, not pnpm: pnpm would try to re-resolve this against the
+          # workspace it is nested under. npm consumes the file: tarballs
+          # directly, with overrides forcing the transitives too.
+          npm install --no-package-lock --omit=optional
+          npm run build
+          popd >/dev/null
+          echo "OK: the shipped standalone scaffold builds against packed tarballs"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - run: pnpm -r --if-present run typecheck
+      # Kept in step with ci.yml: every workspace package defines `typecheck`,
+      # and it covers `src/**/*` including `__tests__`, which the build excludes
+      # so that compiled tests never reach a tarball.
+      - run: pnpm run typecheck
       - run: pnpm run test
 
       - name: Create GitHub Release (draft)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,3 +116,14 @@ Each package uses Node.js [subpath imports](https://nodejs.org/api/packages.html
 - **Published packages:** Consumers resolve `#/*` via the `"default"` condition to `./dist/*`.
 - **Local dev server:** The standalone template uses `NODE_OPTIONS='--conditions=development'` to explicitly activate the condition.
 - **Cross-package references** (e.g., `builtins` importing from `core`) go through `exports`, which always point to `./dist/`. Run `pnpm -r run build` before running tests in downstream packages.
+
+### Build vs. typecheck
+
+Each package has two TypeScript configs, and the split exists because of the point above:
+
+- `tsconfig.json` — what `build` emits. It excludes `src/**/__tests__/**`. A compiled test in `dist/` would be published (`files: ["dist", …]`), and it would carry the `#/` specifiers that only test files use — which resolve through the package's own `imports` map to `./src/*` under the `development` condition, a path no tarball ships. CI's `publish-readiness` job asserts against both, on the tarball.
+- `tsconfig.typecheck.json` — what `typecheck` checks (`tsc --noEmit`). It re-includes `src/**/*`, tests included, and emits nothing.
+
+So `pnpm run typecheck` is the only thing that type-checks test files; `pnpm run build` no longer does. Both run in `ci.yml` and `release.yml`. `tests/integration` has no build at all, so its `typecheck` is a plain `tsc --noEmit` against its own already-`noEmit` config.
+
+A test file must therefore never be imported by shipped source — the build cannot see it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,23 @@ and version sections follow the release labeling policy in
     logs `unauthenticated_non_loopback_bind` at warn when it sees a non-loopback
     bind with no caller authentication configured.
 
+- `qs` and `body-parser` are pinned above two advisories that the new
+  `pnpm audit --prod --audit-level=low` gate refuses:
+  [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) (a
+  remotely triggerable `qs.stringify` DoS) and
+  [GHSA-v422-hmwv-36x6](https://github.com/advisories/GHSA-v422-hmwv-36x6)
+  (`body-parser` silently disabling size enforcement when given an invalid
+  limit). Both reach this workspace only through `express`, a production
+  dependency of `@o3co/auth.policy-verifier.server`.
+
+  This was a stale lockfile rather than an exposure for consumers:
+  `express@5.2.1` asks for `qs@^6.14.0` and `body-parser@^2.2.1`, both of which
+  admit the patched releases, so an install resolving today already floats to
+  them — but `pnpm-lock.yaml` had pinned `qs@6.15.0` and `body-parser@2.2.2`.
+  The `overrides` block added to `pnpm-workspace.yaml` scopes each entry to the
+  vulnerable range, so it lapses on its own once `express` requires a fixed
+  version instead of holding the floor down indefinitely.
+
 ### Added
 
 - HS256 signing-secret rotation, so the algorithm this stack ships as its
@@ -460,3 +477,47 @@ and version sections follow the release labeling policy in
   (`v1.2.3-rc.1`, `v1.2.3-rc-1`, `v1.2.3-0.3.7`); build metadata
   (`v1.2.3+build.5`) is refused, because npm ignores `+…` when comparing
   versions and two such tags would be one registry version.
+
+- CI now gates dependency advisories and publish readiness, closing the gap
+  against `auth.provider`'s pipeline for the same stack
+  ([#122](https://github.com/o3co/auth.policy-verifier/issues/122)).
+
+  `pnpm audit --prod --audit-level=low` runs before lint and build. It is
+  exposed as the root `audit` script, which is what `make audit` has always
+  called — that target was broken, because no such script existed
+  ([#145](https://github.com/o3co/auth.policy-verifier/issues/145)); CI and a
+  contributor's laptop now run the identical command.
+
+  A `publish-readiness` job tarballs every package `pnpm -r publish` would
+  offer to the registry — read back from pnpm rather than matched against a
+  name pattern, so it cannot drift from the real publish surface — and then
+  builds the scaffold out of the packed `@o3co/create-auth-policy-verifier`
+  tarball against those tarballs, rather than against the `workspace:*` links
+  a local build resolves. A template referencing a symbol that is not in the
+  published tarball is invisible in the workspace, where `src/` is right there,
+  and used to surface only after the tag was pushed. The job also asserts that
+  no tarball ships compiled tests or a `#/` subpath specifier in `dist/`, and
+  that `templates/versions.json` pins every workspace dependency the shipped
+  template declares.
+
+- Published tarballs no longer contain compiled test files. Each package's
+  `tsconfig.json` excludes `src/**/__tests__/**`, so `dist/__tests__/` is no
+  longer emitted or shipped by `.core`, `.builtins`, `.server` or
+  `@o3co/create-auth-policy-verifier`. Those files also carried the only `#/`
+  subpath specifiers that survived into `dist/`, which resolve through each
+  package's own `imports` map to `./src/*` under the `development` condition —
+  a path no tarball ships, so any consumer running under Vitest or `tsx watch`
+  could resolve them into nothing. The scaffold's own
+  `templates/standalone/src/__tests__/` is consumer-facing source and is still
+  shipped, unchanged.
+
+- `pnpm -r --if-present run typecheck` in `ci.yml` and `release.yml` was a
+  no-op — no package defined a `typecheck` script, and `--if-present` swallowed
+  it silently ([#145](https://github.com/o3co/auth.policy-verifier/issues/145)).
+  Every workspace package now defines one, and both workflows call the root
+  `typecheck` script (also `make typecheck`). It runs against a
+  `tsconfig.typecheck.json` covering `src/**/*` *including* `__tests__`, which
+  the build now excludes — so making the step real is what keeps test files
+  type-checked at all. Turning it on surfaced three pre-existing type errors in
+  `tests/integration`, a package that has no build step and had therefore never
+  been type-checked; they are fixed.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ build: clean install
 lint:
 	pnpm run lint
 
+.PHONY: typecheck
+typecheck:
+	pnpm run typecheck
+
 .PHONY: test
 test:
 	pnpm run test

--- a/create-app/package.json
+++ b/create-app/package.json
@@ -29,6 +29,7 @@
 	],
 	"scripts": {
 		"build": "tsc",
+		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
 		"prebuild": "node scripts/copy-templates.mjs",
 		"pretest": "node scripts/copy-templates.mjs",
 		"test": "vitest run"

--- a/create-app/tsconfig.json
+++ b/create-app/tsconfig.json
@@ -5,5 +5,5 @@
 		"outDir": "./dist"
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }

--- a/create-app/tsconfig.typecheck.json
+++ b/create-app/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
 		"build": "pnpm -r run build",
 		"test": "pnpm -r run test",
 		"test:coverage": "pnpm -r --if-present run test:coverage",
+		"typecheck": "pnpm -r --if-present run typecheck",
 		"lint": "biome check packages/ templates/ create-app/ tests/",
+		"audit": "pnpm audit --prod --audit-level=low",
 		"docs": "typedoc"
 	},
 	"devDependencies": {

--- a/packages/builtins/package.json
+++ b/packages/builtins/package.json
@@ -27,6 +27,7 @@
 	"scripts": {
 		"prebuild": "rimraf dist",
 		"build": "tsc",
+		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage"
 	},

--- a/packages/builtins/tsconfig.json
+++ b/packages/builtins/tsconfig.json
@@ -6,5 +6,5 @@
 		"paths": { "#/*": ["./src/*"] }
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }

--- a/packages/builtins/tsconfig.typecheck.json
+++ b/packages/builtins/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
 	"scripts": {
 		"prebuild": "rimraf dist",
 		"build": "tsc",
+		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage"
 	},

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,5 +6,5 @@
 		"paths": { "#/*": ["./src/*"] }
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,6 +27,7 @@
 	"scripts": {
 		"prebuild": "rimraf dist",
 		"build": "tsc",
+		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage"
 	},

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,5 +6,5 @@
 		"paths": { "#/*": ["./src/*"] }
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }

--- a/packages/server/tsconfig.typecheck.json
+++ b/packages/server/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs@>=6.11.1 <=6.15.1: ^6.15.2
+  body-parser@>=2.0.0 <2.3.0: ^2.3.0
+
 importers:
 
   .:
@@ -879,8 +883,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   brace-expansion@5.0.7:
@@ -917,6 +921,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1363,8 +1371,8 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -1422,8 +1430,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -1434,8 +1442,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -1508,6 +1516,10 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typedoc@0.28.20:
     resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
@@ -2133,17 +2145,17 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.1.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.3
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2174,6 +2186,8 @@ snapshots:
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2299,7 +2313,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -2318,7 +2332,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.3
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -2638,9 +2652,10 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
@@ -2729,7 +2744,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -2749,11 +2764,11 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -2783,7 +2798,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.0
+      qs: 6.15.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2828,6 +2843,12 @@ snapshots:
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,24 @@ packages:
   - "templates/*"
   - "create-app"
   - "tests/*"
+
+# Transitive advisories that `pnpm run audit` (--prod --audit-level=low) refuses.
+# Both reach us only through `express`, a production dependency of
+# packages/server, and both are fixed in a semver-compatible patch that express's
+# own range already allows — so pinning the floor here upgrades the resolved
+# version without forcing a new express.
+#
+# Each key is scoped to the *vulnerable* range rather than the bare package name,
+# so the override lapses on its own once express depends on a version at or above
+# the fix, instead of silently pinning us below a future release.
+#
+# Lives here rather than in package.json's `pnpm.overrides`: as of pnpm 10.29 that
+# field is no longer read ("The 'pnpm' field in package.json is no longer read by
+# pnpm"), and settings moved to this file.
+overrides:
+  # GHSA-q8mj-m7cp-5q26 — qs.stringify DoS on null/undefined entries in
+  # comma-format arrays with encodeValuesOnly.
+  "qs@>=6.11.1 <=6.15.1": "^6.15.2"
+  # GHSA-v422-hmwv-36x6 — body-parser silently disables size enforcement when
+  # given an invalid limit value.
+  "body-parser@>=2.0.0 <2.3.0": "^2.3.0"

--- a/templates/standalone/package.json
+++ b/templates/standalone/package.json
@@ -10,6 +10,7 @@
 	},
 	"scripts": {
 		"build": "tsc",
+		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
 		"start": "node dist/main.mjs",
 		"test": "vitest run",
 		"debug": "NODE_OPTIONS='--conditions=development' tsx watch src/main.mts"

--- a/templates/standalone/tsconfig.json
+++ b/templates/standalone/tsconfig.json
@@ -5,5 +5,5 @@
 		"outDir": "./dist"
 	},
 	"include": ["src/**/*"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
 }

--- a/templates/standalone/tsconfig.typecheck.json
+++ b/templates/standalone/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -7,6 +7,7 @@
 		"node": ">=22.0.0"
 	},
 	"scripts": {
+		"typecheck": "tsc --noEmit",
 		"test": "vitest run"
 	},
 	"dependencies": {

--- a/tests/integration/src/evaluate-with-rules.test.mts
+++ b/tests/integration/src/evaluate-with-rules.test.mts
@@ -36,7 +36,11 @@ describe("evaluate with AttrLiteralEqual + AttrPairNotEqual + AttrLiteralCompare
 	const rules: Rule[] = [ruleEqual, rulePairNotEqual, ruleCompare];
 
 	it("Scenario A: all three rules satisfied → allow", () => {
-		const attrs: Attributes = new Map([
+		// Explicit type arguments: these entry lists mix string and number values,
+		// so without them the Map constructor's overload resolution narrows to
+		// Map<string, string> from the first entry and rejects `level`. The
+		// annotation on `attrs` cannot rescue it — overload resolution runs first.
+		const attrs: Attributes = new Map<string, unknown>([
 			["role", "admin"],
 			["userId", "u1"],
 			["ownerId", "u2"],
@@ -50,7 +54,7 @@ describe("evaluate with AttrLiteralEqual + AttrPairNotEqual + AttrLiteralCompare
 
 	it("Scenario B: AttrPairNotEqual fails (userId === ownerId) → deny with attr_match", () => {
 		// Break AttrPairNotEqual: userId equals ownerId.
-		const attrs: Attributes = new Map([
+		const attrs: Attributes = new Map<string, unknown>([
 			["role", "admin"],
 			["userId", "u1"],
 			["ownerId", "u1"], // same → rule fails
@@ -72,7 +76,7 @@ describe("evaluate with AttrLiteralEqual + AttrPairNotEqual + AttrLiteralCompare
 		// AttrLiteralCompare still passes.
 		// Evaluator processes groups in insertion order: ruleEqual's group is first,
 		// so the deny reflects ruleEqual's code/message.
-		const attrs: Attributes = new Map([
+		const attrs: Attributes = new Map<string, unknown>([
 			["role", "user"], // not "admin" → AttrLiteralEqual fails
 			["userId", "u1"],
 			["ownerId", "u1"], // same → AttrPairNotEqual fails


### PR DESCRIPTION
Closes #122

Ports the two gates `auth.provider` runs for the same stack and this repo did not: a `pnpm audit` gate, and a publish-readiness job that tarballs the packages and builds the shipped scaffold against them.

## What was ported, and what was adapted

**The audit gate** is a straight port — `pnpm audit --prod --audit-level=low`, run before lint and build so an advisory in a shipped dependency fails fast rather than being buried under a test log.

**The publish-readiness job** needed three adaptations:

1. **Publish surface, not a name glob.** The provider packs `packages/*` filtered by a `@o3co/auth-provider-*` name pattern. That shape would silently miss `@o3co/create-auth-policy-verifier`, which lives outside `packages/` and does not share the prefix. This job instead reads the surface back from `pnpm list -r --depth -1 --json` and filters on `private` — the same question `pnpm -r publish` asks, so it cannot drift from what actually gets published. Today that resolves to the four packages AGENTS.md names; `templates/standalone` and `tests/integration` are `private: true` and never appear.

2. **A guard against a vacuous pass.** A separate step asserts the packed set equals that list. Without it, a pack that silently failed would leave every later assertion iterating a short tarball set and passing.

3. **The scaffold is built out of the create-app tarball.** The provider builds `templates/standalone` directly because its template tsconfig is self-contained. Ours still `extends ../../tsconfig.base.json`, and `copy-templates.mjs` inlines that base only when staging the shipped copy — so building the in-repo template in a scratch dir would fail on the missing base config. The job untars the packed `@o3co/create-auth-policy-verifier` and builds `package/templates/standalone` out of it, which is both the self-contained copy and the one consumers actually receive. That also puts the create-app tarball's own contents under test.

**Not ported: `check-versions-json.mjs`.** Its intent is covered more directly here — an assertion compares the shipped `templates/versions.json` against the shipped template's `workspace:*` deps, on the tarball. And unlike the provider, this repo already fails loudly on that drift at runtime: `scaffold()` in `create-app/src/index.mts` throws ``Cannot resolve version for workspace dependency "…"``, exercised by create-app's own suite. A second static copy of a guard that already exists would be the weaker of the two.

## The assertions were not hypothetical here

Porting the tarball assertions surfaced that this repo currently fails both:

- Every package's `tsconfig.json` included `src/**/__tests__/**`, so all four published packages shipped `dist/__tests__/` — **129 files**.
- **30 of those** kept `#/` specifiers. Those resolve through the package's own `imports` map, and under the `development` condition that is `./src/*` — a path no tarball ships. Node applies `--conditions` to every package on the graph, not just the root, so any consumer running under Vitest or `tsx watch` could resolve them into nothing. The workspace cannot see this, because `src/` is right there.

Excluding `src/**/__tests__/**` from each emitting `tsconfig.json` fixes both. The scaffold's own `templates/standalone/src/__tests__/` is consumer-facing source and is still shipped — the assertion is scoped to `dist/`, deliberately.

## The two #145 findings

Both are resolved, so **#145 can be closed**.

**`make audit` was broken** — the Makefile called a `pnpm run audit` script that did not exist. The script now exists and is exactly what the CI step runs, so the two cannot diverge. Added `make typecheck` alongside it for the same reason.

**`pnpm -r --if-present run typecheck` was a no-op in both workflows.** I made it real rather than deleting it, because the tsconfig change above gave it a job that `build` no longer does:

- each package's `tsconfig.json` (what `build` emits) now excludes `__tests__`
- each package's new `tsconfig.typecheck.json` (what `typecheck` checks, `--noEmit`) re-includes them

So `typecheck` is now the *only* thing type-checking test files, not a duplicate of `build`. Deleting the step would have silently dropped that coverage the moment the build stopped compiling tests. Both workflows call the root `typecheck` script together, so they stay in step. `tests/integration` has no build at all, so it gets a plain `tsc --noEmit`.

Turning it on surfaced **three pre-existing type errors** in `tests/integration/src/evaluate-with-rules.test.mts` — a package with no build step, which had therefore never been type-checked by anything. Heterogeneous `new Map([...])` entry lists whose overload resolution narrows to `Map<string, string>` and then rejects a numeric `level`. Fixed with explicit type arguments; runtime behaviour is unchanged (vitest strips types without checking them), and all 51 of its tests still pass.

## Vulnerabilities the audit gate found

Adding the gate did not produce a green run. On the unmodified tree `pnpm audit --prod --audit-level=low` reported two advisories, both reaching this workspace only through `express`, a production dependency of `@o3co/auth.policy-verifier.server`:

| | advisory | package | vulnerable | patched |
|---|---|---|---|---|
| moderate | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) | `qs` | `>=6.11.1 <=6.15.1` | `>=6.15.2` |
| low | [GHSA-v422-hmwv-36x6](https://github.com/advisories/GHSA-v422-hmwv-36x6) | `body-parser` | `>=2.0.0 <2.3.0` | `>=2.3.0` |

These are a **stale lockfile, not consumer exposure**: `express@5.2.1` asks for `qs@^6.14.0` and `body-parser@^2.2.1`, both of which admit the patched releases, so a consumer resolving today already floats to them. Our `pnpm-lock.yaml` had pinned `qs@6.15.0` and `body-parser@2.2.2`.

Fixed by upgrading, not by weakening the gate — `--audit-level=low` is untouched and nothing is ignored. The `overrides` block is scoped to each *vulnerable range* rather than the bare package name, so it lapses on its own once `express` requires a fixed version instead of holding the floor down indefinitely. It lives in `pnpm-workspace.yaml` rather than `package.json`'s `pnpm.overrides`, which pnpm 10.29 warns it no longer reads (the provider still has it in the old location).

## Local validation

Everything below was run in the worktree, from a clean `node_modules` and `dist`.

- **YAML parses** (`yaml.safe_load`) for all three workflows; `ci.yml` is 2 jobs — `build-and-test` (15 steps), `publish-readiness` (13 steps, `needs: build-and-test`).
- **Every `pnpm run <script>` the workflows call exists** — checked by extracting them from the parsed YAML and matching against root `package.json`: `audit`, `build`, `lint`, `test`, `test:coverage`, `typecheck`.
- **The publish-readiness job was extracted from the parsed YAML and executed verbatim**, not re-typed. All six steps green: packs exactly the 4 publishable packages, no `dist/__tests__`, no `#/` in `dist`, versions.json pins all 3 workspace deps, and the shipped scaffold builds against the packed tarballs.
- **Negative test** — reverted the `__tests__` exclusion in `packages/builtins`, rebuilt and repacked, and confirmed both assertions fire on the pre-fix tarball. The gate is not vacuously green.
- **`pnpm run audit` → `No known vulnerabilities found`**, and **`make audit` runs the identical command**.
- **Full CI sequence from clean**: `pnpm install --frozen-lockfile` → `audit` → `lint` (131 files) → `build` → `typecheck` (6/6 projects) → `test`.
- **Tests: 1099 passed across 49 files, 6 packages** — core 62, builtins 474, server 417, integration 51, standalone 30, create-app 65. No `--coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

