### PR TITLE
fix(server)!: put a 256-bit floor under every HS256 secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,93 @@ and version sections follow the release labeling policy in
   framework can know, and `RequestContextAttributeCollector` already offers the
   declared-allowlist shape for operators who want one.
 
+- **BREAKING**: an HS256 secret must now carry at least **32 bytes (256 bits)**
+  of key material
+  ([#114](https://github.com/o3co/auth.policy-verifier/issues/114)). The only
+  check before this was non-emptiness, so `OAUTH_JWT_SECRET=s` booted a
+  verifier, and the shipped examples used values like `secret` and
+  `your-secret`. HS256 is this project's default algorithm and it is symmetric:
+  the value that verifies a token is the value that signs one, so guessing it
+  is not read access to tokens, it is the ability to **mint** them for any
+  subject. RFC 7518 §3.2 requires a key at least as wide as the hash output,
+  and auth.provider holds the same shared value to the same floor
+  ([auth.provider#282](https://github.com/o3co/auth.provider/issues/282)) — a
+  floor that either side applies alone is a floor neither side has.
+
+  **How it is measured.** On the **decoded** material, at the smallest
+  plausible reading — the one an attacker gets to use. `openssl rand -hex 16`
+  produces a 32-*character* value carrying 16 *bytes*, and counting characters
+  would wave through a key of half the intended strength:
+
+  | Value | Reads as | Verdict |
+  | --- | --- | --- |
+  | 64 hex characters (`openssl rand -hex 32`) | 32 bytes | passes |
+  | 32 hex characters (`openssl rand -hex 16`) | 16 bytes | refused |
+  | 43 base64 characters + `=` (`openssl rand -base64 32`) | 32 bytes | passes |
+  | 32 random alphanumerics | 24 bytes — a base64 body | refused |
+  | 32-character passphrase containing punctuation | 32 bytes | passes |
+
+  Rejecting 32 alphanumerics is deliberate, not an artefact: 62 possibilities
+  per character is ~5.95 bits, not 8, so such a value really does carry only
+  ~190 bits. A value that is not a valid encoding — including a passphrase that
+  merely ends in `=` — is measured on its raw UTF-8 length rather than being
+  trimmed into a "base64 body" and scored short. What the check cannot see is
+  structure: a 40-character English sentence measures 40 bytes and carries far
+  less, so generate the secret randomly. This is a floor on key length, not a
+  review.
+
+  **One rule over every secret.** The floor applies to `oauth.jwt.secret` and
+  to every entry of `oauth.jwt.previousSecrets` (the HS256 rotation added in
+  [#112](https://github.com/o3co/auth.policy-verifier/issues/112)) in a single
+  check, because they are the same kind of value: a retired secret is a live
+  verification key for its whole overlap window, so it can mint tokens exactly
+  as the current one can. Splitting the check would have left one of them the
+  laxer half.
+
+  Both boundaries enforce it, as with the JWKS transport check: `AppConfigSchema`
+  rejects a short secret at config-parse time — so the deployment fails at boot,
+  where an operator sees it — and the HS256 `KeyResolverFactory` repeats the
+  check for hand-built configs that never met the schema. `insecure-decode`
+  mode is unaffected: it uses no key material at all. `createVerifyRouter`
+  takes key material directly rather than a config, and does not apply the
+  floor; a consumer wiring a `KeyObject` by hand owns that check.
+
+  The failure names the key the operator wrote and never echoes the value —
+  these messages reach stdout, container logs and pasted bug reports:
+
+  ```
+  oauth.jwt.secret must carry at least 32 bytes (256 bits) of key material,
+  but carries 11 — generate one with `openssl rand -hex 32`. Hex and base64
+  values are measured on their DECODED length, so a 32-character hex string
+  counts as only 16 bytes.
+  ```
+
+  **Operator migration** — every HS256 deployment whose secret is under the
+  floor stops booting, which is the point:
+
+  1. **Generate a conforming secret** and give the *same* value to
+     auth.provider, which signs with it:
+
+     ```bash
+     OAUTH_JWT_SECRET=$(openssl rand -hex 32)     # or: openssl rand -base64 32
+     ```
+
+     Do not shorten it to fit an existing secret store field, and do not reuse
+     a password. `openssl rand -hex 16` is **not** enough — that is 16 bytes.
+  2. **Rotate rather than cut over**, if tokens are in flight. Changing the
+     secret invalidates every token signed with the old one, so use the
+     `previousSecrets` overlap window documented in the README's *Rotating the
+     HS256 secret*: stage the new secret on the verifier first, move the
+     provider, then demote the old secret with an `expiresAt` of your
+     access-token TTL plus a buffer. Note the retired secret must itself clear
+     the floor — a rotation *away from* a weak secret needs the old value
+     dropped outright, and the outage that implies is bounded by the token TTL.
+  3. **Or move off HS256.** With a symmetric algorithm every relying party
+     holds a token-forging key. `algorithm = "RS256" | "ES256" | "EdDSA"` with
+     `jwksUri` lets this verifier hold only a public key; auth.provider
+     publishes the JWKS.
+  4. **Update fixtures and scripts** that mint tokens with a short shared
+     secret — they now fail at boot rather than at verification.
 - **BREAKING**: a bearer token must now carry `exp` **and** `iat`, and is
   refused if it does not
   ([#110](https://github.com/o3co/auth.policy-verifier/issues/110)). jose
@@ -384,7 +471,19 @@ and version sections follow the release labeling policy in
   ([#112](https://github.com/o3co/auth.policy-verifier/issues/112)), for
   consumers building a JWT config by hand or registering their own HS256 key
   resolver. They apply the identical contract the schema does, so a hand-built
-  config gets the same answer as a parsed one.
+  config gets the same answer as a parsed one. Both now also apply the entropy
+  floor over `secret` and every `previousSecrets[].secret`
+  ([#114](https://github.com/o3co/auth.policy-verifier/issues/114)) — a config
+  with no rotation at all is still checked, since the floor is one rule over
+  every HS256 secret rather than a rotation-only concern.
+- `@o3co/auth.policy-verifier.server` exports `measureSecretEntropyBytes` and
+  `describeWeakSecret` with the constant `MIN_SECRET_ENTROPY_BYTES`
+  ([#114](https://github.com/o3co/auth.policy-verifier/issues/114)), so a
+  consumer that accepts its own operator secrets — a custom key resolver, a
+  composition root assembling a JWT config — applies the identical reading
+  rather than a second opinion about what a 32-character hex string is worth.
+  `describeWeakSecret` takes the measurement and not the secret, which is the
+  guarantee that a rejection cannot echo the value into a log.
 - `@o3co/auth.policy-verifier.server` exports `resolveJwtTimeClaimBounds`
   (with `JwtTimeClaimConfig` / `JwtTimeClaimBounds`) and the constants
   `DEFAULT_MAX_TOKEN_AGE_SECONDS`, `DEFAULT_CLOCK_TOLERANCE_SECONDS` and

--- a/README.ja.md
+++ b/README.ja.md
@@ -72,11 +72,13 @@ POST /verify/batch — 同じ契約で、1 往復に N 件の decision
 npx @o3co/create-auth-policy-verifier my-policy-verifier
 cd my-policy-verifier
 pnpm install
-OAUTH_JWT_SECRET=your-secret \
+OAUTH_JWT_SECRET=$(openssl rand -hex 32) \
   OAUTH_JWT_ISSUER=https://issuer.example.com \
   OAUTH_JWT_AUDIENCE=https://api.example.com \
   pnpm start
 ```
+
+HS256 シークレットは鍵素材として **32 バイト（256 ビット）以上**を要求し、これを下回ると起動を拒否する — 詳細は [HS256 シークレットのローテーション](#hs256-シークレットのローテーション)。auth.provider が署名に使うのと同じ値を設定すること。
 
 ```bash
 curl -X POST http://localhost:3000/verify \
@@ -194,7 +196,7 @@ oauth {
     algorithm = ${?OAUTH_JWT_ALGORITHM}
 
     # ---- HS256 専用。以下 2 グループのどちらか一方だけを使うこと。 --------
-    secret = ${?OAUTH_JWT_SECRET}
+    secret = ${?OAUTH_JWT_SECRET}            # デコード後 32 バイト以上 — `openssl rand -hex 32`
     kid = ${?OAUTH_JWT_KID}                  # 上の secret に名前を付ける。未設定ならトークンヘッダを参照しない
     # previousSecrets — 重複期間中の旧シークレット、最大 3 件。ここにあえて
     # 書いていない: このキーは RS256/ES256/EdDSA では（空リストであっても）
@@ -299,6 +301,22 @@ oauth.jwt {
 }
 ```
 
+**HS256 シークレットは鍵素材として 32 バイト（256 ビット）以上を持つこと。** 足りない値は最初のリクエストではなく起動時に拒否される。HS256 は対称鍵であり、トークンを検証する値がトークンを署名する値そのものなので、推測されることは読み取りではなく「任意の subject のトークンを発行できる」ことを意味する。RFC 7518 §3.2 はハッシュ出力幅以上の鍵を要求しており、auth.provider も同じ値に同じ下限を課している。
+
+生成は `openssl rand -hex 32`（または `openssl rand -base64 32`）。判定は**デコード後**の素材に対して、もっとも小さく読める解釈で行う:
+
+| 値 | 読み取り結果 | 判定 |
+| --- | --- | --- |
+| `openssl rand -hex 32` — 16 進 64 文字 | 32 バイト | 通る |
+| `openssl rand -hex 16` — 16 進 32 文字 | 16 バイト | 拒否 |
+| `openssl rand -base64 32` — 43 文字 + `=` | 32 バイト | 通る |
+| ランダムな英数字 32 文字 | 24 バイト（base64 本体として読める） | 拒否 |
+| 記号を含む 32 文字のパスフレーズ | 32 バイト | 通る |
+
+見えるのは長さだけで、40 文字の英文は 40 バイトと数えられるが実際の強度ははるかに低い。シークレットは必ずランダムに生成すること。この検査は下限であって審査ではない。
+
+下限は `secret` と下記 `previousSecrets` の全エントリに 1 つのルールとして適用される — 退役したシークレットも重複期間中は検証鍵であり、現行と同じようにトークンを発行できるからである。
+
 ### HS256 シークレットのローテーション
 
 共有シークレットが 1 つしかない状態では、無停止でシークレットを変更する方法が存在しない。auth.provider が新しい値で署名を始めた瞬間、すでに発行済みのトークンは両サービスを同時に再起動し終えるまですべてここで弾かれる。`previousSecrets` はその同時再起動を不要にする重複期間であり、auth.provider がローテーションに使うのと同じ `kid` + `secret` + `expiresAt` の形なので、同じ 1 組の値を両側で動かすだけで済む。
@@ -384,7 +402,7 @@ cd my-verifier
 docker build -t my-verifier .
 docker run -p 3000:3000 \
   -e HTTP_HOSTNAME=0.0.0.0 -e HTTP_CALLER_AUTH_TOKEN=<secret> \
-  -e OAUTH_JWT_SECRET=secret my-verifier
+  -e OAUTH_JWT_SECRET=$(openssl rand -hex 32) my-verifier
 ```
 
 スキャフォルダーが `pnpm-lock.yaml` を生成します。イメージは

--- a/README.md
+++ b/README.md
@@ -72,11 +72,13 @@ POST /verify/batch — the same contract, N decisions per round trip
 npx @o3co/create-auth-policy-verifier my-policy-verifier
 cd my-policy-verifier
 pnpm install
-OAUTH_JWT_SECRET=your-secret \
+OAUTH_JWT_SECRET=$(openssl rand -hex 32) \
   OAUTH_JWT_ISSUER=https://issuer.example.com \
   OAUTH_JWT_AUDIENCE=https://api.example.com \
   pnpm start
 ```
+
+The HS256 secret must carry at least **32 bytes (256 bits)** of key material or the process refuses to boot — see [Rotating the HS256 secret](#rotating-the-hs256-secret). Use the same value auth.provider signs with.
 
 ```bash
 curl -X POST http://localhost:3000/verify \
@@ -198,7 +200,7 @@ oauth {
     algorithm = ${?OAUTH_JWT_ALGORITHM}
 
     # ---- HS256 only. Keep exactly one of these two groups. --------------
-    secret = ${?OAUTH_JWT_SECRET}
+    secret = ${?OAUTH_JWT_SECRET}            # >= 32 decoded bytes — `openssl rand -hex 32`
     kid = ${?OAUTH_JWT_KID}                  # names the secret above; unset means the token header is not consulted
     # previousSecrets — retired secrets still inside their overlap window,
     # max 3. Omitted here on purpose: the key is REFUSED at boot under
@@ -304,6 +306,22 @@ oauth.jwt {
 }
 ```
 
+**Every HS256 secret must carry at least 32 bytes (256 bits) of key material**, and a shorter one is refused at boot rather than at the first request. HS256 is symmetric: the value that verifies a token is the value that signs one, so guessing it is not read access, it is the ability to mint tokens for any subject. RFC 7518 §3.2 requires a key at least as wide as the hash output, and auth.provider enforces the same floor on the same value.
+
+Generate one with `openssl rand -hex 32` (or `openssl rand -base64 32`). The measurement is on **decoded** material, at the smallest plausible reading:
+
+| Value | Reads as | Verdict |
+| --- | --- | --- |
+| `openssl rand -hex 32` — 64 hex characters | 32 bytes | passes |
+| `openssl rand -hex 16` — 32 hex characters | 16 bytes | refused |
+| `openssl rand -base64 32` — 43 characters + `=` | 32 bytes | passes |
+| 32 random alphanumerics | 24 bytes (a base64 body) | refused |
+| a 32-character passphrase with punctuation | 32 bytes | passes |
+
+Length is all this can see: a 40-character English sentence measures 40 bytes and carries far less. Generate the secret randomly; the check is a floor, not a review.
+
+The floor applies to `secret` and to every entry of `previousSecrets` below, in one rule — a retired secret verifies for its whole overlap window, so it can mint tokens exactly as the current one can.
+
 ### Rotating the HS256 secret
 
 Under a single shared secret there is no way to change it without an outage: the moment auth.provider signs with a new value, every token already in flight fails here until both services have restarted in lockstep. `previousSecrets` is the overlap window that removes the lockstep — the same `kid` + `secret` + `expiresAt` shape auth.provider rotates with, so one pair of values moves on both sides.
@@ -389,7 +407,7 @@ cd my-verifier
 docker build -t my-verifier .
 docker run -p 3000:3000 \
   -e HTTP_HOSTNAME=0.0.0.0 -e HTTP_CALLER_AUTH_TOKEN=<secret> \
-  -e OAUTH_JWT_SECRET=secret my-verifier
+  -e OAUTH_JWT_SECRET=$(openssl rand -hex 32) my-verifier
 ```
 
 The scaffolder generates `pnpm-lock.yaml`; the image builds with

--- a/packages/server/README.ja.md
+++ b/packages/server/README.ja.md
@@ -99,7 +99,7 @@ const AppConfigSchema = z.object({
   }),
   oauth: z.object({
     jwt: z.object({
-      secret: z.string(),
+      secret: z.string().optional(),                                   // HS256: デコード後 32 バイト以上
       mode: z.enum(["verify", "insecure-decode"]).default("verify"),
       issuer: z.union([z.string(), z.array(z.string())]).optional(),   // mode = "verify" のとき必須
       audience: z.union([z.string(), z.array(z.string())]).optional(), // mode = "verify" のとき必須
@@ -126,6 +126,8 @@ type AppConfig = z.infer<typeof AppConfigSchema>;
 ```
 
 `attribute.collectors` と `rule.collectors` の各エントリには `collector` フィールド（登録済みファクトリ名）が必須です。追加フィールドはファクトリへの設定としてそのまま渡されます。
+
+**HS256 のシークレットは鍵素材として 32 バイト（256 ビット）以上を持つこと。** この下限は `oauth.jwt.secret` と `oauth.jwt.previousSecrets[].secret` の全件に 1 つのルールとして適用されます — 退役したシークレットも重複期間中は検証鍵であり、現行と同じようにトークンを発行できるからです。判定はデコード後の素材に対してもっとも小さく読める解釈で行うため、16 進 64 文字は通り（32 バイト）、16 進 32 文字は通りません（16 バイト）。生成は `openssl rand -hex 32`。`AppConfigSchema` が config パース時に拒否し、HS256 の `KeyResolverFactory` が hand-built config のために同じ検査を繰り返します。独自の HS256 key resolver を登録する利用者向けに `measureSecretEntropyBytes` / `describeWeakSecret` / `MIN_SECRET_ENTROPY_BYTES` を公開しています。`createVerifyRouter` は鍵素材を直接受け取るため下限を適用しません — `KeyObject` を自分で組み立てる呼び出し側がその検査を負います。
 
 ### 信頼境界
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -99,7 +99,7 @@ const AppConfigSchema = z.object({
   }),
   oauth: z.object({
     jwt: z.object({
-      secret: z.string(),
+      secret: z.string().optional(),                                   // HS256: >= 32 decoded bytes
       mode: z.enum(["verify", "insecure-decode"]).default("verify"),
       issuer: z.union([z.string(), z.array(z.string())]).optional(),   // required when mode is "verify"
       audience: z.union([z.string(), z.array(z.string())]).optional(), // required when mode is "verify"
@@ -126,6 +126,8 @@ type AppConfig = z.infer<typeof AppConfigSchema>;
 ```
 
 Each entry in `attribute.collectors` and `rule.collectors` requires a `collector` field (the registered factory name). Additional fields are passed through to the factory as configuration.
+
+**HS256 secrets must carry at least 32 bytes (256 bits) of key material.** The floor applies to `oauth.jwt.secret` and to every `oauth.jwt.previousSecrets[].secret` in one rule, since a retired secret verifies for its whole overlap window and can mint tokens exactly as the current one can. It is measured on decoded material at the smallest plausible reading, so 64 hex characters pass (32 bytes) and 32 hex characters do not (16 bytes); generate one with `openssl rand -hex 32`. `AppConfigSchema` rejects a short secret at config-parse time and the HS256 `KeyResolverFactory` repeats the check for hand-built configs. `measureSecretEntropyBytes` / `describeWeakSecret` / `MIN_SECRET_ENTROPY_BYTES` are exported for consumers registering their own HS256 key resolver; `createVerifyRouter` takes key material directly and does not apply the floor, so a caller wiring a `KeyObject` by hand owns that check.
 
 ### Trust boundary
 

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -12,7 +12,8 @@ import {
 	JWT_MODE_MIGRATION_MESSAGE,
 } from "#/index.mjs";
 
-const JWT_SECRET = "test-secret";
+/** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
+const JWT_SECRET = "11".repeat(32);
 const secretKey = new TextEncoder().encode(JWT_SECRET);
 const ISSUER = "https://issuer.test";
 const AUDIENCE = "https://api.test";
@@ -969,4 +970,31 @@ describe("createApp — HS256 secret rotation (#112)", () => {
 			}),
 		).rejects.toThrow(/^oauth\.jwt\.kid is required/);
 	});
+
+	it.each([
+		["the current secret", { secret: "your-secret" }, /^oauth\.jwt\.secret must carry at least/],
+		[
+			"a retired secret",
+			{
+				previousSecrets: [{ kid: "v0", secret: "your-secret", expiresAt: "2999-01-01T00:00:00Z" }],
+			},
+			/^oauth\.jwt\.previousSecrets\[0\]\.secret must carry at least/,
+		],
+	])(
+		"refuses to boot on a hand-built config whose %s is under the entropy floor (#114)",
+		async (_label, override, message) => {
+			const handBuilt = {
+				...rotatedConfig,
+				oauth: { jwt: { ...rotatedConfig.oauth.jwt, ...override } },
+			} as unknown as typeof rotatedConfig;
+
+			await expect(
+				createApp({
+					pathResolver: (s: string) => s,
+					config: handBuilt,
+					modules: [testModule, builtinKeyResolversModule],
+				}),
+			).rejects.toThrow(message);
+		},
+	);
 });

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -3,13 +3,21 @@
 
 import { describe, expect, it } from "vitest";
 import { AppConfigSchema, JWT_MODE_MIGRATION_MESSAGE } from "#/config/application.schema.mjs";
-import { MAX_PREVIOUS_SECRETS } from "#/config/defaults.mjs";
+import { MAX_PREVIOUS_SECRETS, MIN_SECRET_ENTROPY_BYTES } from "#/config/defaults.mjs";
 import { checkHs256Rotation, parseHs256Rotation } from "#/jwt/hs256Rotation.mjs";
 
 const baseBody = {
 	attribute: { collectors: [] },
 	rule: { collectors: [] },
 };
+
+/**
+ * 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces on
+ * every HS256 secret. Every HS256 fixture in this file has to clear it, so the
+ * cases about other keys are not silently testing a rejected secret instead.
+ */
+const SECRET = "11".repeat(32);
+const OLD_SECRET = "22".repeat(32);
 
 /** Issuer/audience are required whenever validation is on; most cases here only care about keys. */
 const rfc9068 = { issuer: "https://issuer.test", audience: "https://api.test" };
@@ -55,7 +63,7 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 
 	it("accepts HS256 with secret", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 } },
+			oauth: { jwt: { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.success).toBe(true);
@@ -64,6 +72,70 @@ describe("AppConfigSchema — JWT algorithm validation", () => {
 	it("skips key-material validation in insecure-decode mode", () => {
 		const result = AppConfigSchema.safeParse({
 			oauth: { jwt: { algorithm: "RS256", mode: "insecure-decode" } },
+			...baseBody,
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
+describe("AppConfigSchema — HS256 secret entropy floor (#114)", () => {
+	const FUTURE = "2999-01-01T00:00:00Z";
+
+	/** Parses an `oauth.jwt` HS256 block with the RFC 9068 fields in place. */
+	const parseJwt = (jwt: Record<string, unknown>) =>
+		AppConfigSchema.safeParse({
+			oauth: { jwt: { algorithm: "HS256", mode: "verify", ...rfc9068, ...jwt } },
+			...baseBody,
+		});
+
+	it.each([
+		["a one-character secret", "x"],
+		["the README's old example value", "your-secret"],
+		["a 32-character hex secret — 16 decoded bytes", "ab".repeat(16)],
+		["32 alphanumerics — a base64 body carrying 24 bytes", "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"],
+	])("refuses %s at config-parse time", (_label, secret) => {
+		const result = parseJwt({ secret });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issue = result.error.issues.find((i) => i.path.at(-1) === "secret");
+			expect(issue?.message).toMatch(/at least 32 bytes/);
+			expect(issue?.message).toMatch(/openssl rand -hex 32/);
+		}
+	});
+
+	it("never echoes the rejected secret into the failure", () => {
+		const result = parseJwt({ secret: "hunter2-do-not-leak" });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(JSON.stringify(result.error.issues)).not.toContain("hunter2-do-not-leak");
+		}
+	});
+
+	it.each([
+		["a 64-character hex secret", SECRET],
+		["a padded base64 secret", "qmV+afsq/SMZ7hPGs9edVQDvPzNmjXemJNjqti181v0="],
+		["a passphrase at exactly the floor", `${"a".repeat(MIN_SECRET_ENTROPY_BYTES - 1)}!`],
+	])("accepts %s", (_label, secret) => {
+		expect(parseJwt({ secret }).success).toBe(true);
+	});
+
+	it("holds every previousSecrets entry to the same floor (#112 rotation)", () => {
+		const result = parseJwt({
+			secret: SECRET,
+			kid: "v1",
+			previousSecrets: [{ kid: "v0", secret: "x", expiresAt: FUTURE }],
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issue = result.error.issues.find((i) => i.message.includes("previousSecrets[0]"));
+			expect(issue?.path).toEqual(["oauth", "jwt", "previousSecrets", 0, "secret"]);
+			expect(issue?.message).toMatch(/at least 32 bytes/);
+		}
+	});
+
+	it("does not apply the floor in insecure-decode mode — no key material is used", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { algorithm: "HS256", mode: "insecure-decode", secret: "x" } },
 			...baseBody,
 		});
 		expect(result.success).toBe(true);
@@ -163,7 +235,7 @@ describe("AppConfigSchema — JWKS transport security (#109)", () => {
 describe("AppConfigSchema — empty rule set policy", () => {
 	it("defaults rule.onEmptyRuleSet to deny", () => {
 		const result = AppConfigSchema.parse({
-			oauth: { jwt: { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 } },
+			oauth: { jwt: { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.rule.onEmptyRuleSet).toBe("deny");
@@ -171,7 +243,7 @@ describe("AppConfigSchema — empty rule set policy", () => {
 
 	it("accepts an explicit allow opt-out", () => {
 		const result = AppConfigSchema.parse({
-			oauth: { jwt: { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 } },
+			oauth: { jwt: { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 } },
 			attribute: { collectors: [] },
 			rule: { collectors: [], onEmptyRuleSet: "allow" },
 		});
@@ -180,7 +252,7 @@ describe("AppConfigSchema — empty rule set policy", () => {
 
 	it("rejects an unrecognized onEmptyRuleSet value", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 } },
+			oauth: { jwt: { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 } },
 			attribute: { collectors: [] },
 			rule: { collectors: [], onEmptyRuleSet: "maybe" },
 		});
@@ -189,7 +261,7 @@ describe("AppConfigSchema — empty rule set policy", () => {
 });
 
 describe("AppConfigSchema — RFC 9068 token validation (#105)", () => {
-	const hs256 = { algorithm: "HS256", secret: "s" };
+	const hs256 = { algorithm: "HS256", secret: SECRET };
 
 	it('rejects mode="verify" without an issuer', () => {
 		const result = AppConfigSchema.safeParse({
@@ -254,7 +326,7 @@ describe("AppConfigSchema — RFC 9068 token validation (#105)", () => {
 });
 
 describe("AppConfigSchema — batch decisions (#124)", () => {
-	const validJwt = { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 };
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
 
 	it("defaults verify.maxBatchSize to 50", () => {
 		const result = AppConfigSchema.parse({ oauth: { jwt: validJwt }, ...baseBody });
@@ -290,7 +362,7 @@ describe("AppConfigSchema — batch decisions (#124)", () => {
 });
 
 describe("AppConfigSchema — token lifetime bounds (#110)", () => {
-	const validJwt = { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 };
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
 
 	/** Parses a valid verify config whose lifetime bounds the case under test overrides. */
 	const parseWithBounds = (jwt: Record<string, unknown>) =>
@@ -351,7 +423,7 @@ describe("AppConfigSchema — token lifetime bounds (#110)", () => {
 });
 
 describe("AppConfigSchema — multiple acceptable issuers (#105)", () => {
-	const hs256 = { algorithm: "HS256", secret: "s" };
+	const hs256 = { algorithm: "HS256", secret: SECRET };
 
 	it("accepts an issuer list, matching the router's issuer type", () => {
 		const result = AppConfigSchema.safeParse({
@@ -427,7 +499,7 @@ describe("AppConfigSchema — oauth.jwt.mode (#134)", () => {
 
 	it('defaults mode to "verify"', () => {
 		const result = AppConfigSchema.parse({
-			oauth: { jwt: { secret: "s", ...rfc9068 } },
+			oauth: { jwt: { secret: SECRET, ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.oauth.jwt.mode).toBe("verify");
@@ -437,7 +509,7 @@ describe("AppConfigSchema — oauth.jwt.mode (#134)", () => {
 		// The default must not be a way to skip iss/aud: an omitted mode is
 		// verify mode, so a config with no issuer still fails to parse.
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { secret: "s" } },
+			oauth: { jwt: { secret: SECRET } },
 			...baseBody,
 		});
 		expect(result.success).toBe(false);
@@ -453,7 +525,7 @@ describe("AppConfigSchema — oauth.jwt.mode (#134)", () => {
 
 	it("rejects an unknown mode value", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { mode: "decode", secret: "s", ...rfc9068 } },
+			oauth: { jwt: { mode: "decode", secret: SECRET, ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.success).toBe(false);
@@ -461,7 +533,7 @@ describe("AppConfigSchema — oauth.jwt.mode (#134)", () => {
 
 	it("rejects a boolean mode — an accidental env-var flip cannot select insecure-decode", () => {
 		const result = AppConfigSchema.safeParse({
-			oauth: { jwt: { mode: false, secret: "s", ...rfc9068 } },
+			oauth: { jwt: { mode: false, secret: SECRET, ...rfc9068 } },
 			...baseBody,
 		});
 		expect(result.success).toBe(false);
@@ -471,7 +543,7 @@ describe("AppConfigSchema — oauth.jwt.mode (#134)", () => {
 		"hard-errors on the removed key %s with the migration message",
 		(staleKey) => {
 			const result = AppConfigSchema.safeParse({
-				oauth: { jwt: { secret: "s", ...rfc9068, [staleKey]: true } },
+				oauth: { jwt: { secret: SECRET, ...rfc9068, [staleKey]: true } },
 				...baseBody,
 			});
 			expect(result.success).toBe(false);
@@ -494,7 +566,7 @@ describe("AppConfigSchema — oauth.jwt.mode (#134)", () => {
 });
 
 describe("AppConfigSchema — http bind address (#108)", () => {
-	const validJwt = { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 };
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
 
 	it("defaults http.hostname to loopback when the http section is absent", () => {
 		// A verifier is a sidecar by default: reachable only from the process
@@ -524,7 +596,7 @@ describe("AppConfigSchema — http bind address (#108)", () => {
 });
 
 describe("AppConfigSchema — http.callerAuth (#108)", () => {
-	const validJwt = { algorithm: "HS256", secret: "s", mode: "verify", ...rfc9068 };
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
 
 	it("leaves http.callerAuth absent when nothing configures it", () => {
 		const result = AppConfigSchema.parse({ oauth: { jwt: validJwt }, ...baseBody });
@@ -584,9 +656,6 @@ describe("AppConfigSchema — http.callerAuth (#108)", () => {
 });
 
 describe("AppConfigSchema — HS256 secret rotation (#112)", () => {
-	/** 64 hex characters — 32 decoded bytes, the floor auth.provider#282 set. */
-	const SECRET = "11".repeat(32);
-	const OLD_SECRET = "22".repeat(32);
 	const FUTURE = "2999-01-01T00:00:00Z";
 
 	/** Parses an `oauth.jwt` block with the RFC 9068 fields already in place. */

--- a/packages/server/src/__tests__/builtinKeyResolversModule.test.mts
+++ b/packages/server/src/__tests__/builtinKeyResolversModule.test.mts
@@ -59,7 +59,12 @@ describe("builtinKeyResolversModule", () => {
 		await builtinKeyResolversModule.init(context);
 
 		const factory = context.keyResolverRegistry.get("HS256");
-		const resolver = await factory({ algorithm: "HS256", secret: "test-secret", validate: true });
+		// 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces.
+		const resolver = await factory({
+			algorithm: "HS256",
+			secret: "11".repeat(32),
+			validate: true,
+		});
 
 		expect(resolver.algorithms).toEqual(["HS256"]);
 		expect(resolver.key).toBeDefined();
@@ -462,6 +467,26 @@ describe("HS256KeyResolverFactory — secret rotation (#112)", () => {
 				previousSecrets: [{ kid: "v0", secret: PREVIOUS, expiresAt: "soon" }],
 			},
 			/^oauth\.jwt\.previousSecrets\[0\]\.expiresAt is not a valid timestamp/,
+		],
+		[
+			"a current secret under the entropy floor (#114)",
+			{ algorithm: "HS256", secret: "your-secret" },
+			/^oauth\.jwt\.secret must carry at least 32 bytes/,
+		],
+		[
+			"a current secret that is 32 hex characters — 16 decoded bytes (#114)",
+			{ algorithm: "HS256", secret: "ab".repeat(16) },
+			/^oauth\.jwt\.secret must carry at least 32 bytes/,
+		],
+		[
+			"a retired secret under the entropy floor (#114)",
+			{
+				algorithm: "HS256",
+				secret: CURRENT,
+				kid: "v1",
+				previousSecrets: [{ kid: "v0", secret: "your-secret", expiresAt: FUTURE }],
+			},
+			/^oauth\.jwt\.previousSecrets\[0\]\.secret must carry at least 32 bytes/,
 		],
 	])("refuses %s at construction", async (_label, config, message) => {
 		// AppConfigSchema rejects these at config-parse time; the factory re-checks

--- a/packages/server/src/__tests__/decisionLogging.test.mts
+++ b/packages/server/src/__tests__/decisionLogging.test.mts
@@ -44,7 +44,8 @@ import { HS256KeyResolverFactory, type VerifyRouterJwtConfig } from "#/jwt/index
 import { decisionEvent } from "#/observability/decisionEvent.mjs";
 import { createVerifyRouter } from "#/routes/verify.mjs";
 
-const JWT_SECRET = "test-secret";
+/** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
+const JWT_SECRET = "11".repeat(32);
 const hs256Key = await HS256KeyResolverFactory({ secret: JWT_SECRET });
 const ISSUER = "https://issuer.test";
 const AUDIENCE = "https://api.test";

--- a/packages/server/src/__tests__/hs256Rotation.test.mts
+++ b/packages/server/src/__tests__/hs256Rotation.test.mts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { MAX_PREVIOUS_SECRETS } from "#/config/defaults.mjs";
+import { MAX_PREVIOUS_SECRETS, MIN_SECRET_ENTROPY_BYTES } from "#/config/defaults.mjs";
 import { checkHs256Rotation, parseHs256Rotation } from "#/jwt/hs256Rotation.mjs";
 
 /** 64 hex characters — 32 decoded bytes, the floor auth.provider#282 set. */
@@ -195,6 +195,108 @@ describe("checkHs256Rotation — the invariants rotation depends on", () => {
 	});
 });
 
+describe("checkHs256Rotation — the entropy floor (#114)", () => {
+	/** 32 characters, but only 16 decoded bytes: the value the floor is for. */
+	const SHORT_HEX = "ab".repeat(16);
+
+	it("refuses a one-character current secret", () => {
+		const result = checkHs256Rotation({ secret: "x" });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.issues).toEqual([
+				{ path: ["secret"], message: expect.stringContaining("at least 32 bytes") },
+			]);
+		}
+	});
+
+	it("measures the current secret on its decoded length, so 32 hex characters is 16 bytes", () => {
+		const result = checkHs256Rotation({ secret: SHORT_HEX });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.issues[0]?.path).toEqual(["secret"]);
+			expect(result.issues[0]?.message).toMatch(/carries 16/);
+		}
+	});
+
+	it("accepts a current secret at exactly the floor", () => {
+		// '!' is outside both base64 alphabets, so the 32-byte UTF-8 reading is
+		// the only plausible one.
+		const atFloor = `${"a".repeat(MIN_SECRET_ENTROPY_BYTES - 1)}!`;
+		expect(checkHs256Rotation({ secret: atFloor }).ok).toBe(true);
+	});
+
+	it("refuses a current secret one byte below the floor", () => {
+		const belowFloor = `${"a".repeat(MIN_SECRET_ENTROPY_BYTES - 2)}!`;
+		expect(checkHs256Rotation({ secret: belowFloor }).ok).toBe(false);
+	});
+
+	it("holds a retired secret to the same floor as the current one", () => {
+		// A retired secret verifies for the whole overlap window, so it can mint
+		// tokens exactly as the current one can.
+		const result = checkHs256Rotation({
+			secret: SECRET,
+			kid: "v1",
+			previousSecrets: [{ kid: "v0", secret: "x", expiresAt: future }],
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.issues).toEqual([
+				{
+					path: ["previousSecrets", 0, "secret"],
+					message: expect.stringContaining("previousSecrets[0].secret"),
+				},
+			]);
+		}
+	});
+
+	it("reports the current secret and every weak entry in one pass", () => {
+		// The point of putting the floor here rather than in either boundary
+		// alone: one rule, one round trip, no laxer half.
+		const result = checkHs256Rotation({
+			secret: "weak",
+			kid: "v2",
+			previousSecrets: [
+				{ kid: "v0", secret: "x", expiresAt: future },
+				{ kid: "v1", secret: OLD_SECRET, expiresAt: future },
+			],
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.issues.map((issue) => issue.path)).toEqual([
+				["secret"],
+				["previousSecrets", 0, "secret"],
+			]);
+		}
+	});
+
+	it("leaves an absent secret to the required-secret check at each boundary", () => {
+		// Nothing to measure, and "secret is required for HS256" is already said
+		// once by the schema and once by the key resolver factory.
+		expect(checkHs256Rotation({ previousSecrets: [] }).ok).toBe(true);
+	});
+
+	it("does not report a weak secret twice when the entry is also malformed", () => {
+		const result = checkHs256Rotation({
+			secret: SECRET,
+			kid: "v1",
+			previousSecrets: [{ kid: "v0", secret: "", expiresAt: future }],
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0]?.message).toMatch(/non-empty string/);
+		}
+	});
+
+	it("accepts the umbrella E2E's shared secret", () => {
+		// Defined once in o3co/auth's Makefile and given to both the provider and
+		// this verifier: 32 decoded bytes, exactly at the floor.
+		expect(checkHs256Rotation({ secret: "qmV+afsq/SMZ7hPGs9edVQDvPzNmjXemJNjqti181v0=" }).ok).toBe(
+			true,
+		);
+	});
+});
+
 describe("parseHs256Rotation", () => {
 	it("returns the narrowed rotation config", () => {
 		expect(
@@ -222,5 +324,21 @@ describe("parseHs256Rotation", () => {
 		expect(() => parseHs256Rotation({ secret: SECRET, previousSecrets: 7 }, "jwt")).toThrow(
 			/^jwt\.previousSecrets must be an array/,
 		);
+	});
+
+	it("throws on a current secret under the floor (#114)", () => {
+		expect(() => parseHs256Rotation({ secret: "x" })).toThrow(
+			/^oauth\.jwt\.secret must carry at least 32 bytes/,
+		);
+	});
+
+	it("throws on a retired secret under the floor (#114)", () => {
+		expect(() =>
+			parseHs256Rotation({
+				secret: SECRET,
+				kid: "v1",
+				previousSecrets: [{ kid: "v0", secret: "x", expiresAt: future }],
+			}),
+		).toThrow(/^oauth\.jwt\.previousSecrets\[0\]\.secret must carry at least 32 bytes/);
 	});
 });

--- a/packages/server/src/__tests__/metrics.test.mts
+++ b/packages/server/src/__tests__/metrics.test.mts
@@ -28,7 +28,8 @@ import { describe, expect, it } from "vitest";
 import { AppConfigSchema, builtinKeyResolversModule, createApp } from "#/index.mjs";
 import { createMetrics, MAX_DENY_CODE_LABELS } from "#/observability/metrics.mjs";
 
-const JWT_SECRET = "metrics-test-secret";
+/** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
+const JWT_SECRET = "11".repeat(32);
 const secretKey = new TextEncoder().encode(JWT_SECRET);
 const ISSUER = "https://issuer.test";
 const AUDIENCE = "https://api.test";

--- a/packages/server/src/__tests__/secretEntropy.test.mts
+++ b/packages/server/src/__tests__/secretEntropy.test.mts
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MIN_SECRET_ENTROPY_BYTES } from "#/config/defaults.mjs";
+import { describeWeakSecret, measureSecretEntropyBytes } from "#/config/secretEntropy.mjs";
+
+describe("MIN_SECRET_ENTROPY_BYTES", () => {
+	it("is 32 bytes (256 bits) — the same floor auth.provider#282 set", () => {
+		expect(MIN_SECRET_ENTROPY_BYTES).toBe(32);
+	});
+});
+
+describe("measureSecretEntropyBytes", () => {
+	it("measures an ordinary passphrase by its UTF-8 byte length", () => {
+		// '.' is outside both the base64 and base64url alphabets, so the UTF-8
+		// reading is the only plausible one.
+		expect(measureSecretEntropyBytes("abc.def")).toBe(7);
+	});
+
+	it("counts multi-byte UTF-8 characters as their encoded byte length", () => {
+		// 5 x 3-byte characters + '.'
+		expect(measureSecretEntropyBytes("パスワード.")).toBe(16);
+	});
+
+	it("returns 0 for an empty string", () => {
+		expect(measureSecretEntropyBytes("")).toBe(0);
+	});
+
+	it("measures a one-character secret as one byte", () => {
+		expect(measureSecretEntropyBytes("x")).toBe(1);
+	});
+
+	it("measures a hex secret on its DECODED length, not its character count", () => {
+		const hex = randomBytes(32).toString("hex"); // 64 characters
+		expect(hex).toHaveLength(64);
+		expect(measureSecretEntropyBytes(hex)).toBe(32);
+	});
+
+	it("reads a 32-character hex secret as the 16 bytes it actually carries", () => {
+		const hex = randomBytes(16).toString("hex"); // 32 characters, 16 bytes
+		expect(measureSecretEntropyBytes(hex)).toBe(16);
+		expect(measureSecretEntropyBytes(hex)).toBeLessThan(MIN_SECRET_ENTROPY_BYTES);
+	});
+
+	it("measures a base64url secret on its decoded length", () => {
+		const b64 = randomBytes(32).toString("base64url"); // 43 characters, unpadded
+		expect(b64).toHaveLength(43);
+		expect(measureSecretEntropyBytes(b64)).toBe(32);
+	});
+
+	it("measures a padded standard-base64 secret on its decoded length", () => {
+		const b64 = randomBytes(32).toString("base64"); // 43 body + 1 pad
+		expect(b64).toHaveLength(44);
+		expect(measureSecretEntropyBytes(b64)).toBe(32);
+	});
+
+	it("takes the SMALLEST plausible reading when several decodings apply", () => {
+		// All-hex strings are simultaneously valid base64url: 64 characters
+		// decode to 32 bytes as hex and 48 as base64url, and the conservative
+		// reading is the one an attacker gets to use.
+		expect(measureSecretEntropyBytes("0".repeat(64))).toBe(32);
+	});
+
+	it("does not read a string whose length no base64 encoding produces as base64", () => {
+		// 21 characters: 21 % 4 === 1, which no encoder emits.
+		expect(measureSecretEntropyBytes("test-secret-for-e2e--")).toBe(21);
+	});
+
+	it("does not read a value that mixes the two base64 alphabets as base64", () => {
+		// '+' is standard-only and '-' is URL-safe-only; a value carrying both is
+		// not a valid encoding in either, so it reads as its 8 raw bytes.
+		expect(measureSecretEntropyBytes("ab+cd-ef")).toBe(8);
+	});
+});
+
+describe("measureSecretEntropyBytes — base64 padding must be well-formed", () => {
+	/*
+	 * An encoder emits zero, one or two '=', and only where the body length calls
+	 * for it. Trimming any run of '=' would turn a passphrase that merely ends in
+	 * equals signs into a "valid" base64 body and score it at three-quarters of
+	 * its real length — fail-closed, but a usability trap with no security to
+	 * show for it. auth.provider#282 shipped that bug and then fixed it; this
+	 * port must not reintroduce it.
+	 */
+
+	it("accepts one '=' after a 3-character final group", () => {
+		const b64 = randomBytes(32).toString("base64");
+		expect(b64.endsWith("=")).toBe(true);
+		expect(b64.endsWith("==")).toBe(false);
+		expect(measureSecretEntropyBytes(b64)).toBe(32);
+	});
+
+	it("accepts two '=' after a 2-character final group", () => {
+		const b64 = randomBytes(31).toString("base64");
+		expect(b64.endsWith("==")).toBe(true);
+		expect(measureSecretEntropyBytes(b64)).toBe(31);
+	});
+
+	it("refuses more than two '=' — 'abcd====' is not base64, so it reads as 8 raw bytes", () => {
+		expect(measureSecretEntropyBytes("abcd====")).toBe(8);
+	});
+
+	it("refuses padding the body length does not call for ('abcd=')", () => {
+		expect(measureSecretEntropyBytes("abcd=")).toBe(5);
+	});
+
+	it("refuses two '=' after a 3-character group ('abc==')", () => {
+		expect(measureSecretEntropyBytes("abc==")).toBe(5);
+	});
+
+	it("does not punish a long passphrase that merely ends in equals signs", () => {
+		const passphrase = `${"a".repeat(40)}====`;
+		expect(passphrase).toHaveLength(44);
+		expect(measureSecretEntropyBytes(passphrase)).toBe(44);
+		expect(measureSecretEntropyBytes(passphrase)).toBeGreaterThanOrEqual(MIN_SECRET_ENTROPY_BYTES);
+	});
+
+	it("returns the raw reading for a value that is only padding", () => {
+		expect(measureSecretEntropyBytes("==")).toBe(2);
+	});
+});
+
+describe("measureSecretEntropyBytes — the values the floor is meant to catch", () => {
+	it("reads 32 alphanumerics as the 24 bytes a base64 body carries", () => {
+		// [A-Za-z0-9]{32} is a valid base64 body, and an operator who picked 32
+		// alphanumerics really does hold only ~190 bits: 62 possibilities per
+		// character is ~5.95 bits, not 8.
+		expect(measureSecretEntropyBytes("a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6")).toBe(24);
+	});
+
+	it.each(["secret", "your-secret", "s", "test-secret"])(
+		"reads the example value %s as short of the floor",
+		(value) => {
+			expect(measureSecretEntropyBytes(value)).toBeLessThan(MIN_SECRET_ENTROPY_BYTES);
+		},
+	);
+
+	it("clears the floor on the umbrella E2E's shared secret", () => {
+		// o3co/auth's Makefile defines this once for both the provider and this
+		// verifier: 43 base64 characters plus one '=' — exactly 32 decoded bytes.
+		const e2e = "qmV+afsq/SMZ7hPGs9edVQDvPzNmjXemJNjqti181v0=";
+		expect(measureSecretEntropyBytes(e2e)).toBe(32);
+		expect(measureSecretEntropyBytes(e2e)).toBeGreaterThanOrEqual(MIN_SECRET_ENTROPY_BYTES);
+	});
+});
+
+describe("describeWeakSecret", () => {
+	it("names the field the operator wrote and the byte count it carries", () => {
+		const message = describeWeakSecret("previousSecrets[0].secret", 7);
+		expect(message).toContain("previousSecrets[0].secret");
+		expect(message).toMatch(/\b7\b/);
+		expect(message).toMatch(/at least 32 bytes/i);
+	});
+
+	it("tells the operator how to generate a conforming secret", () => {
+		expect(describeWeakSecret("secret", 1)).toMatch(/openssl rand -hex 32/);
+	});
+
+	it("explains that encoded values are measured on their decoded length", () => {
+		expect(describeWeakSecret("secret", 16)).toMatch(/decoded/i);
+	});
+
+	it("never echoes the rejected value — it takes only the measurement", () => {
+		// The signature is the guarantee: there is no parameter to leak through.
+		expect(describeWeakSecret("secret", 19)).not.toContain("hunter2");
+	});
+});

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -29,7 +29,8 @@ import { createVerifyRouter } from "#/routes/verify.mjs";
 
 const generateKeyPairAsync = promisify(generateKeyPair);
 
-const JWT_SECRET = "test-secret";
+/** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
+const JWT_SECRET = "11".repeat(32);
 const hs256Key = await HS256KeyResolverFactory({ secret: JWT_SECRET });
 
 /** Canonical issuer/audience this verifier deployment pins (RFC 9068 §4). */

--- a/packages/server/src/__tests__/verifyLogging.test.mts
+++ b/packages/server/src/__tests__/verifyLogging.test.mts
@@ -39,9 +39,10 @@ import { describe, expect, it, vi } from "vitest";
 import { HS256KeyResolverFactory, type VerifyRouterJwtConfig } from "#/jwt/index.mjs";
 import { createVerifyRouter } from "#/routes/verify.mjs";
 
-const JWT_SECRET = "test-secret";
+/** 64 hex characters each — 32 decoded bytes, the entropy floor #114 enforces. */
+const JWT_SECRET = "11".repeat(32);
 const hs256Key = await HS256KeyResolverFactory({ secret: JWT_SECRET });
-const wrongKey = await HS256KeyResolverFactory({ secret: "a-different-secret" });
+const wrongKey = await HS256KeyResolverFactory({ secret: "22".repeat(32) });
 
 const ISSUER = "https://issuer.test";
 const AUDIENCE = "https://api.test";

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -81,6 +81,14 @@ export const AppConfigSchema = z.object({
 		jwt: z
 			.object({
 				algorithm: z.string().default("HS256"),
+				/**
+				 * The HS256 shared secret. Required whenever the algorithm is
+				 * HS256 and the mode is `"verify"`, and held to the entropy floor
+				 * in `superRefine` below (#114): the same value verifies and
+				 * signs, so a guessable one is not a read of tokens but the
+				 * ability to mint them. `.optional()` here because the asymmetric
+				 * algorithms have no use for it.
+				 */
 				secret: z.string().optional(),
 				/**
 				 * Names the HS256 secret the issuer signs with today (#112), the
@@ -111,7 +119,10 @@ export const AppConfigSchema = z.object({
 				 * Capped at `MAX_PREVIOUS_SECRETS` and checked again in
 				 * `jwt/hs256Rotation.mts`: a token carrying no `kid` is tried
 				 * against every configured secret, so the list length is the work
-				 * one unauthenticated request can force.
+				 * one unauthenticated request can force. Each entry's `secret`
+				 * clears the same entropy floor the current one does (#114) — a
+				 * retired secret verifies for its whole overlap window, so it can
+				 * mint tokens exactly as the current one can.
 				 *
 				 * `.optional()` and not `.nullish()`: the only ways to say
 				 * "nothing is being rotated" are omitting the key and `[]`.
@@ -262,7 +273,9 @@ export const AppConfigSchema = z.object({
 					});
 				}
 				if (data.algorithm === "HS256") {
-					// #112. The rotation contract is stated once, in
+					// #112 / #114. The HS256 secret contract — the rotation shape,
+					// and the entropy floor over `secret` and every
+					// `previousSecrets[].secret` — is stated once, in
 					// `jwt/hs256Rotation.mts`, and spent twice: here for config
 					// files, and in the HS256 KeyResolverFactory for hand-built
 					// configs that never met this schema. Every issue is reported

--- a/packages/server/src/config/defaults.mts
+++ b/packages/server/src/config/defaults.mts
@@ -90,6 +90,28 @@ export const DEFAULT_CLOCK_TOLERANCE_SECONDS = 0;
 export const MAX_CLOCK_TOLERANCE_SECONDS = 300;
 
 /**
+ * Floor on the key material an HS256 secret must carry, in bytes (#114).
+ *
+ * 32 bytes = 256 bits = the output width of SHA-256, which is the most an HS256
+ * key can contribute. RFC 7518 §3.2 states the requirement directly: "A key of
+ * the same size as the hash output ... or larger MUST be used." Before this the
+ * only check was non-emptiness, so a one-character secret booted — and with a
+ * symmetric algorithm, guessing the secret is not read access to tokens, it is
+ * the ability to MINT them for any subject.
+ *
+ * The same number auth.provider enforces (its #282), deliberately: the two
+ * services share one secret, so a floor that either side applies alone is a
+ * floor neither side has. This is the one statement of that reasoning in the
+ * code — `config/secretEntropy.mts` and `jwt/hs256Rotation.mts` point here
+ * rather than restating it, so a later clarification lands once.
+ *
+ * It is measured on DECODED material at the smallest plausible reading — see
+ * `config/secretEntropy.mts`, which is what makes `openssl rand -hex 16` (32
+ * characters, 16 bytes) fail rather than sneak through on its character count.
+ */
+export const MIN_SECRET_ENTROPY_BYTES = 32;
+
+/**
  * Ceiling on `oauth.jwt.previousSecrets` — how many retired HS256 secrets a
  * deployment may hold alongside the current one (#112).
  *

--- a/packages/server/src/config/secretEntropy.mts
+++ b/packages/server/src/config/secretEntropy.mts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * How much key material an operator-supplied shared secret actually carries,
+ * and how to say so when it is not enough (#114).
+ *
+ * The check exists because HS256 is this project's default algorithm and its
+ * secret had no floor at all: `secret is required for HS256` refused an empty
+ * string and accepted everything else, so `OAUTH_JWT_SECRET=s` booted a
+ * verifier. A symmetric secret is not merely a key that reads tokens — the same
+ * value signs them, so anyone who guesses it mints tokens for any subject, and
+ * the shipped examples used values like `secret` and `your-secret`.
+ *
+ * The measurement is auth.provider's, ported rather than reinvented (its #282).
+ * `MIN_SECRET_ENTROPY_BYTES` in `config/defaults.mts` records why the two
+ * services must agree on the floor at all; what matters HERE is that agreeing on
+ * the number is not enough on its own. A verifier that measured a value
+ * differently from the provider would reject secrets the provider had just told
+ * the operator were fine — so the reading below is the same reading, down to its
+ * treatment of malformed base64 padding.
+ *
+ * Deliberately dependency-free, like `jwt/jwks.mts` and `config/bounds.mts`:
+ * `AppConfigSchema` reaches it through `jwt/hs256Rotation.mts`, so a weak secret
+ * fails at config-parse time (at boot, where an operator sees it) rather than at
+ * the first request, and config-only consumers of the schema must not pull jose
+ * or express in behind it.
+ */
+
+import { MIN_SECRET_ENTROPY_BYTES } from "./defaults.mjs";
+
+/** Decoded byte length if `value` is a well-formed hex string, else undefined. */
+function hexByteLength(value: string): number | undefined {
+	if (value.length === 0 || value.length % 2 !== 0) return undefined;
+	if (!/^[0-9a-fA-F]+$/.test(value)) return undefined;
+	return value.length / 2;
+}
+
+/**
+ * Decoded byte length if `value` is a well-formed base64 / base64url string,
+ * else undefined.
+ *
+ * Hand-rolled rather than delegated to `Buffer.from(value, "base64")`: Node's
+ * decoder is lenient — it silently drops characters outside the alphabet — so it
+ * answers for a string that is not base64 at all, and answers *small*, which
+ * would reject perfectly good passphrases.
+ *
+ * Padding is held to the same standard as the alphabet. An encoder emits zero,
+ * one or two `=`, and only where the body length calls for it: one after a
+ * 3-character final group, two after a 2-character one. `"abcd===="` and
+ * `"abcd="` are therefore not base64, and this returns undefined for them so the
+ * raw-bytes reading stands. Trimming any run of `=` instead — the shape
+ * auth.provider shipped first and then fixed — turns a passphrase that merely
+ * ends in equals signs into a "valid" base64 body and scores it at
+ * three-quarters of its real length: fail-closed, but a usability trap with no
+ * security to show for it.
+ */
+function base64ByteLength(value: string): number | undefined {
+	// Count the trailing '=' run without assuming it is well-formed.
+	const padding = value.length - value.replace(/=+$/, "").length;
+	if (padding > 2) return undefined;
+	const body = value.slice(0, value.length - padding);
+	if (body.length === 0) return undefined;
+	// Standard (`+/`) and URL-safe (`-_`) alphabets; a value mixing the two is
+	// not a valid encoding in either.
+	if (!/^[A-Za-z0-9+/]+$/.test(body) && !/^[A-Za-z0-9_-]+$/.test(body)) return undefined;
+	const remainder = body.length % 4;
+	// No base64 encoding produces a body of length ≡ 1 (mod 4).
+	if (remainder === 1) return undefined;
+	// When padding is present it must bring the total to a multiple of 4.
+	if (padding > 0 && remainder !== 4 - padding) return undefined;
+	return Math.floor((body.length * 3) / 4);
+}
+
+/**
+ * Estimates how many bytes of key material a configured secret carries.
+ *
+ * The answer is the SMALLEST plausible reading of the string, because that is
+ * the one an attacker gets to use. `openssl rand -hex 16` produces a
+ * 32-*character* value that is only 16 *bytes* of randomness; counting its
+ * characters would wave through a key with half the intended strength. The same
+ * reasoning applies to base64: a 32-character base64 body is 24 bytes.
+ *
+ * The conservative reading is also right for values never meant as an encoding.
+ * A 32-character password drawn from `[A-Za-z0-9]` reads as base64 here and
+ * scores 24 bytes — and it genuinely carries only ~190 bits, because 62
+ * possibilities per character is ~5.95 bits, not 8. Treating printable ASCII as
+ * a full byte each is the optimistic error, and this does not make it.
+ *
+ * What it cannot see is structure: a 40-character English sentence measures 40
+ * bytes and carries far less. This is a check on key *length*, not a substitute
+ * for generating the key randomly — which is what {@link describeWeakSecret}
+ * tells the operator to do.
+ */
+export function measureSecretEntropyBytes(secret: string): number {
+	const candidates = [
+		Buffer.byteLength(secret, "utf8"),
+		hexByteLength(secret),
+		base64ByteLength(secret),
+	].filter((length): length is number => length !== undefined);
+	return Math.min(...candidates);
+}
+
+/**
+ * Operator-facing explanation for a secret that misses the floor, naming the
+ * field the way the config path does (`secret`, `previousSecrets[0].secret`).
+ *
+ * It takes the measurement and not the secret, which is the guarantee that the
+ * rejected value cannot be echoed: this message is destined for stdout, a
+ * container log, and quite possibly a pasted bug report.
+ */
+export function describeWeakSecret(field: string, actualBytes: number): string {
+	return (
+		`${field} must carry at least ${MIN_SECRET_ENTROPY_BYTES} bytes ` +
+		`(${MIN_SECRET_ENTROPY_BYTES * 8} bits) of key material, but carries ${actualBytes} — ` +
+		`generate one with \`openssl rand -hex ${MIN_SECRET_ENTROPY_BYTES}\`. Hex and base64 ` +
+		`values are measured on their DECODED length, so a ${MIN_SECRET_ENTROPY_BYTES}-character ` +
+		`hex string counts as only ${MIN_SECRET_ENTROPY_BYTES / 2} bytes.`
+	);
+}

--- a/packages/server/src/index.mts
+++ b/packages/server/src/index.mts
@@ -16,7 +16,13 @@ export {
 	DEFAULT_MAX_TOKEN_AGE_SECONDS,
 	MAX_CLOCK_TOLERANCE_SECONDS,
 	MAX_PREVIOUS_SECRETS,
+	MIN_SECRET_ENTROPY_BYTES,
 } from "./config/defaults.mjs";
+// The HS256 entropy floor's measurement (#114), exported so a consumer that
+// accepts its own operator secrets — a custom key resolver, a composition root
+// building a JWT config by hand — applies the identical reading rather than a
+// second opinion about what a 32-character hex string is worth.
+export { describeWeakSecret, measureSecretEntropyBytes } from "./config/secretEntropy.mjs";
 export {
 	type CallerAuthConfig,
 	type CallerAuthErrorContext,

--- a/packages/server/src/jwt/hs256Rotation.mts
+++ b/packages/server/src/jwt/hs256Rotation.mts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * HS256 signing-secret rotation (#112): the config shape a deployment writes to
- * hold a retired secret alongside the current one, and the checks that shape
- * must pass before any of it becomes key material.
+ * The HS256 signing-secret contract: the config shape a deployment writes to
+ * hold a retired secret alongside the current one (#112), and the checks that
+ * shape must pass before any of it becomes key material — the entropy floor
+ * every one of those secrets clears (#114) included.
  *
  * Why this exists at all: with exactly one secret, rotating means the provider
  * starts signing with a new value and every token minted under the old one is
@@ -16,7 +17,15 @@
  * `previousSecrets` — `kid` + `secret` + `expiresAt` per entry, current secret
  * named by its own `kid` — in `packages/core/src/keys/factory.mts`. The wire
  * shape here is the same, so an operator rotating the pair writes the same
- * three fields on both sides and moves the same pair of values.
+ * three fields on both sides and moves the same pair of values. The entropy
+ * floor is ported from the same place (auth.provider#282) for the same reason —
+ * see `MIN_SECRET_ENTROPY_BYTES` in `config/defaults.mts`, which states it.
+ *
+ * Why the floor lives here rather than in either boundary: `oauth.jwt.secret`
+ * and every entry of `previousSecrets` are the same kind of value — a retired
+ * secret verifies for its whole overlap window, so it can mint tokens exactly as
+ * the current one can. One rule over both is what keeps either of them from
+ * quietly becoming the laxer half.
  *
  * Deliberately dependency-free, like `jwt/jwks.mts` next to it: `AppConfigSchema`
  * imports it so a malformed rotation block fails at config-parse time (at boot,
@@ -27,7 +36,8 @@
  * `checkJwksUri` / `parseJwksUri`.
  */
 
-import { MAX_PREVIOUS_SECRETS } from "../config/defaults.mjs";
+import { MAX_PREVIOUS_SECRETS, MIN_SECRET_ENTROPY_BYTES } from "../config/defaults.mjs";
+import { describeWeakSecret, measureSecretEntropyBytes } from "../config/secretEntropy.mjs";
 
 /**
  * One retired secret and the window it stays a verification key for.
@@ -63,6 +73,11 @@ export interface Hs256PreviousSecret {
  * caller can put anything at `previousSecrets`.
  */
 export interface Hs256RotationConfig {
+	/**
+	 * The secret the deployment verifies with today. Read here only to hold it to
+	 * the entropy floor (#114) — an absent one is reported by each boundary's own
+	 * "secret is required for HS256", which is where that check already lives.
+	 */
 	secret?: string;
 	/**
 	 * Names the secret the issuer currently signs with. Optional, and the
@@ -104,15 +119,32 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
+ * Holds one secret to the entropy floor (#114), collecting an issue at the path
+ * the operator wrote when it falls short. True when the secret may go on to
+ * become key material.
+ *
+ * Applied identically to `oauth.jwt.secret` and to every `previousSecrets[].secret`
+ * — see the note at the top of this file on why that is one rule and not two.
+ */
+function clearsEntropyFloor(
+	secret: string,
+	field: string,
+	path: (string | number)[],
+	issues: Hs256RotationIssue[],
+): boolean {
+	const actualBytes = measureSecretEntropyBytes(secret);
+	if (actualBytes >= MIN_SECRET_ENTROPY_BYTES) {
+		return true;
+	}
+	// The message carries the measurement, never the value: unlike `expiresAt`
+	// below, echoing this back would put the secret in a log line.
+	issues.push({ path, message: describeWeakSecret(field, actualBytes) });
+	return false;
+}
+
+/**
  * Validates one `previousSecrets` entry into the collector, returning the
  * narrowed entry or `undefined` when it contributed an issue instead.
- *
- * Note what is deliberately NOT checked here: the entropy of `secret`. A retired
- * secret is a live verification key for the whole overlap window, so it carries
- * exactly the forgery risk the current one does and belongs behind exactly the
- * same floor — which is why that floor is one check over `oauth.jwt.secret` and
- * every entry of this list together (tracked as #114), and not a check that
- * lands here alone and leaves the current secret the laxer of the two.
  */
 function checkEntry(
 	entry: unknown,
@@ -137,6 +169,15 @@ function checkEntry(
 			issues.push({ path: at(field), message: `${label}.${field} must be a non-empty string` });
 			ok = false;
 		}
+	}
+	// Only once the secret is known to be a string, and reported alone: a value
+	// that is not a string has nothing to measure, and saying so twice would make
+	// one mistake look like two.
+	if (
+		isNonEmptyString(raw.secret) &&
+		!clearsEntropyFloor(raw.secret, `${label}.secret`, at("secret"), issues)
+	) {
+		ok = false;
 	}
 	if (!isNonEmptyString(raw.expiresAt)) {
 		issues.push({
@@ -164,7 +205,10 @@ function checkEntry(
 }
 
 /**
- * Applies the rotation contract to an `oauth.jwt` block.
+ * Applies the HS256 secret contract to an `oauth.jwt` block: the rotation shape,
+ * and the entropy floor over `secret` and every `previousSecrets[].secret`
+ * (#114). A config with no rotation at all still passes through the floor —
+ * that is the whole point of the check living in one place.
  *
  * An *absent* `previousSecrets` means "no rotation configured": a deployment
  * that has never rotated writes nothing, and an operator closing a window
@@ -196,10 +240,18 @@ function checkEntry(
  */
 export function checkHs256Rotation(config: Hs256RotationConfig): Hs256RotationCheck {
 	const issues: Hs256RotationIssue[] = [];
-	const { kid } = config;
+	const { kid, secret } = config;
 
 	if (kid !== undefined && !isNonEmptyString(kid)) {
 		issues.push({ path: ["kid"], message: "kid must be a non-empty string" });
+	}
+
+	// The current secret clears the same floor as the retired ones (#114).
+	// Absent or empty is somebody else's issue — `AppConfigSchema` and the HS256
+	// `KeyResolverFactory` each say `secret is required for HS256` — so this adds
+	// nothing there rather than reporting one missing key twice.
+	if (isNonEmptyString(secret)) {
+		clearsEntropyFloor(secret, "secret", ["secret"], issues);
 	}
 
 	const raw = config.previousSecrets;

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -6,11 +6,13 @@ auth.policy-verifier のデプロイ可能なサーバーテンプレートで�
 
 ```sh
 pnpm install
-OAUTH_JWT_SECRET=your-secret \
+OAUTH_JWT_SECRET=$(openssl rand -hex 32) \
   OAUTH_JWT_ISSUER=https://issuer.example.com \
   OAUTH_JWT_AUDIENCE=https://api.example.com \
   pnpm run start
 ```
+
+`OAUTH_JWT_SECRET` はデコード後の長さで 32 バイト（256 ビット）以上を要求し、下回る値は起動時に拒否されます。[HS256 シークレットの強度](#hs256-シークレットの強度)を参照。
 
 ## 設定
 
@@ -34,7 +36,7 @@ OAUTH_JWT_SECRET=your-secret \
 | `HTTP_PATH_PREFIX` | `""` | URL パスプレフィックス |
 | `HTTP_CALLER_AUTH_TOKEN` | （未設定） | 呼び出し元サービスが提示する共有資格情報。未設定の場合、ポートに到達できる任意の相手が判定を要求できる |
 | `HTTP_CALLER_AUTH_HEADER` | `x-caller-token` | その資格情報を載せるヘッダ |
-| `OAUTH_JWT_SECRET` | （必須） | HMAC-HS256 JWT 署名シークレット |
+| `OAUTH_JWT_SECRET` | （必須） | HMAC-HS256 JWT 署名シークレット。デコード後 32 バイト以上 — [HS256 シークレットの強度](#hs256-シークレットの強度)を参照 |
 | `OAUTH_JWT_ISSUER` | （必須） | この deployment が受け入れる issuer — RFC 9068 §4 `iss` |
 | `OAUTH_JWT_AUDIENCE` | （必須） | この resource server を指す audience — RFC 9068 §4 `aud` |
 | `OAUTH_JWT_JWKS_URI` | — | RS256/ES256/EdDSA の JWKS エンドポイント。`https://` 必須。平文 `http://` はループバックホスト（`localhost`, `127.0.0.0/8`, `[::1]`）のみ許可 |
@@ -46,6 +48,27 @@ OAUTH_JWT_SECRET=your-secret \
 | `RULE_ON_EMPTY_RULE_SET` | `deny` | ルールが 1 つも集まらなかったときの決定（`deny` \| `allow`） |
 | `VERIFY_MAX_BATCH_SIZE` | `50` | `POST /verify/batch` の件数上限 |
 | `LOG_LEVEL` | `info` | 出力する最低レベル: `trace`\|`debug`\|`info`\|`warn`\|`error`\|`fatal`\|`silent`。decision ログのスイッチも兼ねる — [可観測性](#可観測性)を参照 |
+
+## HS256 シークレットの強度
+
+`OAUTH_JWT_SECRET` は鍵素材として **32 バイト（256 ビット）以上**を持つ必要があります。足りない値は config パース時に拒否されるため、推測可能な鍵で稼働し続けるのではなく起動時に失敗します。
+
+HS256 は対称鍵です。トークンを検証する値がそのままトークンを署名する値なので、推測された場合の被害は「発行済みトークンを読める」ことではなく「任意の subject のトークンを発行できる」ことです。RFC 7518 §3.2 はハッシュ出力幅以上の鍵を要求しており、auth.provider も同じ共有値に同じ下限を課しています。
+
+```sh
+OAUTH_JWT_SECRET=$(openssl rand -hex 32)      # 64 文字 / 32 バイト
+OAUTH_JWT_SECRET=$(openssl rand -base64 32)   # 44 文字 / 32 バイト
+```
+
+判定は**デコード後**の素材に対して、もっとも小さく読める解釈で行います。攻撃者が実際に使えるのがその解釈だからです。
+
+- `openssl rand -hex 16` は 32 *文字* だが 16 *バイト* しかない — 拒否。
+- ランダムな英数字 32 文字は base64 本体として読めるため 24 バイト — 拒否。1 文字あたり 62 通りは約 5.95 ビットであり、8 ビットではない。
+- 記号を含むパスフレーズは UTF-8 長で測られるため、32 文字なら通る。
+
+同じ下限がローテーションブロックの `previousSecrets[].secret` 全件にも適用されます — 退役したシークレットも重複期間中は検証鍵であり、現行と同じようにトークンを発行できるからです。
+
+この検査で見えるのは長さだけです。40 文字の英文は 40 バイトと数えられますが実際の強度ははるかに低いので、値は必ずランダムに生成してください。
 
 ## 信頼境界
 
@@ -213,7 +236,7 @@ docker run \
   -p 3000:3000 \
   -e HTTP_HOSTNAME=0.0.0.0 \
   -e HTTP_CALLER_AUTH_TOKEN=<secret> \
-  -e OAUTH_JWT_SECRET=secret \
+  -e OAUTH_JWT_SECRET=$(openssl rand -hex 32) \
   -e OAUTH_JWT_ISSUER=https://issuer.example.com \
   -e OAUTH_JWT_AUDIENCE=https://api.example.com \
   auth-policy-verifier

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -6,11 +6,13 @@ Deployable server template for auth.policy-verifier. This is the composition roo
 
 ```sh
 pnpm install
-OAUTH_JWT_SECRET=your-secret \
+OAUTH_JWT_SECRET=$(openssl rand -hex 32) \
   OAUTH_JWT_ISSUER=https://issuer.example.com \
   OAUTH_JWT_AUDIENCE=https://api.example.com \
   pnpm run start
 ```
+
+`OAUTH_JWT_SECRET` must carry at least 32 bytes (256 bits) of key material, measured on its decoded length — a shorter value is refused at boot. See [HS256 secret strength](#hs256-secret-strength).
 
 ## Configuration
 
@@ -34,7 +36,7 @@ Individual values can also be overridden with environment variables.
 | `HTTP_PATH_PREFIX` | `""` | URL path prefix |
 | `HTTP_CALLER_AUTH_TOKEN` | (unset) | Shared credential the calling service must present. Unset means any caller who can reach the port may ask for decisions |
 | `HTTP_CALLER_AUTH_HEADER` | `x-caller-token` | Header carrying that credential |
-| `OAUTH_JWT_SECRET` | (required) | HMAC-HS256 JWT signing secret |
+| `OAUTH_JWT_SECRET` | (required) | HMAC-HS256 JWT signing secret. At least 32 decoded bytes — see [HS256 secret strength](#hs256-secret-strength) |
 | `OAUTH_JWT_ISSUER` | (required) | Issuer this deployment accepts — RFC 9068 §4 `iss` |
 | `OAUTH_JWT_AUDIENCE` | (required) | Audience identifying this resource server — RFC 9068 §4 `aud` |
 | `OAUTH_JWT_JWKS_URI` | — | JWKS endpoint for RS256/ES256/EdDSA. Must be `https://`; plaintext `http://` is accepted only for loopback hosts (`localhost`, `127.0.0.0/8`, `[::1]`) |
@@ -46,6 +48,27 @@ Individual values can also be overridden with environment variables.
 | `RULE_ON_EMPTY_RULE_SET` | `deny` | Decision when no rule is collected (`deny` \| `allow`) |
 | `VERIFY_MAX_BATCH_SIZE` | `50` | Cap on `POST /verify/batch` entries |
 | `LOG_LEVEL` | `info` | Minimum level emitted: `trace`\|`debug`\|`info`\|`warn`\|`error`\|`fatal`\|`silent`. Also the switch for the decision log — see [Observability](#observability) |
+
+## HS256 secret strength
+
+`OAUTH_JWT_SECRET` must carry at least **32 bytes (256 bits)** of key material. A shorter one is refused when the config is parsed, so the process fails at boot rather than serving with a guessable key.
+
+HS256 is symmetric: the value that verifies a token is the value that signs one, so anyone who guesses it can mint tokens for any subject — not merely read the ones already issued. RFC 7518 §3.2 requires a key at least as wide as the hash output, and auth.provider holds the same shared value to the same floor.
+
+```sh
+OAUTH_JWT_SECRET=$(openssl rand -hex 32)      # 64 characters, 32 bytes
+OAUTH_JWT_SECRET=$(openssl rand -base64 32)   # 44 characters, 32 bytes
+```
+
+The measurement is on **decoded** material at the smallest plausible reading, which is the one an attacker gets to use:
+
+- `openssl rand -hex 16` produces 32 *characters* but only 16 *bytes* — refused.
+- 32 random alphanumerics read as a base64 body (24 bytes) — refused, and rightly: 62 possibilities per character is ~5.95 bits, not 8.
+- A passphrase containing punctuation is measured on its UTF-8 length, so 32 characters passes.
+
+The same floor applies to every `previousSecrets[].secret` in the rotation block — a retired secret verifies for its whole overlap window and can mint tokens exactly as the current one can.
+
+Length is all the check can see. A 40-character sentence measures 40 bytes and carries far less; generate the value randomly.
 
 ## Trust boundary
 
@@ -214,7 +237,7 @@ docker run \
   -p 3000:3000 \
   -e HTTP_HOSTNAME=0.0.0.0 \
   -e HTTP_CALLER_AUTH_TOKEN=<secret> \
-  -e OAUTH_JWT_SECRET=secret \
+  -e OAUTH_JWT_SECRET=$(openssl rand -hex 32) \
   -e OAUTH_JWT_ISSUER=https://issuer.example.com \
   -e OAUTH_JWT_AUDIENCE=https://api.example.com \
   auth-policy-verifier

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -35,6 +35,16 @@ oauth {
   jwt {
     algorithm = "HS256"
     algorithm = ${?OAUTH_JWT_ALGORITHM}
+    # The HS256 shared secret. It must carry at least 32 bytes (256 bits) of
+    # key material or the process refuses to boot: HS256 is symmetric, so the
+    # value that verifies a token is the value that signs one, and guessing it
+    # buys the ability to MINT tokens for any subject. Generate it with
+    # `openssl rand -hex 32` (or -base64 32) and never write it in this file.
+    #
+    # The floor is measured on DECODED material at the smallest plausible
+    # reading: `openssl rand -hex 16` is 32 characters but only 16 bytes and is
+    # refused, and 32 random alphanumerics read as a 24-byte base64 body. The
+    # same floor applies to every previousSecrets entry below.
     secret = ${?OAUTH_JWT_SECRET}
     # HS256 only. Names the secret above, matching the `kid` auth.provider
     # stamps into every token it mints (its own default is "v0"). Leave it unset

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -17,6 +17,12 @@ import { loadAppConfig } from "../loadConfig.js";
 
 const configDirPath = fileURLToPath(new URL("../../config/", import.meta.url));
 
+/**
+ * 64 hex characters — 32 decoded bytes, the entropy floor the schema enforces
+ * on every HS256 secret (#114). A short value now fails to load at all.
+ */
+const TEST_SECRET = "11".repeat(32);
+
 const envKeys = [
 	"OAUTH_JWT_SECRET",
 	"OAUTH_JWT_ISSUER",
@@ -31,7 +37,7 @@ const envKeys = [
 
 /** application.conf leaves issuer/audience unset, so every load must supply them. */
 function setRequiredEnv(): void {
-	process.env.OAUTH_JWT_SECRET = "test-secret";
+	process.env.OAUTH_JWT_SECRET = TEST_SECRET;
 	process.env.OAUTH_JWT_ISSUER = "https://issuer.test";
 	process.env.OAUTH_JWT_AUDIENCE = "https://api.test";
 }
@@ -62,7 +68,7 @@ describe("loadAppConfig", () => {
 				callerAuth: { header: "x-caller-token" },
 			});
 			expect(config.oauth.jwt.algorithm).toBe("HS256");
-			expect(config.oauth.jwt.secret).toBe("test-secret");
+			expect(config.oauth.jwt.secret).toBe(TEST_SECRET);
 			expect(config.oauth.jwt.mode).toBe("verify");
 			expect(config.oauth.jwt.issuer).toBe("https://issuer.test");
 			expect(config.oauth.jwt.audience).toBe("https://api.test");
@@ -155,6 +161,22 @@ describe("loadAppConfig", () => {
 		);
 	});
 
+	it.each([
+		["a one-character OAUTH_JWT_SECRET", "s"],
+		["the README's old example value", "your-secret"],
+		["32 hex characters — 16 decoded bytes", "ab".repeat(16)],
+	])("refuses to load %s (#114)", (_label, secret) => {
+		// The floor applies to the shipped config as loaded, not only to
+		// hand-built objects: `secret = ${?OAUTH_JWT_SECRET}` is where a weak
+		// value actually enters a deployment.
+		setRequiredEnv();
+		process.env.OAUTH_JWT_SECRET = secret;
+
+		expect(() => loadAppConfig(configDirPath, "development")).toThrow(
+			/must carry at least 32 bytes/,
+		);
+	});
+
 	it("rejects an env name that escapes the config directory", () => {
 		expect(() => loadAppConfig(configDirPath, "../secrets")).toThrow(/resolves outside/);
 	});
@@ -162,14 +184,14 @@ describe("loadAppConfig", () => {
 
 describe("loadAppConfig — RFC 9068 requirements (#105)", () => {
 	it("fails to load when the issuer is not supplied", () => {
-		process.env.OAUTH_JWT_SECRET = "test-secret";
+		process.env.OAUTH_JWT_SECRET = TEST_SECRET;
 		process.env.OAUTH_JWT_AUDIENCE = "https://api.test";
 
 		expect(() => loadAppConfig(configDirPath, "development")).toThrow();
 	});
 
 	it("fails to load when the audience is not supplied", () => {
-		process.env.OAUTH_JWT_SECRET = "test-secret";
+		process.env.OAUTH_JWT_SECRET = TEST_SECRET;
 		process.env.OAUTH_JWT_ISSUER = "https://issuer.test";
 
 		expect(() => loadAppConfig(configDirPath, "development")).toThrow();

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -27,7 +27,8 @@ import { SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
 
-const JWT_SECRET = "standalone-smoke-secret";
+/** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
+const JWT_SECRET = "11".repeat(32);
 const secretKey = new TextEncoder().encode(JWT_SECRET);
 const ISSUER = "https://issuer.test";
 const AUDIENCE = "https://api.test";


### PR DESCRIPTION
Closes #114

## The floor

Every HS256 secret must carry at least **32 bytes (256 bits)** of key material. Before this the only check was non-emptiness, so `OAUTH_JWT_SECRET=s` booted a verifier and the shipped examples used `secret` / `your-secret`. HS256 is symmetric: the value that verifies a token is the value that signs one, so guessing it is not read access to tokens, it is the ability to **mint** them for any subject. RFC 7518 §3.2 requires a key at least as wide as the hash output.

The measurement is **ported from auth.provider#282** (`packages/core/src/keys/secretEntropy.mts`), not reinvented — the two services hold the *same* secret, so a verifier that measured it differently from the provider would reject values the provider had just accepted, and a floor either side applies alone is a floor neither side has. The follow-up fix that tightened base64 detection is ported with it: only *valid* padding (0–2 `=`, and only where the body length calls for it) is treated as base64, so a passphrase merely ending in `=` is measured on its raw UTF-8 length rather than trimmed into a short "base64 body". `packages/server/src/__tests__/secretEntropy.test.mts` pins that behaviour with the same cases (`abcd====` → 8, `abcd=` → 5, `abc==` → 5, `"a"*40 + "===="` → 44).

## How it is measured

On the **decoded** material, at the smallest plausible reading — the one an attacker gets to use.

| Value | Reads as | Verdict |
| --- | --- | --- |
| 64 hex characters (`openssl rand -hex 32`) | 32 bytes | passes |
| 32 hex characters (`openssl rand -hex 16`) | 16 bytes | refused |
| 43 base64 characters + `=` (`openssl rand -base64 32`) | 32 bytes | passes |
| 32 random alphanumerics | 24 bytes — a valid base64 body | refused |
| 32-character passphrase containing punctuation | 32 bytes | passes |

Refusing 32 alphanumerics is deliberate rather than an artefact: 62 possibilities per character is ~5.95 bits, not 8, so such a value genuinely carries only ~190 bits. What the check cannot see is structure — a 40-character English sentence measures 40 bytes and carries far less — which is why the failure message tells the operator to generate the value rather than choose it.

## Coverage of `previousSecrets`

The floor is **one check over `oauth.jwt.secret` and every entry of `oauth.jwt.previousSecrets`**, applied inside `checkHs256Rotation` — the function #112 already spends at both boundaries. A retired secret is a live verification key for its whole overlap window, so it can mint tokens exactly as the current one can; splitting the check would have left one of them the laxer half, which is exactly why #112's `checkEntry` doc deferred it to this issue rather than landing it on the list alone. That comment is replaced by the check it was waiting for.

Both boundaries enforce it, the same schema-plus-runtime-guard division as `checkJwksUri` / `parseJwksUri`:

- `AppConfigSchema` reports zod issues at the paths the operator wrote (`oauth.jwt.secret`, `oauth.jwt.previousSecrets[0].secret`), so a config file fails at boot;
- the HS256 `KeyResolverFactory` re-checks via `parseHs256Rotation` for hand-built configs that never met the schema, and `createApp` refuses to boot.

`insecure-decode` mode is unaffected — it uses no key material at all. `createVerifyRouter` takes key material directly rather than a config and does not apply the floor; a consumer wiring a `KeyObject` by hand owns that check, which is why `tests/integration` (which does exactly that) is untouched.

The failure names the key and the measurement, never the value — these messages reach stdout, container logs and pasted bug reports:

```
oauth.jwt.secret must carry at least 32 bytes (256 bits) of key material,
but carries 11 — generate one with `openssl rand -hex 32`. Hex and base64
values are measured on their DECODED length, so a 32-character hex string
counts as only 16 bytes.
```

## Structure

Following the repo's existing consolidation patterns (`config/bounds.mts`, `net/loopback.mts`):

- `MIN_SECRET_ENTROPY_BYTES = 32` in `packages/server/src/config/defaults.mts`, next to `MAX_PREVIOUS_SECRETS`.
- `packages/server/src/config/secretEntropy.mts` — new, dependency-free, so the config layer does not pull jose or express in behind it. Exports `measureSecretEntropyBytes` and `describeWeakSecret`, both re-exported from the package index so a consumer accepting its own operator secrets applies the identical reading. `describeWeakSecret` takes the measurement and *not* the secret, which is the structural guarantee that a rejection cannot echo the value.
- No private copy of the measurement anywhere; `hs256Rotation.mts` is its only in-repo caller.

## Umbrella E2E verdict

**Clears the floor unchanged — no change needed in o3co/auth.**

`o3co/auth`'s Makefile defines the shared secret once and interpolates it into both the provider and the verifier containers:

```
export OAUTH_JWT_SECRET := qmV+afsq/SMZ7hPGs9edVQDvPzNmjXemJNjqti181v0=
```

44 characters: a 43-character base64 body plus one `=`, which decodes to exactly **32 bytes** — at the floor, passing. `tests/docker-compose.yml` passes the same interpolated value to both services (`${OAUTH_JWT_SECRET:?run via make test-e2e}`), so there is no second literal that could measure differently. The value is asserted directly in this PR's tests (`secretEntropy.test.mts` and `hs256Rotation.test.mts`) so a future change to the measurement cannot silently break the E2E.

## Examples updated

Every shipped example that used a too-weak secret now generates one — otherwise the repo would ship examples that cannot boot:

- `README.md` / `README.ja.md` — Quick Start (`your-secret` → `$(openssl rand -hex 32)`), the Docker one-liner (`=secret`), the config-reference comment, and a new HS256-secret-strength subsection with the reading table.
- `templates/standalone/README.md` / `.ja.md` — Usage snippet, the `OAUTH_JWT_SECRET` env table row, the `docker run` example, and a new "HS256 secret strength" section.
- `templates/standalone/config/application.conf` — the `secret` key now carries the requirement and how to generate it.
- `packages/server/README.md` / `.ja.md` — the `AppConfigSchema` shape and a paragraph on where the floor is (and is not) enforced.

Test fixtures that used short secrets (`test-secret`, `"s"`, `standalone-smoke-secret`) are raised to conforming values; `tests/integration` constructs raw HMAC keys below the config boundary and is deliberately left alone.

## Rebased onto `develop`

Rebased twice: past #148/#149/#150, then again past #123 (`df3080f`) when it landed mid-CI. Four textual conflicts, all the same Docker-example block in `README.md` / `README.ja.md` / `templates/standalone/README.md` / `.ja.md`: `develop` had expanded it with `-p 3000:3000` / `HTTP_HOSTNAME` / `HTTP_CALLER_AUTH_TOKEN` while this branch replaced the weak `OAUTH_JWT_SECRET=secret`. Resolved by keeping both — the expanded flags with the generated secret. The CHANGELOG merged cleanly, every entry kept.

The conflicts a textual rebase could **not** show were the point: #150 added `packages/server/src/__tests__/decisionLogging.test.mts` and `metrics.test.mts`, both minting tokens with a short shared secret (`test-secret`, `metrics-test-secret` — 14 bytes read as a base64 body). Both now boot a verifier the floor refuses, so both are raised to a conforming value. That is why the whole suite plus `pnpm run typecheck` was re-run after each rebase rather than trusting a clean textual merge.

The second rebase conflicted only in `CHANGELOG.md`, and only because #123 and #114 both add a new bullet at the top of `### Security`. Both are kept, blank line between them, #123 first (it landed first); every pre-existing entry is intact. #123's branded `UntrustedRequestContext` needed no change here — nothing in this diff builds a `CollectorContext` by hand.

`hs256Rotation.mts`'s rationale for why the two services must agree on the floor was hand-copied into four places; it now has one home — the `MIN_SECRET_ENTROPY_BYTES` doc comment in `config/defaults.mts` — with `config/secretEntropy.mts` and `jwt/hs256Rotation.mts` pointing at it (the same "see that constant's doc comment" pattern `app.mts` uses for `CALLER_AUTH_REQUIRED`). `secretEntropy.mts` keeps only the part that is its own: agreeing on the *number* is not enough, the *reading* has to match too. The CHANGELOG copy stays — it is operator-facing and has to stand alone once released — and is now word-identical to the canonical sentence, so a grep finds both.

## Migration

`CHANGELOG.md` carries a **BREAKING** entry under `[Unreleased]` with the operator migration: generate with `openssl rand -hex 32` (or `-base64 32`) and give the same value to auth.provider; rotate through `previousSecrets` rather than cutting over if tokens are in flight — noting that a rotation *away from* a weak secret cannot stage the old value, since it would not clear the floor either; or move to RS256/ES256/EdDSA with a JWKS so the verifier never holds a token-forging key.

## Test results

TDD throughout — the new tests were written and watched fail before the implementation landed.

```
pnpm lint          biome check, 133 files      clean
pnpm -r run build  6 projects                  clean
pnpm run typecheck tsc --noEmit (tests incl.)  clean
```

| Project | Files | Tests |
| --- | --- | --- |
| create-app | 1 | 78 passed |
| packages/core | 9 | 70 passed |
| packages/builtins | 21 | 474 passed |
| packages/server | 13 | 508 passed |
| templates/standalone | 4 | 35 passed |
| tests/integration | 5 | 51 passed |

**1216 passed, 0 failed.** No `--coverage` on the final run.

New coverage: `secretEntropy.test.mts` (measurement, padding well-formedness, the values the floor catches, the E2E secret); floor cases added to `hs256Rotation.test.mts` (current secret, retired secrets, both reported in one pass, `parseHs256Rotation` messages), `application.schema.test.mts` (config-parse rejection, no echo of the value, `previousSecrets` path, decode-mode exemption), `builtinKeyResolversModule.test.mts` and `app.test.mts` (the runtime guard for hand-built configs), and `templates/standalone` `loadConfig.test.mts` (a weak `OAUTH_JWT_SECRET` refuses to load the shipped config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

