### PR TITLE
fix(core,builtins,server)!: move the rule-purity prohibition from collect time to verify time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,81 @@ jobs:
       - run: pnpm run audit
 
       - run: pnpm run lint
+
+      - name: Assert no verify() body reads a collector context
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Per AGENTS.md "Collector / Rule / Attribute Contract": a rule's
+          # `verify` must be a deterministic function of `attrs`. Fixing what the
+          # rule *looks for* at collect time is fine — that is how
+          # `ResourceActionScopeRuleCollector` builds its `HasScope`. Keeping the
+          # `CollectorContext` and reading it *inside* `verify` is not.
+          #
+          # This is a TEXTUAL BACKSTOP for the obvious shape only: a `verify(…) {…}`
+          # body that mentions `ctx.` or `context.`. It brace-matches the body
+          # rather than reading a line, because the violation is rarely on the
+          # signature's line — but it is still a string search, and it does not
+          # see a context reached through a differently-named binding, a helper
+          # call, or a closure defined elsewhere.
+          #
+          # The real check is behavioural and lives in
+          # `tests/integration/src/conformance/rulePurity.mts`, which collects the
+          # rules through a revocable view of the context, revokes it, and asks
+          # them again. That one cannot be dodged by renaming a variable, and it
+          # runs in the `pnpm run test` step below. This gate exists because the
+          # violation has now been written twice by copy-paste (#150, #152), and
+          # a named CI failure is what stops the third copy at review time.
+          #
+          # One file is exempt, and the exemption is the gate admitting its own
+          # limits: `rule-purity-conformance.test.mts` contains violating rules on
+          # purpose — they are the fixtures proving the conformance suite rejects
+          # them, and the suite asserts each one is refused. A text search cannot
+          # tell a violation from a test that a violation is caught. The exemption
+          # is one exact path rather than a marker comment, so it cannot be spread
+          # to a file that wants to opt out; a rule that actually decided anything
+          # would not live in the integration suite's negative cases in the first
+          # place.
+          node -e '
+            const fs = require("fs");
+            const { execSync } = require("child_process");
+            const FIXTURES = "tests/integration/src/rule-purity-conformance.test.mts";
+            const files = execSync("git ls-files \"*.mts\" \"*.ts\"", { encoding: "utf8" })
+              .split("\n")
+              .filter((f) => f && !f.includes("/dist/") && f !== FIXTURES);
+            const header = /(^|[^A-Za-z0-9_.$])verify\s*\([^)]*\)\s*(:[^{;]*)?\{/g;
+            const reads = /\b(ctx|context)\s*[.[]/;
+            let failed = false;
+            for (const file of files) {
+              const src = fs.readFileSync(file, "utf8");
+              header.lastIndex = 0;
+              let match;
+              while ((match = header.exec(src)) !== null) {
+                const open = match.index + match[0].length - 1;
+                let depth = 0;
+                let end = src.length;
+                for (let i = open; i < src.length; i++) {
+                  if (src[i] === "{") depth++;
+                  else if (src[i] === "}" && --depth === 0) { end = i; break; }
+                }
+                const body = src.slice(open, end + 1);
+                const hit = reads.exec(body);
+                if (!hit) continue;
+                const line = src.slice(0, open + hit.index).split("\n").length;
+                console.error(`::error file=${file},line=${line}::verify() reads the collector context here`);
+                console.error(`  ${body.slice(hit.index, hit.index + 100).split("\n")[0].trim()}`);
+                failed = true;
+              }
+            }
+            if (failed) {
+              console.error("A rule decides from `attrs` alone. Read the request in `collect`, copy out the");
+              console.error("value the rule compares against, and let `verify` take everything else from `attrs`.");
+              console.error("See AGENTS.md \"Collector / Rule / Attribute Contract\".");
+              process.exit(1);
+            }
+            console.log(`OK: no verify() body reads a collector context (${files.length} files scanned)`);
+          '
+
       - run: pnpm run build
 
       # Real work, not a no-op: every workspace package defines `typecheck`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,17 @@ The engine enforces a strict separation between the context-reading layer and th
 
 - **Collectors** (`AttributeCollector`, `RuleCollector`) are the only layer that reads `CollectorContext`. They transform the raw request into static outputs: attributes or rules.
 - **Attributes** are plain values (`Map<string, unknown>`). Once produced by collectors, they carry no reference to the originating request.
-- **Rules** are predicates over attributes (`verify(attrs): boolean`). A rule's decision must be derivable from `attrs` alone. Rules must not reference `CollectorContext`, close over request state, or perform side effects.
+- **Rules** are predicates over attributes (`verify(attrs): boolean`). `verify` must be a **deterministic, side-effect-free function of `attrs`**: equal attributes give equal answers, and it must not mutate its input, perform I/O, or observe anything the engine cannot see. `verify` is handed a `ReadonlyAttributes` (`ReadonlyMap<string, unknown>`), so the "must not mutate" half is a compile error rather than a request.
 
-This contract guarantees that rules are pure functions of attributes: testable in isolation, cacheable, and free from hidden coupling to request shape.
+This contract guarantees that rules are pure functions of attributes: testable in isolation, cacheable, and free from hidden coupling to request shape. It is also what `evaluate()` spends when it runs every rule group instead of stopping at the first failure.
 
-**Violation pattern to avoid:** a rule constructor that captures values from `CollectorContext` (e.g. `context.payload.sub` and `context.requestContext.someField`), then returns the captured comparison from `verify(attrs)` while ignoring `attrs`. This "bakes the decision at collect time" and defeats the contract. The correct shape is: a collector writes both values into attributes under well-known keys, and the rule compares them via `attrs.get(...)`.
+**What a rule may do.** A rule **may** hold values fixed at collect time — *what it looks for*. `ResourceActionScopeRuleCollector` computes `` `${context.action}:${context.resource.resourceType}` `` while the request is in hand and passes the resulting string to `new HasScope(...)`. The comparand is request-derived and that is fine: it is fixed once, and `HasScope.verify` remains a function of `attrs`.
+
+**What a rule must not do.** A rule **must not** retain `CollectorContext`, or any live reference into it, and read it inside `verify`. The answer would then depend on request state the engine cannot observe, which breaks isolation testing, caching, and the guarantee `evaluate()` relies on. The two shapes look alike — both mention `context.action` in the collector — which is precisely why the difference is spelled out rather than left to taste.
+
+**The deciding test:** collect the rule, discard the context, then call `verify(attrs)`. The answer must be unchanged. A rule that copied a string out at collect time answers identically; a rule that kept the request cannot answer at all.
+
+That test is executable, not rhetorical. `describeRulePurityConformance` in [`tests/integration/src/conformance/rulePurity.mts`](tests/integration/src/conformance/rulePurity.mts) collects the rules through a revocable view of the context, revokes it, and re-runs `verify` — so a rule holding the request throws on the access, and one holding a copied value does not. Apply it to every rule collector you add. `.github/workflows/ci.yml` also greps `verify` bodies for context reads, but that is a backstop for the obvious shape; the conformance suite is the check.
 
 ## Core Vocabulary Scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,36 @@ and version sections follow the release labeling policy in
 
 ### Added
 
+- **A rule-purity conformance suite, so the contract `evaluate()` spends is one
+  something can fail** ([#152](https://github.com/o3co/auth.policy-verifier/issues/152)).
+  `evaluate()` runs every rule group rather than stopping at the first failure
+  and justifies it in a comment — "Rules are pure predicates over attributes by
+  contract, so running them all is safe." Nothing checked that: not a runtime
+  check, not the type system, not lint, not CI, not a conformance suite. The
+  four existing suites are all engine-level; none could be pointed at a rule.
+
+  `describeRulePurityConformance` (and the `assertRuleIndependentOfContext`
+  primitive under it) joins them in `tests/integration/src/conformance/`. It
+  runs the contract's deciding test literally: the rules are collected through a
+  **revocable** view of the `CollectorContext`, the view is revoked, and every
+  rule is asked again. A rule that copied a string out at collect time answers
+  identically; a rule that kept the request — or any object reached through it,
+  which is why the view is revoked all the way down rather than at the top
+  level — throws on the access, named in the failure. Determinism and
+  non-mutation are checked in the same pass.
+
+  Because the check is behavioural, it cannot be satisfied by renaming a
+  variable, and its own negative cases are part of the suite: the violating
+  shapes from `app.test.mts` and `metrics.test.mts` are run through it to prove
+  it rejects them. Both builtin rule collectors are held to it and both pass.
+
+  CI additionally greps `verify` bodies for `ctx.` / `context.` reads. That is a
+  textual backstop for the obvious shape — it brace-matches the body rather than
+  reading a line, but it is still a string search and does not see a context
+  reached through a differently-named binding or a helper. It exists because the
+  violation has now been written twice by copy-paste; the conformance suite is
+  the check.
+
 - **A per-decision audit log and a `GET /metrics` endpoint, so the PDP can
   answer "why was this denied?" from its own output**
   ([#111](https://github.com/o3co/auth.policy-verifier/issues/111)). There was
@@ -557,6 +587,81 @@ and version sections follow the release labeling policy in
   result rather than throwing.
 
 ### Changed
+
+- **BREAKING (types only)**: `Rule.verify` now takes a `ReadonlyAttributes`
+  (`ReadonlyMap<string, unknown>`) instead of `Attributes`
+  ([#152](https://github.com/o3co/auth.policy-verifier/issues/152)).
+
+  The evaluator hands the **same live map** to every rule in every group, so a
+  rule that wrote into it would silently change the inputs of every group
+  evaluated after it — and nothing said it must not. `Object.freeze` was
+  considered and rejected: it does not affect a `Map`'s contents, whose entries
+  live in an internal slot, so `map.set(...)` still succeeds on a frozen one. It
+  would have been a guard that guards nothing. The type is the guard instead.
+
+  **What a rule author must change:** a rule that annotates its parameter,
+  one line each.
+
+  ```diff
+  -verify(attrs: Attributes): boolean {
+  +verify(attrs: ReadonlyAttributes): boolean {
+  ```
+
+  `ReadonlyAttributes` is exported from `@o3co/auth.policy-verifier.core`. Every
+  read a rule already does — `get`, `has`, `size`, iteration — is unchanged; only
+  `set` / `delete` / `clear` are gone, and a rule that called one of those was
+  violating the contract already. A rule written as an object literal typed
+  `Rule` needs no change at all: it picks the parameter type up contextually.
+  Note that TypeScript's method-parameter bivariance means an implementation
+  that keeps the old `Attributes` annotation still *compiles* — it simply keeps
+  write access it is not supposed to use, which is why the builtins were all
+  moved over rather than left to the compiler.
+
+  `Attributes` itself is **unchanged** and still a mutable `Map`:
+  `AttributeCollector.collect` builds one by writing into it, and
+  `AttributePipeline` merges them the same way. Only the rule's view is narrowed.
+
+- **BREAKING (meaning, not signature)**: the Collector / Rule / Attribute
+  contract in `AGENTS.md` has been rewritten, and it now forbids a different set
+  of things ([#152](https://github.com/o3co/auth.policy-verifier/issues/152)).
+  Anyone who wrote a custom rule against the old text should re-read it.
+
+  The old sentence — "Rules must not reference `CollectorContext`, close over
+  request state, or perform side effects" — was wrong in two opposite
+  directions. It **illegalized** the project's own flagship pattern:
+  `ResourceActionScopeRuleCollector` computes
+  `` `${context.action}:${context.resource.resourceType}` `` at collect time and
+  hands the string to `new HasScope(...)`, which "closes over request state" by
+  the letter of the rule while leaving `HasScope.verify` a perfectly
+  deterministic function of `attrs`. And the violation pattern it described —
+  a rule returning a captured comparison "while ignoring `attrs`" — was too
+  narrow to catch the real violation in this repo, which read `attrs` *and* the
+  request.
+
+  The prohibition has moved from **capturing at collect time** to **reading the
+  context at verify time**:
+
+  - `verify` must be a deterministic, side-effect-free function of `attrs`.
+  - A rule **may** hold values fixed at collect time — *what it looks for*.
+  - A rule **must not** retain `CollectorContext`, or any live reference into
+    it, and read it inside `verify`.
+  - The deciding test: collect the rule, discard the context, call
+    `verify(attrs)` — the answer must be unchanged.
+
+  So a rule that was legal under the old *text* may be illegal now (one that
+  keeps `ctx` and reads it in `verify` — previously indistinguishable from the
+  blessed pattern), and one that looked illegal is explicitly legal (fixing a
+  comparand at collect time). No runtime behaviour changed for a rule that was
+  already pure.
+
+  Also **dropped**: the old text's prescribed fix, "a collector writes both
+  values into attributes under well-known keys". For the scope rule that would
+  have meant adding `ATTR_ACTION` / `ATTR_RESOURCE_TYPE` to core, which the
+  Core Vocabulary Scope section directly below it forbids — those keys are
+  request-shaped, not the transport-neutral OAuth/OIDC/RBAC subject facts
+  `ATTR_*` is reserved for. Promoting both operands into attributes remains a
+  fine thing for a *consuming project* to do under its own keys (see
+  `metrics.test.mts`); it is no longer prescribed as the only correct shape.
 
 - **BREAKING (types only)**: the `EventLogger` port
   (`@o3co/auth.policy-verifier.core`) now requires `info` alongside `warn` and

--- a/docs/extending.ja.md
+++ b/docs/extending.ja.md
@@ -32,11 +32,12 @@ interface Rule {
   ruleType: string;
   code: string;
   message: string;
-  verify(attrs: Attributes): boolean;
+  verify(attrs: ReadonlyAttributes): boolean;
 }
 ```
 
 - `verify(attrs)` は述語です。通過時に `true`、失敗時に `false` を返します。**safe-deny 規約:** 欠落・型不一致・不正な属性は `false` を返してください。例外を投げない。例外を投げるとポリシー失敗がエラー応答になり、評価状態が漏れます。
+- `attrs` はコレクターが返す `Attributes` ではなく `ReadonlyAttributes`（`ReadonlyMap<string, unknown>`）です。評価器は同一の live map を全グループの全 Rule に渡すため、書き込む Rule は以降のグループが判定される対象そのものを書き換えてしまいます。read-only ビューはそれをデバッグ作業ではなくコンパイルエラーにします。コレクター側は従来どおり可変の `Map` を組み立てて返します。
 - `ruleType` は評価器が Rule をグループ化するのに使います。同じ `ruleType` の Rule は OR 結合されます（いずれか 1 つ通ればグループ通過）。異なる `ruleType` の Rule はグループ間 AND 結合されます（全グループ通過が必要）。**既定の `ruleType` は、暗黙の衝突を避けるためにルール設定を十分にエンコードしてください。** 例えば `AttrLiteralEqual` は `attr_literal_equal:${a}:${typeof v}:${String(v)}` を使います — `typeof v` セグメントは `v=true` と `v="true"` が同じ `ruleType` に畳み込まれて意図に反して OR 結合されるのを防ぎます。
 - `code` は短く安定した識別子（例: `"no_permission"`、`"attr_not_equal"`）で、下流のプログラム的ハンドリングに適した文字列にしてください。**1 つの Rule が生成しうる code の集合は小さく固定に保つこと。** `code` は `auth_denials_total` メトリクスの `code` ラベルと decision ログ行の `deniedBy` になるため、リクエストごとに導出される code（例えばリソース ID を畳み込んだもの）は有界でないメトリクスラベルになります。これは、監視すべき対象を監視する仕組みそのものをメトリクスエンドポイントが落とす経路です。サーバー側は異なる値 32 個で打ち止め、それ以降を `code="other"` に潰すので、最悪でも「Prometheus が死ぬ」ではなく「メトリクスが役に立たなくなる」で済みますが、変動する部分はラベルにならない `message` に入れてください。
 - `message` は人間可読な denial メッセージです。有益な情報を載せつつ、機微な属性値は漏らさないこと。
@@ -46,7 +47,7 @@ interface Rule {
 `userLevel` が設定値以上の数値のときに通過する Rule:
 
 ```ts
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 
 export interface UserLevelAtLeastConfig {
   threshold: number;
@@ -68,7 +69,7 @@ export class UserLevelAtLeast implements Rule {
     this.message = `User level must be at least ${String(config.threshold)}.`;
   }
 
-  verify(attrs: Attributes): boolean {
+  verify(attrs: ReadonlyAttributes): boolean {
     const level = attrs.get("userLevel");
     if (typeof level !== "number") return false;
     return level >= this.config.threshold;
@@ -179,7 +180,9 @@ RuleCollector は `CollectorContext` 全体を見られるため、エンジン�
 
 成立していなければならない性質は、`verify(attrs)` が `attrs` の決定的かつ副作用のない関数であることです — 評価器が最初の失敗で止まらず全グループを実行できるのは、この性質があるからです。Rule が *探す値* を collect 時に固定することはこれを壊しませんが、context を保持して *verify 時に読む* ことは壊します。
 
-**そしてこれは規約であって検査ではありません。** `verify(attrs)` は attribute しか受け取りませんが、Collector の context を Rule が保持してそこで参照することは何も妨げておらず、コンパイラもテストスイートも教えてくれません。答えを焼き込んでしまった Rule の直し方は次のとおりです: *検査される側の値* は `attrs.get(...)` から取得し、*それが照合される相手の値* はリクエストから捕捉したままでよい。
+**そしてこれは今や規約であるだけでなく検査でもあります。** 決め手となるテストは「Rule を collect し、context を捨て、`verify(attrs)` を呼ぶ — 答えが変わらないこと」です。[`tests/integration/src/conformance/rulePurity.mts`](../tests/integration/src/conformance/rulePurity.mts) の `describeRulePurityConformance` がまさにこれを実行します: revoke 可能な context ビュー経由で Rule を collect し、revoke してから再び問う。context を保持した Rule はアクセス時に throw し、値をコピーしただけの Rule は throw しません。自作の RuleCollector もこれに通してください。（CI も `verify` の本体に `ctx.` / `context.` がないか grep しますが、それは分かりやすい形に対する backstop であり、実際に判定するのは conformance suite です。）
+
+答えを焼き込んでしまった Rule の直し方は次のとおりです: *検査される側の値* は `attrs.get(...)` から取得し、*それが照合される相手の値* はリクエストから捕捉したままでよい — ただし context への live な参照ではなく、コピーされた値として。
 
 ## 関連資料
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -32,11 +32,12 @@ interface Rule {
   ruleType: string;
   code: string;
   message: string;
-  verify(attrs: Attributes): boolean;
+  verify(attrs: ReadonlyAttributes): boolean;
 }
 ```
 
 - `verify(attrs)` is the predicate. Return `true` to pass, `false` to fail. **Safe-deny convention:** missing, wrong-type, or malformed attributes must return `false`, not throw. Throwing turns a policy failure into an error response and leaks evaluation state.
+- `attrs` is a `ReadonlyAttributes` (`ReadonlyMap<string, unknown>`), not the `Attributes` a collector returns. The evaluator hands the same live map to every rule in every group, so a rule that wrote into it would change what every later group is judged against — the read-only view makes that a compile error instead of a debugging session. Collectors still build and return a mutable `Map`.
 - `ruleType` is used by the evaluator to group rules. Rules sharing a `ruleType` are OR-combined (any one passing satisfies the group). Rules with different `ruleType`s are AND-combined across groups (all groups must be satisfied). **Default `ruleType`s must encode enough of the rule's configuration to avoid silent collisions.** For example, `AttrLiteralEqual` uses `attr_literal_equal:${a}:${typeof v}:${String(v)}` — the `typeof v` segment prevents `v=true` and `v="true"` from collapsing into the same `ruleType` and being OR-combined against intent.
 - `code` is a short, stable identifier (e.g. `"no_permission"`, `"attr_not_equal"`) suitable for downstream programmatic handling. **Keep the set of codes a rule can produce small and fixed.** `code` becomes the `code` label on the `auth_denials_total` metric and the `deniedBy` field of the decision log line, so a code derived per request — folding in the resource id, say — is an unbounded metric label, which is how a metrics endpoint takes down the monitoring meant to watch it. The server caps the label at 32 distinct values and collapses the rest into `code="other"`, so the failure mode is a useless metric rather than a dead Prometheus; put the varying part in `message`, which is never a label.
 - `message` is a human-readable denial message. Keep it informative but do not leak sensitive attribute values.
@@ -46,7 +47,7 @@ interface Rule {
 A rule that passes when `userLevel` is a number greater than or equal to a configured threshold:
 
 ```ts
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 
 export interface UserLevelAtLeastConfig {
   threshold: number;
@@ -68,7 +69,7 @@ export class UserLevelAtLeast implements Rule {
     this.message = `User level must be at least ${String(config.threshold)}.`;
   }
 
-  verify(attrs: Attributes): boolean {
+  verify(attrs: ReadonlyAttributes): boolean {
     const level = attrs.get("userLevel");
     if (typeof level !== "number") return false;
     return level >= this.config.threshold;
@@ -179,7 +180,9 @@ The builtins show the line. `ResourceActionScopeRuleCollector` builds `new HasSc
 
 The property that has to hold is that `verify(attrs)` is a deterministic, side-effect-free function of `attrs` — which is what lets the evaluator run every group rather than stopping at the first failure. Fixing what a rule *looks for* at collect time does not break that; retaining the context and reading it *at verify time* does.
 
-**And it is a convention, not a check.** `verify(attrs)` takes only attributes, but nothing stops a rule from holding on to its collector's context and consulting it there, and neither the compiler nor the test suite will tell you. The fix for a rule that has baked its answer in: the value being tested comes from `attrs.get(...)`, while the value it is tested against may still be captured from the request.
+**And it is a check now, not only a convention.** The deciding test is: collect the rule, discard the context, call `verify(attrs)` — the answer must be unchanged. `describeRulePurityConformance` in [`tests/integration/src/conformance/rulePurity.mts`](../tests/integration/src/conformance/rulePurity.mts) runs exactly that, collecting the rules through a revocable view of the context and revoking it before asking again, so a rule holding the request throws on the access and one holding a copied value does not. Run your own rule collector through it. (CI also greps `verify` bodies for `ctx.` / `context.`, but that is a backstop for the obvious shape; the conformance suite is what actually decides.)
+
+The fix for a rule that has baked its answer in: the value being tested comes from `attrs.get(...)`, while the value it is tested against may still be captured from the request — as a copied value, not as a live reference into the context.
 
 ## Further reading
 

--- a/packages/builtins/src/rules/AttrLiteralCompare.mts
+++ b/packages/builtins/src/rules/AttrLiteralCompare.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	applyCompare,
 	type CompareOp,
@@ -47,7 +47,7 @@ export class AttrLiteralCompare implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must be ${config.op} ${String(config.v)}.`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const x = attrs.get(this.config.a);
 		if (typeof x !== "number") return false;
 		return applyCompare(this.config.op, x, this.config.v);

--- a/packages/builtins/src/rules/AttrLiteralEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralEqual.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	type LiteralValue,
 	requireAttrName,
@@ -51,7 +51,7 @@ export class AttrLiteralEqual implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${String(config.v)}.`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const x = attrs.get(this.config.a);
 		if (typeof x !== typeof this.config.v) return false;
 		return x === this.config.v;

--- a/packages/builtins/src/rules/AttrLiteralIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralIn.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	computeValuesKey,
 	type LiteralValue,
@@ -57,7 +57,7 @@ export class AttrLiteralIn implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must be one of [${values.map(String).join(", ")}].`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const x = attrs.get(this.config.a);
 		if (typeof x !== this.elementType) return false;
 		return this.valuesSet.has(x as LiteralValue);

--- a/packages/builtins/src/rules/AttrLiteralNotEqual.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotEqual.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	type LiteralValue,
 	requireAttrName,
@@ -50,7 +50,7 @@ export class AttrLiteralNotEqual implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must not equal ${String(config.v)}.`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const x = attrs.get(this.config.a);
 		if (typeof x !== typeof this.config.v) return false;
 		return x !== this.config.v;

--- a/packages/builtins/src/rules/AttrLiteralNotIn.mts
+++ b/packages/builtins/src/rules/AttrLiteralNotIn.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	computeValuesKey,
 	type LiteralValue,
@@ -52,7 +52,7 @@ export class AttrLiteralNotIn implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must not be one of [${values.map(String).join(", ")}].`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const x = attrs.get(this.config.a);
 		if (typeof x !== this.elementType) return false;
 		return !this.valuesSet.has(x as LiteralValue);

--- a/packages/builtins/src/rules/AttrPairCompare.mts
+++ b/packages/builtins/src/rules/AttrPairCompare.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import {
 	applyCompare,
 	type CompareOp,
@@ -50,7 +50,7 @@ export class AttrPairCompare implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must be ${config.op} ${config.b}.`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const a = attrs.get(this.config.a);
 		const b = attrs.get(this.config.b);
 		if (typeof a !== "number") return false;

--- a/packages/builtins/src/rules/AttrPairEqual.mts
+++ b/packages/builtins/src/rules/AttrPairEqual.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { requireAttrName, requireOptionalGroup } from "./_sharedValidation.mjs";
 
 export interface AttrPairEqualConfig {
@@ -44,7 +44,7 @@ export class AttrPairEqual implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must equal ${config.b}.`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const a = attrs.get(this.config.a);
 		const b = attrs.get(this.config.b);
 		if (typeof a !== "string" || a.length === 0) return false;

--- a/packages/builtins/src/rules/AttrPairNotEqual.mts
+++ b/packages/builtins/src/rules/AttrPairNotEqual.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { requireAttrName, requireOptionalGroup } from "./_sharedValidation.mjs";
 
 export interface AttrPairNotEqualConfig {
@@ -43,7 +43,7 @@ export class AttrPairNotEqual implements Rule {
 		this.message = `Attribute constraint not satisfied: ${config.a} must not equal ${config.b}.`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const a = attrs.get(this.config.a);
 		const b = attrs.get(this.config.b);
 		if (typeof a !== "string" || a.length === 0) return false;

--- a/packages/builtins/src/rules/HasPermission.mts
+++ b/packages/builtins/src/rules/HasPermission.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Role, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Role, Rule } from "@o3co/auth.policy-verifier.core";
 import { ATTR_PERMISSIONS, ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 
 /**
@@ -24,7 +24,7 @@ export class HasPermission implements Rule {
 		this.message = `User does not have required permission: ${permission}`;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const direct = (attrs.get(ATTR_PERMISSIONS) as string[] | undefined) ?? [];
 		const fromRoles = ((attrs.get(ATTR_ROLES) as Role[] | undefined) ?? []).flatMap(
 			(role) => role.permissions,

--- a/packages/builtins/src/rules/HasScope.mts
+++ b/packages/builtins/src/rules/HasScope.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Attributes, Rule } from "@o3co/auth.policy-verifier.core";
+import type { ReadonlyAttributes, Rule } from "@o3co/auth.policy-verifier.core";
 import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 
 /** Options accepted by `HasScope`. */
@@ -60,7 +60,7 @@ export class HasScope implements Rule {
 		this.allowBareScopeRewrite = options?.allowBareScopeRewrite ?? false;
 	}
 
-	verify(attrs: Attributes): boolean {
+	verify(attrs: ReadonlyAttributes): boolean {
 		const scopes: unknown = attrs.get(ATTR_SCOPES);
 		if (!Array.isArray(scopes)) return false;
 		return scopes.some((s) => typeof s === "string" && this.matchScope(s, this.scope));

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -101,9 +101,10 @@ interface ModuleContext {
 | `ResourceParseError` | `raw`（拒否した文字列）と `detail`（理由）を持つ `Error` サブクラス。サーバーエラーではなく**リクエスト**エラーであり、トランスポート層は 400 系で応答する。クラスとして export されるため `instanceof` で絞り込める |
 | `CollectorContext` | 各コレクターに渡される入力: `payload`、`resource`、`action`、省略可能な `headers` と `requestContext` |
 | `UntrustedRequestContext` | `requestContext` の型 — 呼び出し側のデータであり、読むには明示的な `readUntrustedRequestContext(...)` が必要な形で封じられている。トランスポート境界で生成するのは `markUntrustedRequestContext(...)`。[docs/extending.ja.md — 信頼境界](../../docs/extending.ja.md#信頼境界-requestcontext-は呼び出し側のもの) を参照 |
-| `Attributes` | `Map<string, unknown>` — サブジェクト属性のバッグ |
+| `Attributes` | `Map<string, unknown>` — サブジェクト属性のバッグ。可変: コレクターがこれを組み立て、`AttributePipeline` がマージする |
+| `ReadonlyAttributes` | `ReadonlyMap<string, unknown>` — Rule が判定対象として受け取るビュー。評価器は同一の live map をすべての Rule に渡すため、書き込む Rule は以降の全グループの入力を書き換えてしまう |
 | `AttributeCollector` | `collect(context: CollectorContext): Promise<Attributes>` |
-| `Rule` | `{ ruleType: string; code: string; message: string; verify(attrs: Attributes): boolean }` |
+| `Rule` | `{ ruleType: string; code: string; message: string; verify(attrs: ReadonlyAttributes): boolean }` — `verify` は `attrs` の決定的かつ副作用のない関数でなければならない。[AGENTS.md — Collector / Rule / Attribute Contract](../../AGENTS.md#collector--rule--attribute-contract) を参照 |
 | `RuleCollector` | `collect(context: CollectorContext): Promise<Rule[]>` |
 | `Decision` | `{ decision: "allow"; reason: DecisionReason } \| { decision: "deny"; code: string; message: string; reason: DecisionReason }` |
 | `DecisionReason` | `{ groups: RuleGroupOutcome[] }` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -95,9 +95,10 @@ A module registers collector, parser, and key resolver factories into the provid
 | `ResourceParseError` | `Error` subclass carrying `raw` (the refused string) and `detail` (why). A **request** error, not a server error — the transport layer answers it 400-class. Exported as a class, so `instanceof` narrows it |
 | `CollectorContext` | Input passed to every collector: `payload`, `resource`, `action`, optional `headers` and `requestContext` |
 | `UntrustedRequestContext` | The type of `requestContext` — the caller's own data, sealed so it takes an explicit `readUntrustedRequestContext(...)` to read. `markUntrustedRequestContext(...)` mints one at the transport boundary. See [docs/extending.md — The trust boundary](../../docs/extending.md#the-trust-boundary-requestcontext-is-the-callers) |
-| `Attributes` | `Map<string, unknown>` — subject attribute bag |
+| `Attributes` | `Map<string, unknown>` — subject attribute bag. Mutable: collectors build one, and `AttributePipeline` merges them |
+| `ReadonlyAttributes` | `ReadonlyMap<string, unknown>` — the view a rule is judged against. The evaluator hands the same live map to every rule, so a rule that wrote into it would change the inputs of every group after it |
 | `AttributeCollector` | `collect(context: CollectorContext): Promise<Attributes>` |
-| `Rule` | `{ ruleType: string; code: string; message: string; verify(attrs: Attributes): boolean }` |
+| `Rule` | `{ ruleType: string; code: string; message: string; verify(attrs: ReadonlyAttributes): boolean }` — `verify` must be a deterministic, side-effect-free function of `attrs`. See [AGENTS.md — Collector / Rule / Attribute Contract](../../AGENTS.md#collector--rule--attribute-contract) |
 | `RuleCollector` | `collect(context: CollectorContext): Promise<Rule[]>` |
 | `Decision` | `{ decision: "allow"; reason: DecisionReason } \| { decision: "deny"; code: string; message: string; reason: DecisionReason }` |
 | `DecisionReason` | `{ groups: RuleGroupOutcome[] }` |

--- a/packages/core/src/__tests__/ruleContract.test.mts
+++ b/packages/core/src/__tests__/ruleContract.test.mts
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { evaluate } from "../evaluate.mjs";
+import type { Attributes, ReadonlyAttributes, Rule } from "../types.mjs";
+
+/*
+ * The `Rule.verify` half of the Collector/Rule/Attribute contract
+ * (o3co/auth.policy-verifier#152).
+ *
+ * AGENTS.md requires `verify` to be a deterministic, side-effect-free function
+ * of `attrs`. Two of those words are checkable here, at the type level and at
+ * the unit level; the third — "does not read the request at verify time" — is
+ * behavioural and lives in `tests/integration/src/conformance/rulePurity.mts`,
+ * which revokes the context and re-runs `verify`.
+ */
+
+/** Fails to compile unless `T` is exactly `true`. */
+type Assert<T extends true> = T;
+
+/** The type `Rule.verify` actually hands an implementation. */
+type VerifyParam = Parameters<Rule["verify"]>[0];
+
+/*
+ * The parameter is a read-only view. "Side-effect-free" includes not writing
+ * into the map the evaluator is about to hand to every other group, and a
+ * `ReadonlyMap` is where that stops being a request in prose. If `Rule.verify`
+ * ever widens back to a mutable `Map`, `"set" extends keyof VerifyParam`
+ * becomes `true` and this line stops compiling — which is the assertion.
+ */
+type _VerifyCannotWrite = Assert<"set" extends keyof VerifyParam ? false : true>;
+type _VerifyCannotDelete = Assert<"delete" extends keyof VerifyParam ? false : true>;
+type _VerifyCannotClear = Assert<"clear" extends keyof VerifyParam ? false : true>;
+
+/* Reading is untouched: a rule still gets `get` / `has` / iteration. */
+type _VerifyCanRead = Assert<"get" extends keyof VerifyParam ? true : false>;
+
+/*
+ * The collector side is deliberately NOT narrowed. `AttributeCollector.collect`
+ * builds its result by mutation and the pipeline merges those maps, so
+ * `Attributes` stays a mutable `Map`; only the rule's view of it is read-only.
+ */
+type _CollectorStillWrites = Assert<"set" extends keyof Attributes ? true : false>;
+
+/** A rule whose answer is a function of `attrs` and of nothing else. */
+const requiresScope = (required: string): Rule => ({
+	ruleType: "scope",
+	code: "invalid_scope",
+	message: `Token does not have required scope: ${required}`,
+	verify(attrs: ReadonlyAttributes) {
+		const scopes = attrs.get("scopes");
+		return Array.isArray(scopes) && scopes.includes(required);
+	},
+});
+
+describe("Rule.verify contract", () => {
+	it("answers identically for two distinct maps carrying equal attributes", () => {
+		// "Equal attrs give equal answers" is the whole of the contract's
+		// determinism clause, and it is what makes a rule testable in isolation:
+		// the map's identity must not be part of the answer.
+		const rule = requiresScope("read:project");
+		const first: Attributes = new Map([["scopes", ["read:project"]]]);
+		const second: Attributes = new Map([["scopes", ["read:project"]]]);
+
+		expect(rule.verify(first)).toBe(true);
+		expect(rule.verify(second)).toBe(true);
+		expect(rule.verify(new Map([["scopes", ["write:project"]]]))).toBe(false);
+	});
+
+	it("answers identically on repeated calls with the same map", () => {
+		const rule = requiresScope("read:project");
+		const attrs: Attributes = new Map([["scopes", ["read:project"]]]);
+
+		expect(rule.verify(attrs)).toBe(true);
+		expect(rule.verify(attrs)).toBe(true);
+	});
+
+	it("leaves the attributes it was judged against untouched", () => {
+		// The evaluator hands the same live map to every rule in every group
+		// (`evaluate.mts` Phase 3). A rule that wrote into it would change the
+		// inputs of every group after it, which is what the read-only view above
+		// makes a compile error rather than a debugging session.
+		const rule = requiresScope("read:project");
+		const attrs: Attributes = new Map([["scopes", ["read:project"]]]);
+		const before = [...attrs];
+
+		evaluate(attrs, [rule, requiresScope("write:project")]);
+
+		expect([...attrs]).toEqual(before);
+	});
+});

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -33,6 +33,7 @@ export type {
 	Decision,
 	DecisionReason,
 	KeyResolver,
+	ReadonlyAttributes,
 	Resource,
 	ResourceParser,
 	Role,

--- a/packages/core/src/types.mts
+++ b/packages/core/src/types.mts
@@ -50,8 +50,22 @@ export interface CollectorContext {
  * Map of attribute keys to values produced by attribute collectors.
  * Values are `unknown` so collectors can contribute any shape; downstream rules
  * are responsible for narrowing.
+ *
+ * Mutable on purpose: a collector builds its slice by writing into one, and
+ * `AttributePipeline` merges those slices the same way. It is the *rule's* view
+ * of the merged result that is narrowed — see {@link ReadonlyAttributes}.
  */
 export type Attributes = Map<string, unknown>;
+
+/**
+ * The read-only view of {@link Attributes} that a rule is judged against.
+ *
+ * The evaluator hands the same live map to every rule in every group, so a rule
+ * that wrote into it would silently change the inputs of every group evaluated
+ * after it. Rules only ever read, so they are handed something that can only be
+ * read — see AGENTS.md "Collector / Rule / Attribute Contract".
+ */
+export type ReadonlyAttributes = ReadonlyMap<string, unknown>;
 
 /**
  * Produces attributes for a request. One collector contributes one logical slice
@@ -65,12 +79,18 @@ export interface AttributeCollector {
  * A single authorization rule. `verify` runs against the merged attributes and
  * returns whether the rule passes; `ruleType` groups alternative rules (OR within
  * a group), and `code` / `message` surface on deny.
+ *
+ * `verify` must be a deterministic, side-effect-free function of `attrs`: equal
+ * attributes give equal answers, and nothing the engine cannot see may decide
+ * the outcome. A rule may hold values fixed at collect time — *what it looks
+ * for* — but must not retain the `CollectorContext` and read it here. See
+ * AGENTS.md "Collector / Rule / Attribute Contract".
  */
 export interface Rule {
 	ruleType: string;
 	code: string;
 	message: string;
-	verify(attrs: Attributes): boolean;
+	verify(attrs: ReadonlyAttributes): boolean;
 }
 
 /**

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -43,14 +43,30 @@ const testModule: Module = {
 		}));
 		context.ruleCollectorRegistry.register("TestScopeRuleCollector", () => ({
 			async collect(ctx) {
+				// The required scope is fixed HERE, at collect time, and copied into
+				// the rule as a plain string — the same shape the real
+				// `ResourceActionScopeRuleCollector` uses to build its `HasScope`.
+				//
+				// The contract (AGENTS.md, Collector / Rule / Attribute) draws its line
+				// between the two things that look alike: fixing *what the rule looks
+				// for* while the request is in hand is fine, because `verify` stays a
+				// function of `attrs` alone. Keeping `ctx` and reading it inside
+				// `verify` is not — the answer would then depend on request state the
+				// evaluator cannot see, which is what breaks isolation testing,
+				// caching, and `evaluate()`'s licence to run every rule group.
+				//
+				// This file is where the violating copy in `metrics.test.mts` was
+				// copied from (#150, #152), so it is written to be copied again.
+				const requiredScope = `${ctx.action}:${ctx.resource.resourceType}`;
 				return [
 					{
 						ruleType: "scope",
 						code: "invalid_scope",
-						message: "Insufficient scope",
+						message: `Insufficient scope: ${requiredScope} is required`,
 						verify(attributes) {
-							const scopes = (attributes.get("scopes") as string[]) ?? [];
-							return scopes.includes(`${ctx.action}:${ctx.resource.resourceType}`);
+							// Safe-deny: a missing or malformed attribute denies, never throws.
+							const scopes = attributes.get("scopes");
+							return Array.isArray(scopes) && scopes.includes(requiredScope);
 						},
 					},
 				];

--- a/packages/server/src/__tests__/metrics.test.mts
+++ b/packages/server/src/__tests__/metrics.test.mts
@@ -52,21 +52,23 @@ const ATTR_REQUIRED_SCOPE = "requiredScope";
  *
  * Deliberately not built per request inside the rule collector. AGENTS.md's
  * Collector/Rule/Attribute contract makes collectors the only layer that reads
- * `CollectorContext`; a rule is a predicate over attributes whose verdict must
- * be derivable from `attrs` alone. A `verify` that closed over the collector's
- * `ctx` to recompute `${ctx.action}:${ctx.resource.resourceType}` would be the
- * violation the contract names by name — it bakes the decision at collect time
- * and holds a reference to the whole request.
+ * `CollectorContext`; a rule's `verify` must be a deterministic function of
+ * `attrs`. A `verify` that kept the collector's `ctx` and read
+ * `${ctx.action}:${ctx.resource.resourceType}` out of it at verify time would be
+ * the violation — not because the value is request-derived, which is fine, but
+ * because the read happens where the evaluator cannot see it.
  *
- * Hoisting it to a constant is what makes the compliance checkable rather than
- * asserted: this object is created once, before any request exists, so it
- * *cannot* carry request state. Everything it compares comes from `attrs`,
- * promoted there by the attribute collector below. `code` is a constant too, as
- * every builtin rule's is — which is what keeps it a bounded metric label.
+ * Hoisting it to a constant is the strongest form of compliance available:
+ * this object is created once, before any request exists, so it *cannot* carry
+ * request state at all. Everything it compares comes from `attrs`, promoted
+ * there by the attribute collector below. `code` is a constant too, as every
+ * builtin rule's is — which is what keeps it a bounded metric label.
  *
- * Nothing in the engine enforces any of this today — no runtime check, no lint,
- * no conformance suite — which is #152. Until that lands, the shape is upheld
- * by hand, so it is written down here rather than left to be inferred.
+ * The weaker-but-legal form is what the builtins do: fix the comparand at
+ * collect time and hold it as a plain value (see `app.test.mts`). #152 added
+ * the check that tells the two apart from the violation —
+ * `tests/integration/src/conformance/rulePurity.mts` collects a rule, revokes
+ * the request, and asks it again.
  */
 const SCOPE_RULE: Rule = {
 	ruleType: "scope",

--- a/tests/integration/src/conformance/rulePurity.mts
+++ b/tests/integration/src/conformance/rulePurity.mts
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+	Attributes,
+	CollectorContext,
+	ReadonlyAttributes,
+	Rule,
+} from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+
+/** The collect half of a `RuleCollector`, which is all this suite needs. */
+export type CollectRules = (context: CollectorContext) => Promise<Rule[]>;
+
+/** One request, and the attributes the rules collected from it are judged against. */
+export interface RulePurityCase {
+	/** Case name, used in test titles. */
+	name: string;
+	/** The request the rules are collected from. */
+	context: CollectorContext;
+	/** Attributes to run the collected rules against. */
+	attrs: Attributes;
+}
+
+/**
+ * Hooks a rule collector must provide to be checked for rule purity. `cases`
+ * carry the collector's own requests and attributes — the suite pins the
+ * property, not any particular policy, so an allowing case and a denying case
+ * are both worth supplying: a rule that answers `false` for everything passes
+ * every purity check while deciding nothing.
+ */
+export interface RulePurityAdapter {
+	/** Collector name, used in test titles. */
+	name: string;
+	collect: CollectRules;
+	cases: RulePurityCase[];
+}
+
+/**
+ * Wraps `context` so every object reachable through it can be revoked at once.
+ *
+ * A shallow `Proxy.revocable(context)` would only catch a rule that kept the
+ * context object itself. The mistake is just as easily made one indirection in —
+ * `const resource = ctx.resource` at collect time, `resource.resourceType`
+ * inside `verify` — so each object read through the proxy is wrapped in its own
+ * revocable proxy and registered here. Primitives are handed back as-is, which
+ * is exactly the distinction the contract draws: copying a value out at collect
+ * time is legal, holding a live reference into the request is not.
+ *
+ * Each target is wrapped **once**, memoized in a `WeakMap`, so the proxy has the
+ * same object identity every time it is read. Wrapping per access would make
+ * `ctx.resource === ctx.resource` false inside `collect`, and an honest
+ * collector that compares or caches a sub-object would fail this suite for a
+ * reason that exists only inside the harness — a gate that reports its own
+ * artifacts as violations is one people learn to disbelieve. Memoizing does not
+ * weaken the revoke: one proxy per target still means every proxy ever handed
+ * out is registered, so revocation reaches a rule that kept `ctx.resource` just
+ * as it reaches one that kept `ctx`.
+ */
+function revocableContext(context: CollectorContext): {
+	proxy: CollectorContext;
+	revoke: () => void;
+} {
+	const revokers: Array<() => void> = [];
+	const wrapped = new WeakMap<object, object>();
+
+	const wrap = <T extends object>(target: T): T => {
+		const memoized = wrapped.get(target);
+		if (memoized !== undefined) return memoized as T;
+
+		const { proxy, revoke } = Proxy.revocable(target, {
+			get(t, prop, receiver) {
+				const value: unknown = Reflect.get(t, prop, receiver);
+				return typeof value === "object" && value !== null ? wrap(value) : value;
+			},
+		});
+		// Registered before any nested read can recurse back into this target.
+		wrapped.set(target, proxy);
+		revokers.push(revoke);
+		return proxy;
+	};
+
+	const proxy = wrap(context);
+	return {
+		proxy,
+		revoke: () => {
+			for (const revoke of revokers) revoke();
+		},
+	};
+}
+
+/** Whether an error is the one a revoked proxy throws on any access. */
+function isRevokedProxyError(error: unknown): boolean {
+	return error instanceof TypeError && /revoked/.test(error.message);
+}
+
+/** Names a rule in an assertion message the way a reader would look for it. */
+function describeRule(rule: Rule, index: number): string {
+	return `rule[${String(index)}] (ruleType="${rule.ruleType}", code="${rule.code}")`;
+}
+
+/**
+ * Runs the contract's deciding test: collect the rules, take the request away,
+ * and ask them again.
+ *
+ * The rules are collected from a revocable view of `context`. Each rule is
+ * verified once while the request is still reachable, the view is then revoked,
+ * and each rule is verified again. A rule that copied what it needs out at
+ * collect time answers identically; a rule that kept the context — or anything
+ * live inside it — throws on the access, which is the violation, reported
+ * against the rule that committed it.
+ *
+ * Determinism and non-mutation are checked in the same pass, because they are
+ * the other two clauses of the same sentence in AGENTS.md and they are free
+ * here: the first verify already gives an answer to compare against, and the
+ * attributes are already in hand to snapshot.
+ *
+ * @returns each rule's answer, in collection order, so a caller can assert the
+ *   collector decides something rather than passing vacuously.
+ * @throws if any rule reads the request at verify time, mutates `attrs`, or
+ *   answers inconsistently.
+ */
+export async function assertRuleIndependentOfContext(
+	collect: CollectRules,
+	context: CollectorContext,
+	attrs: Attributes,
+): Promise<boolean[]> {
+	const { proxy, revoke } = revocableContext(context);
+	const rules = await collect(proxy);
+
+	const snapshot = JSON.stringify([...attrs]);
+	const withContext = rules.map((rule) => rule.verify(attrs));
+
+	if (JSON.stringify([...attrs]) !== snapshot) {
+		throw new Error(
+			"a rule mutated the attributes it was judged against. The evaluator hands the same map to " +
+				"every rule in every group, so a write here changes the inputs of every group after it.",
+		);
+	}
+
+	// Same map, same question, before anything else changes: an answer that
+	// moves on its own is not a function of `attrs` at all.
+	const repeated = rules.map((rule) => rule.verify(attrs));
+	for (const [index, answer] of repeated.entries()) {
+		if (answer !== withContext[index]) {
+			throw new Error(
+				`${describeRule(rules[index], index)} is not a deterministic function of its attributes: ` +
+					`it answered ${String(withContext[index])} and then ${String(answer)} for the same map.`,
+			);
+		}
+	}
+
+	revoke();
+
+	const withoutContext = rules.map((rule, index) => {
+		try {
+			return rule.verify(attrs);
+		} catch (error) {
+			if (isRevokedProxyError(error)) {
+				throw new Error(
+					`${describeRule(rules[index], index)} read its collector's context at verify time. ` +
+						"A rule may fix what it looks for at collect time, but its answer must come from " +
+						'`attrs` alone — see AGENTS.md "Collector / Rule / Attribute Contract".',
+				);
+			}
+			throw error;
+		}
+	});
+
+	for (const [index, answer] of withoutContext.entries()) {
+		if (answer !== withContext[index]) {
+			throw new Error(
+				`${describeRule(rules[index], index)} changed its answer once the request was gone: ` +
+					`${String(withContext[index])} with the context, ${String(answer)} without it.`,
+			);
+		}
+	}
+
+	return withoutContext;
+}
+
+/**
+ * Conformance suite pinning rule purity
+ * (o3co/auth.policy-verifier#152).
+ *
+ * `evaluate()` runs every rule group rather than stopping at the first failure,
+ * and justifies it in a comment: "Rules are pure predicates over attributes by
+ * contract, so running them all is safe." This suite is what turns that "by
+ * contract" into something that fails a build. The same property is what makes
+ * a rule testable in isolation and a decision cacheable, and what lets an engine
+ * that only ever receives a decision document sit behind the same contract — a
+ * rule that reads the live request is not portable to one.
+ *
+ * The check is behavioural rather than textual, so it cannot be satisfied by
+ * renaming a variable: the request is genuinely taken away and the rule is
+ * genuinely asked again.
+ */
+export function describeRulePurityConformance(adapter: RulePurityAdapter): void {
+	describe(`rule purity conformance — ${adapter.name}`, () => {
+		for (const testCase of adapter.cases) {
+			describe(testCase.name, () => {
+				it("answers the same once the request it was collected from is gone", async () => {
+					const answers = await assertRuleIndependentOfContext(
+						adapter.collect,
+						testCase.context,
+						testCase.attrs,
+					);
+					// Guards against a vacuous pass: a collector that returns nothing
+					// satisfies every property below without deciding anything.
+					expect(answers.length).toBeGreaterThan(0);
+				});
+
+				it("answers the same for a distinct map carrying equal attributes", async () => {
+					// The map's identity must not be part of the answer, or "cacheable"
+					// and "testable in isolation" both stop being true.
+					const rules = await adapter.collect(testCase.context);
+					const copy: Attributes = new Map(testCase.attrs);
+
+					expect(rules.map((rule) => rule.verify(copy))).toEqual(
+						rules.map((rule) => rule.verify(testCase.attrs)),
+					);
+				});
+
+				it("only reads the attributes it is handed", async () => {
+					// The read-only view `Rule.verify` declares, enforced at runtime for
+					// the sake of a rule authored in JavaScript, where the type is gone.
+					const rules = await adapter.collect(testCase.context);
+					const readOnly: ReadonlyAttributes = new Map(testCase.attrs);
+					const before = JSON.stringify([...readOnly]);
+
+					for (const rule of rules) rule.verify(readOnly);
+
+					expect(JSON.stringify([...readOnly])).toBe(before);
+				});
+			});
+		}
+	});
+}

--- a/tests/integration/src/rule-purity-conformance.test.mts
+++ b/tests/integration/src/rule-purity-conformance.test.mts
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	ResourceActionPermissionRuleCollector,
+	ResourceActionScopeRuleCollector,
+} from "@o3co/auth.policy-verifier.builtins";
+import type { Attributes, CollectorContext, Rule } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import {
+	assertRuleIndependentOfContext,
+	describeRulePurityConformance,
+} from "./conformance/rulePurity.mjs";
+
+const scopeContext: CollectorContext = {
+	payload: { sub: "user-1", scope: "read:project write:project" },
+	resource: { raw: "project:1", resourceType: "project", resourceId: "1" },
+	action: "read",
+};
+
+const permissionContext: CollectorContext = {
+	payload: { sub: "user-1" },
+	resource: { raw: "project:1", resourceType: "project", resourceId: "1" },
+	action: "read",
+};
+
+describeRulePurityConformance({
+	name: "ResourceActionScopeRuleCollector",
+	collect: (context) => new ResourceActionScopeRuleCollector().collect(context),
+	cases: [
+		{
+			name: "a request the collected rule passes",
+			context: scopeContext,
+			attrs: new Map<string, unknown>([["scopes", ["read:project", "write:project"]]]),
+		},
+		{
+			name: "a request the collected rule denies",
+			context: scopeContext,
+			attrs: new Map<string, unknown>([["scopes", ["read:document"]]]),
+		},
+		{
+			name: "attributes the rule cannot read at all",
+			context: scopeContext,
+			attrs: new Map<string, unknown>(),
+		},
+	],
+});
+
+describeRulePurityConformance({
+	name: "ResourceActionPermissionRuleCollector",
+	collect: (context) => new ResourceActionPermissionRuleCollector().collect(context),
+	cases: [
+		{
+			name: "a request the collected rule passes",
+			context: permissionContext,
+			attrs: new Map<string, unknown>([["permissions", ["project:1.perm:read"]]]),
+		},
+		{
+			name: "a request the collected rule denies",
+			context: permissionContext,
+			attrs: new Map<string, unknown>([["permissions", ["project:1.perm:write"]]]),
+		},
+	],
+});
+
+/*
+ * The suite above only proves the builtins are clean. These cases prove the
+ * check is capable of failing — a conformance helper that cannot reject a
+ * violation is a green tick, not a guarantee.
+ *
+ * Both violating shapes below are lifted from real ones: the first is
+ * `app.test.mts:50-53` as it stood before #152 (and `metrics.test.mts` before
+ * #150), the second is the same mistake made one indirection deeper, where a
+ * grep for `ctx.` inside `verify` would not see it.
+ */
+describe("rule purity conformance — the check itself", () => {
+	const attrs: Attributes = new Map([["scopes", ["read:project"]]]);
+
+	it("rejects a rule that reads the collector's context at verify time", async () => {
+		const collect = async (ctx: CollectorContext): Promise<Rule[]> => [
+			{
+				ruleType: "scope",
+				code: "invalid_scope",
+				message: "Insufficient scope",
+				verify(attributes) {
+					const scopes = attributes.get("scopes");
+					// Reads `attrs` *and* the live request — the shape the old
+					// "while ignoring `attrs`" wording could not describe.
+					return (
+						Array.isArray(scopes) && scopes.includes(`${ctx.action}:${ctx.resource.resourceType}`)
+					);
+				},
+			},
+		];
+
+		await expect(assertRuleIndependentOfContext(collect, scopeContext, attrs)).rejects.toThrow(
+			/read its collector's context/,
+		);
+	});
+
+	it("rejects a rule that kept a reference into the context rather than the context", async () => {
+		const collect = async (ctx: CollectorContext): Promise<Rule[]> => {
+			// Not `ctx` itself — one field of it, held live.
+			const resource = ctx.resource;
+			const action = ctx.action;
+			return [
+				{
+					ruleType: "scope",
+					code: "invalid_scope",
+					message: "Insufficient scope",
+					verify(attributes) {
+						const scopes = attributes.get("scopes");
+						return Array.isArray(scopes) && scopes.includes(`${action}:${resource.resourceType}`);
+					},
+				},
+			];
+		};
+
+		await expect(assertRuleIndependentOfContext(collect, scopeContext, attrs)).rejects.toThrow(
+			/read its collector's context/,
+		);
+	});
+
+	it("accepts the builtin shape: a comparand copied out at collect time", async () => {
+		// `action` and `resourceType` are strings, read once and copied. Nothing
+		// live survives into `verify`, which is why this is legal and the two
+		// cases above are not.
+		const collect = async (ctx: CollectorContext): Promise<Rule[]> => {
+			const required = `${ctx.action}:${ctx.resource.resourceType}`;
+			return [
+				{
+					ruleType: "scope",
+					code: "invalid_scope",
+					message: "Insufficient scope",
+					verify(attributes) {
+						const scopes = attributes.get("scopes");
+						return Array.isArray(scopes) && scopes.includes(required);
+					},
+				},
+			];
+		};
+
+		await expect(assertRuleIndependentOfContext(collect, scopeContext, attrs)).resolves.toEqual([
+			true,
+		]);
+	});
+
+	it("hands the collector a stable identity for every object it reads", async () => {
+		// The harness must not change the semantics of the thing it is checking.
+		// Wrapping each nested object on every access would make
+		// `ctx.resource === ctx.resource` false, so a collector that compares or
+		// caches a sub-object — an honest thing to do — would fail this suite for
+		// a reason that exists only inside the proxy. A gate that reports its own
+		// artifacts as violations is one people learn to disbelieve.
+		let sameObjectTwice = false;
+		let distinctFieldsStayDistinct = false;
+		let survivesRoundTrip = false;
+
+		const collect = async (ctx: CollectorContext): Promise<Rule[]> => {
+			const first = ctx.resource;
+			const second = ctx.resource;
+			sameObjectTwice = first === second;
+			// Memoization must not collapse two different objects into one proxy.
+			distinctFieldsStayDistinct = (ctx.resource as object) !== (ctx.payload as object);
+			// Identity holds through a nested read, not just a repeated top-level one.
+			survivesRoundTrip = new Set([ctx.resource, ctx.resource, ctx.payload]).size === 2;
+
+			const required = `${ctx.action}:${ctx.resource.resourceType}`;
+			return [
+				{
+					ruleType: "scope",
+					code: "invalid_scope",
+					message: "Insufficient scope",
+					verify(attributes) {
+						const scopes = attributes.get("scopes");
+						return Array.isArray(scopes) && scopes.includes(required);
+					},
+				},
+			];
+		};
+
+		await assertRuleIndependentOfContext(collect, scopeContext, attrs);
+
+		expect(sameObjectTwice).toBe(true);
+		expect(distinctFieldsStayDistinct).toBe(true);
+		expect(survivesRoundTrip).toBe(true);
+	});
+
+	it("rejects a rule that mutates the attributes it is judged against", async () => {
+		const collect = async (): Promise<Rule[]> => [
+			{
+				ruleType: "scope",
+				code: "invalid_scope",
+				message: "Insufficient scope",
+				verify(attributes) {
+					// The cast is the point: `ReadonlyAttributes` makes this a compile
+					// error for a TypeScript author, and nothing at all for a JavaScript
+					// one. The behavioural check has to stand on its own.
+					(attributes as Attributes).set("scopes", ["escalated"]);
+					return true;
+				},
+			},
+		];
+
+		await expect(
+			assertRuleIndependentOfContext(
+				collect,
+				scopeContext,
+				new Map([["scopes", ["read:project"]]]),
+			),
+		).rejects.toThrow(/mutated the attributes/);
+	});
+
+	it("rejects a rule whose answer is not a function of the attributes alone", async () => {
+		let calls = 0;
+		const collect = async (): Promise<Rule[]> => [
+			{
+				ruleType: "scope",
+				code: "invalid_scope",
+				message: "Insufficient scope",
+				verify() {
+					calls += 1;
+					return calls === 1;
+				},
+			},
+		];
+
+		await expect(assertRuleIndependentOfContext(collect, scopeContext, attrs)).rejects.toThrow(
+			/not a deterministic function/,
+		);
+	});
+});


### PR DESCRIPTION
## The contract was wrong in two opposite directions

`AGENTS.md`'s Collector / Rule / Attribute Contract said:

> A rule's decision must be derivable from `attrs` alone. Rules must not reference `CollectorContext`, close over request state, or perform side effects.

**Too broad.** "Must not close over request state" illegalizes `packages/builtins/src/rules/collectors/ResourceActionScopeRuleCollector.mts:94`, which computes `` `${context.action}:${context.resource.resourceType}` `` at collect time and hands it to `new HasScope(...)`. That is legitimate: the comparand is fixed once, and `HasScope.verify` remains a deterministic function of `attrs`. The project's flagship rule could not satisfy its own contract as written.

**Too narrow.** The violation paragraph described a rule that returns the captured comparison from `verify(attrs)` *"while ignoring `attrs`"*. The actual in-tree violation at `packages/server/src/__tests__/app.test.mts:50-53` **did** read `attributes.get("scopes")` — and also read `ctx.action` / `ctx.resource.resourceType` at verify time. The documented pattern would not have flagged the one violation in the repo.

**And the prescribed fix was unfollowable.** "A collector writes both values into attributes under well-known keys" requires `ATTR_ACTION` / `ATTR_RESOURCE_TYPE` in `packages/core/src/keys.mts` — which the *Core Vocabulary Scope* section, directly below, forbids: `ATTR_*` is reserved for transport-neutral OAuth/OIDC/RBAC subject facts (scopes, permissions, roles, `sub`, `azp`). `action` and `resourceType` are request-shaped. Adding them would have smuggled a semantic change to the core vocabulary in as a lint fix.

The property that actually matters is the one `packages/core/src/evaluate.mts:63-64` spends when it justifies running every rule group: *"Rules are pure predicates over attributes by contract, so running them all is safe."*

## The new contract text, as landed

> - **Rules** are predicates over attributes (`verify(attrs): boolean`). `verify` must be a **deterministic, side-effect-free function of `attrs`**: equal attributes give equal answers, and it must not mutate its input, perform I/O, or observe anything the engine cannot see. `verify` is handed a `ReadonlyAttributes` (`ReadonlyMap<string, unknown>`), so the "must not mutate" half is a compile error rather than a request.
>
> **What a rule may do.** A rule **may** hold values fixed at collect time — *what it looks for*. `ResourceActionScopeRuleCollector` computes `` `${context.action}:${context.resource.resourceType}` `` while the request is in hand and passes the resulting string to `new HasScope(...)`. The comparand is request-derived and that is fine: it is fixed once, and `HasScope.verify` remains a function of `attrs`.
>
> **What a rule must not do.** A rule **must not** retain `CollectorContext`, or any live reference into it, and read it inside `verify`. The answer would then depend on request state the engine cannot observe, which breaks isolation testing, caching, and the guarantee `evaluate()` relies on.
>
> **The deciding test:** collect the rule, discard the context, then call `verify(attrs)`. The answer must be unchanged.

The `ATTR_ACTION` / `ATTR_RESOURCE_TYPE` prescription is deleted. Promoting both operands into attributes stays a fine thing for a *consuming project* to do under its own keys — `metrics.test.mts` does exactly that — it is just no longer presented as the only correct shape.

## What the conformance helper proves

`tests/integration/src/conformance/rulePurity.mts`, alongside the four existing engine-level suites. `assertRuleIndependentOfContext(collect, context, attrs)` runs the deciding test literally:

1. Collect the rules through a **revocable** view of the `CollectorContext`.
2. Verify each rule once, while the request is still reachable.
3. Revoke the view.
4. Verify each rule again.

A rule that copied a string out at collect time answers identically. A rule that kept the request throws on the access, and the failure names the offending rule by `ruleType` / `code`. Determinism and non-mutation are checked in the same pass, since they are the other two clauses of the same sentence.

The view is revoked **all the way down**, not just at the top level: each object read through the proxy is wrapped in its own revocable proxy. A shallow revoke would only catch a rule that kept `ctx` itself, and the mistake is just as easily made one indirection in (`const resource = ctx.resource` at collect time, `resource.resourceType` in `verify`). Primitives pass through untouched — which is exactly the line the contract draws: **copying a value out at collect time is legal; holding a live reference into the request is not.**

Because it is behavioural, it cannot be dodged by renaming a variable. Its own negative cases are part of the suite, so the helper is proven capable of failing rather than merely green:

- rejects the `app.test.mts` shape (reads `attrs` *and* `ctx` — the shape the old wording could not describe)
- rejects the one-indirection-deeper shape a grep cannot see
- **accepts** the builtin shape (comparand copied out at collect time)
- rejects a rule that mutates `attrs`
- rejects a rule whose answer is not a function of `attrs`

Applied to both builtin rule collectors. **Neither violates the new contract** — `ResourceActionScopeRuleCollector` and `ResourceActionPermissionRuleCollector` both pass, which is the outcome the rewrite was aiming for: the wording now blesses what the builtins actually do.

It lives in `tests/integration` (private) rather than as a `testing` export from core, following the house pattern of the four sibling suites. Trade-off: a third-party rule author cannot import it today. Shipping it would mean a new published entry point and build config; worth doing if someone asks, but not something to decide here.

## `Rule.verify` takes a `ReadonlyMap` — BREAKING

`packages/core/src/types.mts` — `verify(attrs: ReadonlyAttributes)`, where `ReadonlyAttributes = ReadonlyMap<string, unknown>` (newly exported). This replaces the `Object.freeze` idea withdrawn in the issue's correcting comment: freeze does not affect a `Map`'s contents, whose entries live in an internal slot, so `map.set(...)` still succeeds on a frozen one — a guard that guards nothing.

The `Attributes` alias is **unchanged** and still a mutable `Map`: `AttributeCollector.collect` builds one by writing into it and `AttributePipeline` merges them the same way. Only the rule's view is narrowed.

One honest limitation, found while implementing: TypeScript's **method-parameter bivariance** means an implementation that keeps the old `verify(attrs: Attributes)` annotation still compiles against the narrowed interface. It just keeps write access it is not supposed to use. So the builtins were all moved to `ReadonlyAttributes` explicitly rather than left to the compiler, and the runtime non-mutation check in the conformance suite carries the weight for a rule authored in JavaScript, where the type is gone entirely. A rule written as an object literal typed `Rule` needs no change — it picks the parameter type up contextually.

`packages/core/src/__tests__/ruleContract.test.mts` pins the narrowing at the type level (`"set" extends keyof VerifyParam ? false : true`), so a future widening back to `Map` fails `pnpm run typecheck` rather than passing silently.

## The grep gate: shipped, scoped honestly

Added to `ci.yml`'s `build-and-test` job, after `pnpm run lint`, in the style of the two existing AGENTS.md gates. It brace-matches every `verify(…) {…}` body and fails on a `ctx.` / `context.` reference, with an `::error file=…,line=…::` annotation and a pointer back to AGENTS.md.

**Verified both ways**, by extracting the step from the YAML and running it:

- On `develop`'s tree it produces exactly one hit — `app.test.mts:53`, the known violation — and **zero false positives** across the repo's tracked `.mts` / `.ts` files. That includes the non-`Rule` `verify` methods (`TokenExpiryAdapter.verify`, `TokenValidationAdapter.verify`, the `builtinKeyResolversModule` test helper); none reference a context.
- Re-introducing the violation after the fix makes it fail again, so it is not vacuous.

**It false-positived once, and the fix is worth reading.** The first CI run failed on `rule-purity-conformance.test.mts` — the conformance suite's own negative fixtures, the deliberately-violating rules the suite asserts are *rejected*. (My local pre-push run missed it because the gate lists files with `git ls-files` and those files were still untracked at the time.) A text search cannot tell a violation from a test proving violations are caught, which is the gate's characteristic weakness arriving on day one.

That one file is now exempt **by exact path**, not by a marker comment — a marker would be exactly the opt-out people learn to sprinkle, whereas a single hard-coded path cannot spread, and renaming the file makes it scanned again (a loud failure, not a silent hole). A rule that actually decided anything would not live in the integration suite's negative cases to begin with. The `ci.yml` comment states all of this rather than leaving a bare exclusion for someone to wonder about.

The comment in `ci.yml` says plainly that it is a **textual backstop for the obvious shape** — a string search that brace-matches, not a parse; blind to a context reached through a differently-named binding, a helper call, or a closure defined elsewhere — and that the conformance suite is the real check. It earns its place because this exact violation has now been written twice by copy-paste (#150, #152), and a named CI failure is what stops the third copy at review time. It is a second line, not the line.

## Also in this PR

- `app.test.mts` fixed: the required scope is computed in `collect` and compared against `attributes` in `verify`, exactly as `ResourceActionScopeRuleCollector` does. Commit `1937293` fixed the copy in `metrics.test.mts` and identified this file as the one it was copied *from*, but left it standing — so it is now written to be copied again, with the reasoning inline.
- `metrics.test.mts`'s long comment updated: it described the violation as "bakes the decision at collect time" (the withdrawn framing) and stated that nothing enforces the contract "which is #152". Both are now false.
- `docs/extending.md` / `.ja.md`: #153 already tightened the prose at lines 176-180 to describe the *property* rather than restate the sentence, and that text is **correct as-is** — it needed no rewrite. Two smaller changes were still required: the `Rule` interface snippet and worked example now show `ReadonlyAttributes`, and the paragraph asserting "**it is a convention, not a check**" is no longer true, so it now points at the conformance suite.
- `packages/core/README.md` / `.ja.md` type tables: `Rule` row updated, `ReadonlyAttributes` row added.
- `CHANGELOG.md` `[Unreleased]`: a **BREAKING** entry for the signature change with the migration diff, and a second **BREAKING (meaning, not signature)** entry — a rule that was legal under the old *text* may be illegal now, and vice versa, which matters to anyone who wrote a custom rule.

## Test results

Run explicitly, no `--coverage` on the final run:

| Command | Result |
|---|---|
| `pnpm lint` | 142 files, clean |
| `pnpm -r run build` | 6/6 workspaces |
| `pnpm run typecheck` | 6/6 workspaces (the only thing type-checking test files since #149) |
| `pnpm run test` | **1239 passed**, 0 failed |

Per workspace: core 73, builtins 474, server 508, tests/integration 71, templates/standalone 35, create-app 78. The new CI gate was run out of the YAML and passes clean.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
