### PR TITLE
docs: state the two-boundary config validation doctrine in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,36 @@ export class SubscriberDidCollector implements AttributeCollector {
 
 The rule then reads `attrs.get(ATTR_SUBSCRIBER_DID)` without ever touching `CollectorContext`.
 
+## Two-Boundary Config Validation
+
+`packages/server` takes its configuration two ways, and both have to reach the same verdict.
+
+- **`AppConfigSchema`** ([`packages/server/src/config/application.schema.mts`](packages/server/src/config/application.schema.mts)) parses config files. It runs at boot and reports every issue at once, at the path the operator wrote.
+- **The runtime guards** — `createApp`, the `KeyResolverFactory` implementations, `createVerifyRouter` — serve the hand-built config objects those entry points also accept. A library consumer reaches them with the schema never having run, and the TypeScript shapes are not a defence: a JavaScript caller ignores them, and a config assembled from `process.env` arrives as strings.
+
+**The rule:** a wire invariant is enforced at **both** boundaries, through **one shared check function**. Not two implementations agreeing on a constant — one function, imported by each side. The schema turns its verdict into a zod issue at the operator's path; the guard throws it, naming the caller and the path. What is accepted, what a missing key defaults to, and how a refusal is worded all come from that one function.
+
+**Why both.** A hand-built config bypasses the schema entirely, so without the guard `createApp` would accept what a config file cannot, and the invariant would be advice. And a check duplicated rather than shared is worse than it looks: the two drift, and the drift is silent — the same configuration written two ways, answered two ways, with nothing failing to say so.
+
+**"Must not get a different answer" is the deciding formulation, not decoration.** It was the explicit tiebreaker for the `previousSecrets` `null` contract (#147): `null` is refused rather than read as "no rotation configured" — diverging from auth.provider's own precedent — because `AppConfigSchema` types the field `z.array(...).optional()` and rejects `null` before `checkHs256Rotation` is ever reached. Accepting it in the guard would have handed a hand-built config a different answer from a parsed one. The full reasoning is written on `checkHs256Rotation`.
+
+**What breaking it cost.** The numeric knobs were the family that shared only *constants*: the schema read each through its own `z.coerce.number().int()…` chain, the runtime through an ad-hoc `??` or `Number(…)`. #157 found seven values the two genuinely disagreed on. `oauth.jwt.jwksCooldownMs = false` meant `0` through the schema — refetch on every miss, the fetch storm the knob exists to prevent — and a boot failure through the resolver. `verify.maxBatchSize = null` was refused at boot by the schema, while `createVerifyRouter`'s `?? DEFAULT` silently applied a 50-entry cap. Nobody wrote either behaviour; both fell out of one knob having two readers. The full table is in the #157 entry of [`CHANGELOG.md`](CHANGELOG.md). This rule is written down because breaking it produced real divergence, not because it is tidy.
+
+**The worked examples**, all under `packages/server/src`:
+
+- `checkJwksUri` ([`jwt/jwks.mts`](packages/server/src/jwt/jwks.mts)) — the JWKS transport policy (#109). Returns a result; the schema renders it as a zod issue, and `parseJwksUri` throws the same message for the `KeyResolverFactory`.
+- `checkHs256Rotation` ([`jwt/hs256Rotation.mts`](packages/server/src/jwt/hs256Rotation.mts)) — the HS256 rotation shape, and the entropy floor over every secret in it (#112, #114). Collects every issue with its path, so both boundaries report a block with two mistakes in one round trip.
+- `resolveBound` ([`config/bounds.mts`](packages/server/src/config/bounds.mts)) — every numeric knob (#157). One spec table carries each knob's default, range and unit; a boundary supplies only the config path it saw the key at.
+
+All three are dependency-free on purpose, and that is part of the rule rather than a coincidence: `AppConfigSchema` imports them, so anything they reached back for would arrive in every config-only consumer of the schema. `jwt/tokenAuthenticator.mts` brings jose with it and `routes/verify.mts` brings express — a check living beside either could not be shared with the schema at all. So write the check function first, somewhere the config layer can import, and only then call it from both sides.
+
+**The deciding test:** write the same configuration twice — once as a config file through `AppConfigSchema`, once as an object handed straight to `createApp` or `createVerifyRouter`. Both must accept it, or both must refuse it and name the same key in the same words. If you cannot point at the single function that decides, the invariant is not enforced twice; it is implemented twice.
+
+**Two known departures**, both deliberate, and to be matched rather than copied:
+
+- `assertVerifyRouterJwtConfig` (`jwt/tokenAuthenticator.mts`) and the schema's `superRefine` enforce the same two invariants — RFC 9068 `iss`/`aud`/`typ` presence, and consent to decode-only mode — as separate implementations, because #134 split the spellings. On the wire the consent is the single key `oauth.jwt.mode = "insecure-decode"`; internally it stays the two-key `validate: false` + `allowInsecureDecode: true` interlock. There is no one shape for a shared function to read, so the two are kept in step by hand and their messages worded alike.
+- A default that only one boundary applies is a divergence of the same kind, which is why `resolveBound` carries each knob's `fallback` and `createApp` spells out `mode ?? "verify"`. The exception is `oauth.jwt.tokenType`: the schema defaults it to `at+jwt` while `assertVerifyRouterJwtConfig` requires it outright, because `VerifyingJwtConfig` declares it required and the API boundary's static contract therefore already asks the caller for it. Adding a default means mirroring it at the other boundary, or writing down why not.
+
 ## Release Process
 
 Releases are triggered by pushing a `v*` tag to GitHub. There is no manual publish step; `.github/workflows/release.yml` handles the rest.

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -130,10 +130,10 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 	// 6. Map the wire `oauth.jwt.mode` onto the router's internal discriminated
 	// union (#134). AppConfigSchema already enforces the wire invariants (the
 	// mode enum, iss/aud/typ presence, rejection of the removed keys) for
-	// schema-validated configs; everything is re-checked here because createApp
-	// also accepts hand-built config objects that never went through the schema
-	// (#106) — with this boundary's field paths, so the operator is pointed at
-	// the oauth.jwt.* key they actually wrote.
+	// schema-validated configs; everything is re-checked here (#106) — see
+	// AGENTS.md, "Two-Boundary Config Validation" — with this boundary's field
+	// paths, so the operator is pointed at the oauth.jwt.* key they actually
+	// wrote.
 	//
 	// Shape first: a hand-built config can carry anything at these paths, and
 	// the key checks below reach into the block with `in` and object spread,

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -28,11 +28,9 @@ export const JWT_MODE_MIGRATION_MESSAGE =
  * `resolveBound` decides everything about the knob: the default when the key is
  * absent, the coercion of the string a HOCON env substitution delivers, the
  * range, and the wording of the refusal. This wrapper only carries the verdict
- * into zod's issue list at the path the operator wrote — the same division of
- * labour `jwksUri` has with `checkJwksUri` and `previousSecrets` with
- * `checkHs256Rotation`. What it replaced was a `z.coerce.number().int()…` chain
- * per knob that shared only the *constants* with `resolveBound`, which is how
- * `jwksCooldownMs = false` came to mean 0 here and a boot failure there.
+ * into zod's issue list at the path the operator wrote — see AGENTS.md,
+ * "Two-Boundary Config Validation", which this boundary shares with
+ * `checkJwksUri` for `jwksUri` and `checkHs256Rotation` for `previousSecrets`.
  *
  * `z.unknown().optional()` and not `z.coerce.number()`: the check must see the
  * value exactly as the operator wrote it. Anything narrower would have zod

--- a/packages/server/src/config/bounds.mts
+++ b/packages/server/src/config/bounds.mts
@@ -13,15 +13,11 @@
  * both need exactly that, so it is written once here rather than restated per
  * knob, and the rejection message has a single shape operators learn once.
  *
- * Both boundaries read a knob through this one function (#157). `AppConfigSchema`
+ * Both boundaries read a knob through this one function (#157): `AppConfigSchema`
  * serves config files and the runtime resolvers serve the hand-built configs
- * `createApp` also accepts; until #157 the schema re-implemented each knob as a
- * `z.coerce.number().int()…` chain and shared only the constants, which is how
- * `jwksCooldownMs = false` came to mean 0 through the schema and a boot failure
- * through the resolver. That is the divergence `checkJwksUri` and
- * `checkHs256Rotation` exist to prevent, and the reasoning written on
- * `checkHs256Rotation` (the `previousSecrets` `null` contract, #147) is the same
- * one: a hand-built config must not get a different answer from a parsed one.
+ * `createApp` also accepts. See AGENTS.md, "Two-Boundary Config Validation" —
+ * the numeric knobs are the worked cautionary example there, since they were the
+ * family that shared only the constants until #157.
  *
  * {@link NUMERIC_BOUNDS} is the whole table, in one place, for the same reason
  * the reader is: a spec kept beside the module that consumes it could not be

--- a/packages/server/src/jwt/builtinKeyResolversModule.mts
+++ b/packages/server/src/jwt/builtinKeyResolversModule.mts
@@ -28,10 +28,9 @@ interface JwtFactoryInput extends JwksFetchConfig, Hs256RotationConfig {
  * file path (in that priority). Throws if no key source is configured.
  *
  * A JWKS URI must be https, or http on a loopback host — see the trust
- * assumption and the carve-out in `jwt/jwks.mts` (#109). The check is repeated
- * here, after `AppConfigSchema` has already made it at config-parse time,
- * because `createApp` also accepts hand-built configs that never met the
- * schema.
+ * assumption and the carve-out in `jwt/jwks.mts` (#109). Checked here as well as
+ * in `AppConfigSchema`, through the one shared function — see AGENTS.md,
+ * "Two-Boundary Config Validation".
  */
 async function resolveAsymmetric(algorithm: string, config: JwtFactoryInput): Promise<KeyResolver> {
 	if (config.jwksUri) {
@@ -162,9 +161,9 @@ export const HS256KeyResolverFactory: KeyResolverFactory = async (config: JwtFac
 	if (!config.secret) {
 		throw new Error("secret is required for HS256");
 	}
-	// Re-checked here, after `AppConfigSchema` has already checked it at
-	// config-parse time, because `createApp` also accepts hand-built configs that
-	// never met the schema — the same division of labor as the JWKS URI above.
+	// Checked here as well as in `AppConfigSchema`, through the one shared
+	// function, as for the JWKS URI above — see AGENTS.md, "Two-Boundary Config
+	// Validation".
 	const { kid, previousSecrets } = parseHs256Rotation(config);
 	const current = toSecretKey(config.secret);
 	if (kid === undefined && previousSecrets.length === 0) {

--- a/packages/server/src/jwt/hs256Rotation.mts
+++ b/packages/server/src/jwt/hs256Rotation.mts
@@ -31,9 +31,8 @@
  * imports it so a malformed rotation block fails at config-parse time (at boot,
  * where an operator sees it) rather than at the first request, and config-only
  * consumers of the schema must not pull jose or express in behind it. The
- * `KeyResolverFactory` re-checks at construction for hand-built configs that
- * never went through the schema — the same division of labor as
- * `checkJwksUri` / `parseJwksUri`.
+ * `KeyResolverFactory` re-checks at construction, through this same function —
+ * see AGENTS.md, "Two-Boundary Config Validation".
  */
 
 import { MAX_PREVIOUS_SECRETS, MIN_SECRET_ENTROPY_BYTES } from "../config/defaults.mjs";

--- a/packages/server/src/jwt/jwks.mts
+++ b/packages/server/src/jwt/jwks.mts
@@ -17,9 +17,8 @@
  * Deliberately dependency-free: `AppConfigSchema` imports it so a rejected URI
  * fails at config-parse time (at boot, where an operator sees it) instead of at
  * the first request, and config-only consumers of the schema must not pull jose
- * or express in behind it. The `KeyResolverFactory` re-checks at construction
- * for hand-built configs that never went through the schema — the same division
- * of labor as `assertVerifyRouterJwtConfig`.
+ * or express in behind it. The `KeyResolverFactory` re-checks at construction,
+ * through this same function — see AGENTS.md, "Two-Boundary Config Validation".
  */
 
 import { NUMERIC_BOUNDS, resolveBound } from "../config/bounds.mjs";

--- a/packages/server/src/jwt/tokenAuthenticator.mts
+++ b/packages/server/src/jwt/tokenAuthenticator.mts
@@ -206,15 +206,15 @@ function isPresent(value: string | string[] | undefined): boolean {
  *    acknowledgment (#106): one mistyped flag must never be enough to disable
  *    all signature verification.
  *
- * Division of labor with `AppConfigSchema`: the schema enforces the same
- * invariants for schema-validated configs at config-parse time — the RFC 9068
- * presence checks via `superRefine`, the decode-only consent via the `mode`
- * enum whose `"insecure-decode"` value is itself the acknowledgment (#134) —
- * reporting every issue at once with zod paths. This guard is the runtime
- * enforcement for hand-built configs that never went through the schema — a
- * JavaScript caller can reach `createApp` or `createVerifyRouter` with fields
- * missing even though the TypeScript shapes require them. Both stay: the
- * schema serves config files, the guard serves the API boundary.
+ * Both boundaries enforce these — see AGENTS.md, "Two-Boundary Config
+ * Validation" — and this is the pair named there as a departure from it, the
+ * one place the two boundaries cannot share a check function. `AppConfigSchema`
+ * reads the wire spelling: the presence checks via `superRefine`, the
+ * decode-only consent via the `mode` enum whose `"insecure-decode"` value is
+ * itself the acknowledgment (#134), every issue reported at once with zod
+ * paths. This guard reads the internal two-key interlock, because #134 split
+ * the two spellings. There is no one shape to check from both sides, so the two
+ * are kept in step by hand and their messages worded alike.
  */
 export function assertVerifyRouterJwtConfig<T extends UncheckedJwtConfig>(
 	jwt: T,


### PR DESCRIPTION
The most frequently applied design rule of the recent 23-commit campaign existed only as folklore: restated in seven wordings across `packages/server`, and absent from `AGENTS.md`. This promotes it to a section, and reduces the restatements to pointers.

## The section as landed

> ## Two-Boundary Config Validation
>
> `packages/server` takes its configuration two ways, and both have to reach the same verdict.
>
> - **`AppConfigSchema`** ([`packages/server/src/config/application.schema.mts`](packages/server/src/config/application.schema.mts)) parses config files. It runs at boot and reports every issue at once, at the path the operator wrote.
> - **The runtime guards** — `createApp`, the `KeyResolverFactory` implementations, `createVerifyRouter` — serve the hand-built config objects those entry points also accept. A library consumer reaches them with the schema never having run, and the TypeScript shapes are not a defence: a JavaScript caller ignores them, and a config assembled from `process.env` arrives as strings.
>
> **The rule:** a wire invariant is enforced at **both** boundaries, through **one shared check function**. Not two implementations agreeing on a constant — one function, imported by each side. The schema turns its verdict into a zod issue at the operator's path; the guard throws it, naming the caller and the path. What is accepted, what a missing key defaults to, and how a refusal is worded all come from that one function.
>
> **Why both.** A hand-built config bypasses the schema entirely, so without the guard `createApp` would accept what a config file cannot, and the invariant would be advice. And a check duplicated rather than shared is worse than it looks: the two drift, and the drift is silent — the same configuration written two ways, answered two ways, with nothing failing to say so.
>
> **"Must not get a different answer" is the deciding formulation, not decoration.** It was the explicit tiebreaker for the `previousSecrets` `null` contract (#147): `null` is refused rather than read as "no rotation configured" — diverging from auth.provider's own precedent — because `AppConfigSchema` types the field `z.array(...).optional()` and rejects `null` before `checkHs256Rotation` is ever reached. Accepting it in the guard would have handed a hand-built config a different answer from a parsed one. The full reasoning is written on `checkHs256Rotation`.
>
> **What breaking it cost.** The numeric knobs were the family that shared only *constants*: the schema read each through its own `z.coerce.number().int()…` chain, the runtime through an ad-hoc `??` or `Number(…)`. #157 found seven values the two genuinely disagreed on. `oauth.jwt.jwksCooldownMs = false` meant `0` through the schema — refetch on every miss, the fetch storm the knob exists to prevent — and a boot failure through the resolver. `verify.maxBatchSize = null` was refused at boot by the schema, while `createVerifyRouter`'s `?? DEFAULT` silently applied a 50-entry cap. Nobody wrote either behaviour; both fell out of one knob having two readers. The full table is in the #157 entry of [`CHANGELOG.md`](CHANGELOG.md). This rule is written down because breaking it produced real divergence, not because it is tidy.
>
> **The worked examples**, all under `packages/server/src`:
>
> - `checkJwksUri` ([`jwt/jwks.mts`](packages/server/src/jwt/jwks.mts)) — the JWKS transport policy (#109). Returns a result; the schema renders it as a zod issue, and `parseJwksUri` throws the same message for the `KeyResolverFactory`.
> - `checkHs256Rotation` ([`jwt/hs256Rotation.mts`](packages/server/src/jwt/hs256Rotation.mts)) — the HS256 rotation shape, and the entropy floor over every secret in it (#112, #114). Collects every issue with its path, so both boundaries report a block with two mistakes in one round trip.
> - `resolveBound` ([`config/bounds.mts`](packages/server/src/config/bounds.mts)) — every numeric knob (#157). One spec table carries each knob's default, range and unit; a boundary supplies only the config path it saw the key at.
>
> All three are dependency-free on purpose, and that is part of the rule rather than a coincidence: `AppConfigSchema` imports them, so anything they reached back for would arrive in every config-only consumer of the schema. `jwt/tokenAuthenticator.mts` brings jose with it and `routes/verify.mts` brings express — a check living beside either could not be shared with the schema at all. So write the check function first, somewhere the config layer can import, and only then call it from both sides.
>
> **The deciding test:** write the same configuration twice — once as a config file through `AppConfigSchema`, once as an object handed straight to `createApp` or `createVerifyRouter`. Both must accept it, or both must refuse it and name the same key in the same words. If you cannot point at the single function that decides, the invariant is not enforced twice; it is implemented twice.
>
> **Two known departures**, both deliberate, and to be matched rather than copied:
>
> - `assertVerifyRouterJwtConfig` (`jwt/tokenAuthenticator.mts`) and the schema's `superRefine` enforce the same two invariants — RFC 9068 `iss`/`aud`/`typ` presence, and consent to decode-only mode — as separate implementations, because #134 split the spellings. On the wire the consent is the single key `oauth.jwt.mode = "insecure-decode"`; internally it stays the two-key `validate: false` + `allowInsecureDecode: true` interlock. There is no one shape for a shared function to read, so the two are kept in step by hand and their messages worded alike.
> - A default that only one boundary applies is a divergence of the same kind, which is why `resolveBound` carries each knob's `fallback` and `createApp` spells out `mode ?? "verify"`. The exception is `oauth.jwt.tokenType`: the schema defaults it to `at+jwt` while `assertVerifyRouterJwtConfig` requires it outright, because `VerifyingJwtConfig` declares it required and the API boundary's static contract therefore already asks the caller for it. Adding a default means mirroring it at the other boundary, or writing down why not.

It is placed after the Attribute Collector material and before Release Process, so the design-rule sections stay together ahead of the process ones. It follows the Collector / Rule / Attribute Contract section (#159) as its model, including the "deciding test" formulation.

## Restatements reduced to pointers

All seven sites from the issue were verified first; line numbers had shifted in several, but every restatement was still there.

| site | what changed |
| --- | --- |
| `config/bounds.mts` | The whole nine-line re-derivation (the `jwksCooldownMs = false` divergence, the `previousSecrets` #147 tiebreaker, "a hand-built config must not get a different answer from a parsed one") reduced to naming the two boundaries and a pointer. The cautionary example now lives once, in AGENTS.md. |
| `jwt/builtinKeyResolversModule.mts` (×2) | Both were pure restatements with no local content; both are now pointers. |

## Restatements reduced, local content kept

| site | kept |
| --- | --- |
| `jwt/jwks.mts` | The dependency-free rationale — why the schema importing this module means it must not pull jose or express in behind it, and why parse-time is where an operator sees the failure. Only the "same division of labor as …" clause went. |
| `jwt/hs256Rotation.mts` | Same, plus everything genuinely its own: the rotation contract, the auth.provider port, the entropy-floor placement, and the full `previousSecrets` `null` reasoning — that one is the *origin* AGENTS.md now cites, not a restatement, so it is untouched. |
| `app.mts` | Which wire invariants the schema enforces, and the field-path reasoning ("so the operator is pointed at the `oauth.jwt.*` key they actually wrote"). |
| `jwt/tokenAuthenticator.mts` | The mapping of which schema mechanism enforces which invariant. Rewritten to name this as the departure rather than to re-derive the rule. |

Untouched on purpose:

- **`config/secretEntropy.mts`** — its rule is genuinely a different one: agreeing with auth.provider on the *number* is not enough, the *reading* must match too, down to the treatment of malformed base64 padding. That is a third-boundary (cross-service) constraint, not this doctrine.
- **`routes/verify.mts`** — its five lines explain why one specific line is `resolveBound(...)` and not `?? 50`, with a `0`-specific consequence AGENTS.md does not carry. A line-local justification, not a rule statement.

## Judgment calls

- **One site edited beyond the issue's seven.** `config/application.schema.mts`'s `boundedNumber` doc carried a third copy of the `jwksCooldownMs = false` example plus a "same division of labour" clause. Leaving it after moving the example into AGENTS.md would have reproduced the folklore problem the issue is about, so it is now a pointer; the local `z.unknown().optional()` rationale is kept in full. The edit is at the top of the file, clear of the stale-key literals `chore/158-review-minors` is fixing.
- **No CHANGELOG entry.** No behaviour changes and nothing consumer-visible. This matches the repo's own precedent: `919d1bd docs: document release process in AGENTS.md` added no entry, and the only docs commit that did touch the CHANGELOG (`5c35c2a`) was correcting the text of an existing entry.
- **The two departures are documented rather than flattened.** See the finding below — the doctrine as stated in the issue ("sharing ONE check function") does not hold universally, and a section that claimed it did would be wrong the first time a contributor met `assertVerifyRouterJwtConfig`. The rule is therefore stated as a requirement (both boundaries, same answer) whose guaranteeing mechanism is the shared function, with the two places that meet the requirement another way named explicitly.

## Finding: `oauth.jwt.tokenType` is a live asymmetry

Turned up while verifying the doctrine holds. It is documented in the section, not changed here.

`AppConfigSchema` declares `tokenType: z.string().default("at+jwt")`, so a config file omitting the key boots. `assertVerifyRouterJwtConfig` requires it outright, so a hand-built config omitting it is refused — `createApp: oauth.jwt.tokenType is required when oauth.jwt.mode is "verify" (RFC 9068 §4)`. This is deliberate and tested (`app.test.mts`, "throws when a hand-built config omits tokenType"), and it is fail-closed rather than a silent value difference — but by the deciding test the two boundaries do give different answers to the same absent key. The defensible reading is that `VerifyingJwtConfig` declares `tokenType: string` required, so the API boundary's static contract already asks for it and the guard is only catching the JS caller who ignored it. That is the reasoning the section records. Worth a separate look if the asymmetry is not in fact intended.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
