### PR TITLE
fix(core,server)!: one name per thing, one answer per value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -588,6 +588,62 @@ and version sections follow the release labeling policy in
 
 ### Changed
 
+- **BREAKING**: `VerifierPayload.tokenType` is renamed to `authScheme`
+  ([#158](https://github.com/o3co/auth.policy-verifier/issues/158)).
+
+  One name meant two unrelated things, and both of them appear in
+  `jwt/tokenAuthenticator.mts`. In config, `tokenType` is the `typ` header the
+  deployment accepts — `"at+jwt"`, RFC 9068 §2.1's access-token type, pinned so
+  an `id_token` signed with the same key cannot pass. On the payload it was the
+  `Authorization` scheme the token arrived under — `"Bearer"`, RFC 6750. Both
+  readings have a standard behind them, which is how the collision survived; a
+  reader who knows only the config key and then meets `payload.tokenType` in a
+  collector has no way to notice they are looking at something else.
+
+  The payload field is the one that gave the name up, for three reasons: it is
+  not a token type at all but a fact about a request header; the config key is
+  what every deployment's HOCON, the `OAUTH_JWT_TOKEN_TYPE` variable and both
+  READMEs already say, so renaming *that* would break every config file to fix a
+  name that is accurate; and the payload field is written on exactly one line
+  and read by nothing in this repo.
+
+  ```diff
+  -const scheme = payload.tokenType;
+  +const scheme = payload.authScheme;
+  ```
+
+  **This one does not fail to compile, and what is left behind is not empty.**
+  `VerifierPayload` carries an open index signature so custom claims can ride
+  along, so `payload.tokenType` is still a legal read — `unknown`, and the type
+  checker will not point at a single call site. Grep for it rather than trusting
+  `tsc`.
+
+  What that read now returns has changed in kind, not just in value. The
+  verifier built the payload as `{ ...decoded, token, tokenType: scheme }` —
+  the claims spread **first**, then its own value written over the top — so a
+  token carrying a `tokenType` claim had that claim silently overwritten with
+  `"Bearer"` and could not be observed at all. The verifier no longer writes
+  that slot. `payload.tokenType` is therefore whatever the token's claims
+  contained, and `undefined` when the token carries no such claim.
+
+  So this is a **new exposure**, not a claim that was always visible under
+  another name: a field that used to hold the verifier's own near-constant
+  string now holds token-supplied data, in the same shape as the trust boundary
+  #123 drew around `requestContext`. The trust level is not identical and should
+  not be overstated — in `mode = "verify"` these claims arrived under a verified
+  signature from a pinned issuer, so this is issuer-attested data, not the
+  caller-typed body that `UntrustedRequestContext` brands. In
+  `mode = "insecure-decode"` no signature was checked at all. Either way it is
+  no longer *the verifier's* value, and nothing validates a custom claim of that
+  name.
+
+  **What to do:** a collector that read `payload.tokenType` for the
+  authorization scheme must move to `payload.authScheme`; it must not be left in
+  place on the assumption that the field is now absent, because a token can put
+  something there. If a deployment's issuer mints a `tokenType` claim, that claim
+  becomes visible to collectors for the first time — which is a change worth
+  knowing about even for a consumer that never read the field.
+
 - **BREAKING (types only)**: `Rule.verify` now takes a `ReadonlyAttributes`
   (`ReadonlyMap<string, unknown>`) instead of `Attributes`
   ([#152](https://github.com/o3co/auth.policy-verifier/issues/152)).
@@ -1015,6 +1071,25 @@ and version sections follow the release labeling policy in
     signal honest for everyone else.
 
 ### Fixed
+
+- A decision response carried `subject: ""` for a token whose `sub` claim is
+  present but empty, while the field's own documentation said it is absent when
+  the token carries none — and while the audit line for the same decision had
+  already dropped it
+  ([#158](https://github.com/o3co/auth.policy-verifier/issues/158)).
+
+  One value, two dispositions: a consumer joining a response to its `decision`
+  log line found the subject in one and not the other. The response now omits
+  the key, which is what `DecisionResponse.subject` (optional since it was
+  written) already promised, and what an empty subject deserves — `subject: ""`
+  names a subject that does not exist, and names the *same* non-existent one for
+  every token without a `sub`. The route derives the subject once now and hands
+  it to both the log line and the response, so the two cannot drift apart again.
+
+  **Operator- and consumer-visible**: a client that read `subject` as a `string`
+  for such a token now sees `undefined`. Client-credentials tokens with no `sub`
+  at all were already answered this way, so a consumer handling that case
+  correctly needs no change.
 
 - `@o3co/create-auth-policy-verifier` scaffolded an **empty directory** whenever
   it was run the documented way. Its template-copy filter excluded any path

--- a/create-app/vitest.config.mts
+++ b/create-app/vitest.config.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -111,7 +111,7 @@ interface ModuleContext {
 | `RuleGroupOutcome` | `{ ruleType: string; passed: true; evaluated: RuleOutcome[]; satisfiedBy: RuleOutcome } \| { ruleType: string; passed: false; evaluated: RuleOutcome[] }` — `evaluated` は実際に走ったルールを評価順に列挙し、`satisfiedBy` は通過グループを満たしたルールを指す |
 | `RuleOutcome` | `{ code: string; message: string; passed: boolean }` |
 | `Role` | `{ name: string; permissions: string[] }` |
-| `VerifierPayload` | デコード済み JWT クレーム: `sub`、`azp`、`scope`、`iss`、`aud`、`exp`、`iat`、`token`、`tokenType`、および任意の追加クレーム |
+| `VerifierPayload` | デコード済み JWT クレーム: `sub`、`azp`、`scope`、`iss`、`aud`、`exp`、`iat`、`token`、`authScheme`（クレームではなく、トークンが到着した `Authorization` スキーム）、および任意の追加クレーム |
 | `PathResolver` | `(specifier: string) => string` — モジュール相対パスを解決する |
 | `AttributeCollectorFactory` | config から `AttributeCollector` を生成するファクトリー関数 |
 | `RuleCollectorFactory` | config から `RuleCollector` を生成するファクトリー関数 |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -105,7 +105,7 @@ A module registers collector, parser, and key resolver factories into the provid
 | `RuleGroupOutcome` | `{ ruleType: string; passed: true; evaluated: RuleOutcome[]; satisfiedBy: RuleOutcome } \| { ruleType: string; passed: false; evaluated: RuleOutcome[] }` — `evaluated` is every rule that ran, in order; `satisfiedBy` names the rule that satisfied a passing group |
 | `RuleOutcome` | `{ code: string; message: string; passed: boolean }` |
 | `Role` | `{ name: string; permissions: string[] }` |
-| `VerifierPayload` | Decoded JWT claims: `sub`, `azp`, `scope`, `iss`, `aud`, `exp`, `iat`, `token`, `tokenType`, plus arbitrary extra claims |
+| `VerifierPayload` | Decoded JWT claims: `sub`, `azp`, `scope`, `iss`, `aud`, `exp`, `iat`, `token`, `authScheme` (the `Authorization` scheme the token arrived under, not a claim), plus arbitrary extra claims |
 | `PathResolver` | `(specifier: string) => string` — resolves module-relative paths |
 | `AttributeCollectorFactory` | Factory function that produces an `AttributeCollector` from config |
 | `RuleCollectorFactory` | Factory function that produces a `RuleCollector` from config |

--- a/packages/core/src/types.mts
+++ b/packages/core/src/types.mts
@@ -167,6 +167,22 @@ export interface VerifierPayload {
 	exp?: number;
 	iat?: number;
 	token?: string;
-	tokenType?: string;
+	/**
+	 * The `Authorization` scheme the token arrived under, as the caller wrote it
+	 * — `"Bearer"` (RFC 6750), whose casing is not normalized because it is
+	 * reported, not compared.
+	 *
+	 * Not a claim, and not the accepted `typ` header: that one is a config value
+	 * named `tokenType`, and this field carried the same name until #158. Two
+	 * unrelated things called `tokenType` is a mistake a reader makes silently,
+	 * so the one that is not a token type gave the name up.
+	 *
+	 * A consequence worth knowing when migrating: nothing writes `tokenType` on
+	 * the payload any more. It used to be written over the spread claims, which
+	 * silently discarded a token's own `tokenType` claim; such a claim now
+	 * reaches the payload like any other. Whatever is read there is the token's,
+	 * not the verifier's.
+	 */
+	authScheme?: string;
 	[key: string]: unknown;
 }

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -5,6 +5,11 @@ import type { Logger, Module } from "@o3co/auth.policy-verifier.core";
 import { SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
+// `JWT_MODE_REMOVED_KEYS` is deliberately not re-exported from the package
+// index: the removed-key list is how the two boundaries agree with each other,
+// not something a consumer configures against (the migration *message* is the
+// consumer-facing half, and that one is public).
+import { JWT_MODE_REMOVED_KEYS } from "#/config/application.schema.mjs";
 import {
 	AppConfigSchema,
 	builtinKeyResolversModule,
@@ -525,6 +530,27 @@ describe("createApp insecure decode mode (#106, #134)", () => {
 			}),
 		).rejects.toThrow(JWT_MODE_MIGRATION_MESSAGE);
 	});
+
+	// Driven off the same exported list the schema is checked against (#158), so
+	// the two boundaries cannot end up refusing different sets of removed keys:
+	// a key added to the constant is asserted here and in the schema suite alike.
+	it.each([...JWT_MODE_REMOVED_KEYS])(
+		"refuses to boot a hand-built config carrying the removed key %s on its own",
+		async (staleKey) => {
+			const handBuilt = {
+				...ackConfig,
+				oauth: { jwt: { [staleKey]: true } },
+			} as unknown as typeof ackConfig;
+
+			await expect(
+				createApp({
+					pathResolver: (s: string) => s,
+					config: handBuilt,
+					modules: [testModule, builtinKeyResolversModule],
+				}),
+			).rejects.toThrow(JWT_MODE_MIGRATION_MESSAGE);
+		},
+	);
 
 	// A JS consumer can hand createApp anything. The stale-key and mode checks
 	// below reach into the block with `in` and object spread, both of which

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { AppConfigSchema, JWT_MODE_MIGRATION_MESSAGE } from "#/config/application.schema.mjs";
+import {
+	AppConfigSchema,
+	JWT_MODE_MIGRATION_MESSAGE,
+	JWT_MODE_REMOVED_KEYS,
+} from "#/config/application.schema.mjs";
 import { MAX_PREVIOUS_SECRETS, MIN_SECRET_ENTROPY_BYTES } from "#/config/defaults.mjs";
 import { checkHs256Rotation, parseHs256Rotation } from "#/jwt/hs256Rotation.mjs";
 import { type JwksFetchConfig, resolveJwksFetchBounds } from "#/jwt/jwks.mjs";
@@ -792,7 +796,11 @@ describe("AppConfigSchema — oauth.jwt.mode (#134)", () => {
 		expect(result.success).toBe(false);
 	});
 
-	it.each(["validate", "allowInsecureDecode"])(
+	// Driven off the exported list, not a copy of it (#158): the removed keys are
+	// half of the same contract the migration message is, and a fourth key added
+	// to the constant must be covered here without anyone remembering to widen a
+	// literal in a test.
+	it.each([...JWT_MODE_REMOVED_KEYS])(
 		"hard-errors on the removed key %s with the migration message",
 		(staleKey) => {
 			const result = AppConfigSchema.safeParse({

--- a/packages/server/src/__tests__/tokenAuthenticator.test.mts
+++ b/packages/server/src/__tests__/tokenAuthenticator.test.mts
@@ -12,7 +12,7 @@
  * `tokenType`. The drift cases are pinned here so the one guard can never
  * regress to the weak form.
  */
-import { errors, type JWTPayload } from "jose";
+import { errors, type JWTPayload, SignJWT } from "jose";
 import { describe, expect, it } from "vitest";
 import {
 	assertTimeClaims,
@@ -31,6 +31,25 @@ const VALID_VERIFYING = {
 	audience: "https://api.test",
 	tokenType: "at+jwt",
 };
+
+/**
+ * The same config with a key long enough to actually sign with — HS256 wants at
+ * least the hash width, and `VALID_VERIFYING`'s short key exists only to be
+ * passed to the guard, which never uses it.
+ */
+const SIGNING_KEY = new TextEncoder().encode("0".repeat(32));
+const SIGNING_CONFIG = { ...VALID_VERIFYING, key: SIGNING_KEY };
+
+/** A token this deployment accepts: right issuer, audience, `typ` and time claims. */
+async function signToken(claims: Record<string, unknown> = {}): Promise<string> {
+	return new SignJWT({ sub: "user-1", ...claims })
+		.setProtectedHeader({ alg: "HS256", typ: VALID_VERIFYING.tokenType })
+		.setIssuedAt()
+		.setExpirationTime("1h")
+		.setIssuer(VALID_VERIFYING.issuer)
+		.setAudience(VALID_VERIFYING.audience)
+		.sign(SIGNING_KEY);
+}
 
 describe("assertVerifyRouterJwtConfig — verifying configs (RFC 9068 §4 presence invariant)", () => {
 	it("accepts a complete verifying config", () => {
@@ -180,6 +199,43 @@ describe("createTokenAuthenticator — construction and bearer parsing", () => {
 		const authenticator = createTokenAuthenticator(VALID_VERIFYING, silentLogger);
 		const result = await authenticator.authenticate("Bearer ");
 		expect(result).toMatchObject({ ok: false, code: "missing_token" });
+	});
+
+	// #158: the payload field carrying the `Authorization` scheme used to be
+	// called `tokenType`, which is also the config key for the accepted `typ`
+	// header — two unrelated meanings under one name, one of them right beside
+	// the other in this very module. The scheme is now `authScheme`, and this
+	// pins the split so the collision cannot be reintroduced by either side.
+	it("names the authorization scheme `authScheme`, distinct from the accepted `typ`", async () => {
+		const authenticator = createTokenAuthenticator(SIGNING_CONFIG, silentLogger);
+		const result = await authenticator.authenticate(`Bearer ${await signToken()}`);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.payload.authScheme).toBe("Bearer");
+		// The accepted `typ` is config, not a fact about the presented token, so
+		// nothing puts it on the payload under any name.
+		expect(result.payload.tokenType).toBeUndefined();
+	});
+
+	// The other half of the rename, and the part a migrating consumer has to see:
+	// the verifier used to write `tokenType` *after* spreading the claims, so a
+	// token carrying a claim of that name had it silently overwritten by
+	// `"Bearer"`. Nothing writes that slot now, so the claim reaches the payload
+	// like any other custom claim. A consumer still reading `payload.tokenType`
+	// is therefore reading the token, not the verifier — which is the opposite of
+	// what it read before.
+	it("no longer shadows a `tokenType` claim the token itself carries", async () => {
+		const authenticator = createTokenAuthenticator(SIGNING_CONFIG, silentLogger);
+		const token = await signToken({ tokenType: "from-the-token" });
+		const result = await authenticator.authenticate(`Bearer ${token}`);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.payload.tokenType).toBe("from-the-token");
+		// The scheme is unaffected: it has its own slot now, so a claim cannot
+		// displace it and it cannot displace a claim.
+		expect(result.payload.authScheme).toBe("Bearer");
 	});
 
 	// The time-claim bounds are resolved once at construction, so a config that

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -915,6 +915,22 @@ describe("POST /verify — decision contract (#124)", () => {
 		expect(res.body.subject).toBeUndefined();
 	});
 
+	it("omits subject when the sub claim is present but empty (#158)", async () => {
+		// The audit line already treats `sub: ""` as no subject at all; the wire
+		// response is the same value and must take the same disposition, or a
+		// consumer reading `subject` sees an empty subject that the log says the
+		// decision did not have. `subject` is optional on `DecisionResponse`, so
+		// omitting it is what the published contract already promises.
+		const token = await signHS256Token({ sub: "", scope: "read:project" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(200);
+		expect(res.body).not.toHaveProperty("subject");
+	});
+
 	it("rejects an array as context on the single endpoint too", async () => {
 		const token = await signHS256Token({ sub: "user-1", scope: "read:project" });
 		const res = await request(app)

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -16,7 +16,11 @@ import {
 } from "@o3co/auth.policy-verifier.core";
 import { createHealthcheckRouter } from "@o3co/auth.utils/express";
 import express from "express";
-import { type AppConfig, JWT_MODE_MIGRATION_MESSAGE } from "./config/application.schema.mjs";
+import {
+	type AppConfig,
+	JWT_MODE_MIGRATION_MESSAGE,
+	JWT_MODE_REMOVED_KEYS,
+} from "./config/application.schema.mjs";
 import { CALLER_AUTH_REQUIRED } from "./config/defaults.mjs";
 import { createCallerAuthMiddleware, resolveCallerAuth } from "./http/callerAuth.mjs";
 import {
@@ -142,7 +146,7 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 	assertConfigObject(config.oauth, "oauth");
 	assertConfigObject(config.oauth.jwt, "oauth.jwt");
 	const jwtWire = config.oauth.jwt;
-	for (const staleKey of ["validate", "allowInsecureDecode"] as const) {
+	for (const staleKey of JWT_MODE_REMOVED_KEYS) {
 		if (staleKey in jwtWire) {
 			// A pre-#134 config must not be silently reinterpreted: a defaulted
 			// mode would mean verify even where the operator had opted into

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -22,6 +22,22 @@ export const JWT_MODE_MIGRATION_MESSAGE =
 	'oauth.jwt.validate/allowInsecureDecode were replaced by oauth.jwt.mode; set mode = "verify" or the explicit "insecure-decode"';
 
 /**
+ * The `oauth.jwt` keys removed in #134, refused by both boundaries with
+ * {@link JWT_MODE_MIGRATION_MESSAGE}.
+ *
+ * Shared for the same reason the message is (#158): the schema refuses these
+ * for parsed configs and `createApp` refuses them for hand-built ones, and a
+ * key added to one list only would be rejected on one path and silently
+ * accepted on the other — which is exactly the "reinterpreted as a defaulted
+ * verify mode" failure #134 removed them to prevent. Two copies of a list
+ * behind one shared message is a list that will drift.
+ *
+ * Not re-exported from the package index: this is how the two boundaries agree
+ * with each other, whereas the message is what an operator reads.
+ */
+export const JWT_MODE_REMOVED_KEYS = ["validate", "allowInsecureDecode"] as const;
+
+/**
  * One numeric knob, read at this boundary by the function that reads it at the
  * other one (#157).
  *
@@ -265,7 +281,7 @@ export const AppConfigSchema = z.object({
 				// be reinterpreted as the defaulted verify mode, failing with an
 				// unrelated "issuer is required" instead of migration guidance.
 				let hasStaleKey = false;
-				for (const staleKey of ["validate", "allowInsecureDecode"] as const) {
+				for (const staleKey of JWT_MODE_REMOVED_KEYS) {
 					if (staleKey in data) {
 						hasStaleKey = true;
 						ctx.addIssue({

--- a/packages/server/src/config/defaults.mts
+++ b/packages/server/src/config/defaults.mts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Dependency-light defaults shared by the config schema and the routers.
  *

--- a/packages/server/src/jwt/tokenAuthenticator.mts
+++ b/packages/server/src/jwt/tokenAuthenticator.mts
@@ -468,7 +468,10 @@ export function createTokenAuthenticator(
 				};
 			}
 
-			return { ok: true, payload: { ...decoded, token, tokenType: scheme } };
+			// `authScheme`, not `tokenType` (#158): `jwt.tokenType` a few lines up
+			// is the accepted `typ` header, an entirely different thing, and the
+			// two shared a name in the one module that mentions both.
+			return { ok: true, payload: { ...decoded, token, authScheme: scheme } };
 		},
 	};
 }

--- a/packages/server/src/observability/decisionEvent.mts
+++ b/packages/server/src/observability/decisionEvent.mts
@@ -60,8 +60,8 @@ export interface DecisionEventInput {
 }
 
 /**
- * A value fit to appear on the line, or `undefined` when the key should be
- * omitted entirely.
+ * A value fit to be reported, or `undefined` when the key should be omitted
+ * entirely.
  *
  * Empty counts as absent, and neither empty value is hypothetical. A proxy that
  * stamps `x-request-id` unconditionally sends the header with nothing in it
@@ -71,8 +71,13 @@ export interface DecisionEventInput {
  * exists, and `requestId: ""` is a correlation key that every such record
  * shares — so grouping by it collapses unrelated decisions into one apparent
  * trace, which is precisely the question the field exists to answer.
+ *
+ * Exported because the verify route applies it to the same `sub` before putting
+ * it on the wire (#158). The audit line and the decision response describe one
+ * decision; the empty subject had to be absent from both or from neither, and
+ * one function is what makes that structural rather than remembered.
  */
-function present(value: string | undefined): string | undefined {
+export function present(value: string | undefined): string | undefined {
 	return value !== undefined && value !== "" ? value : undefined;
 }
 

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -22,7 +22,7 @@ import {
 	createTokenAuthenticator,
 	type VerifyRouterJwtConfig,
 } from "../jwt/tokenAuthenticator.mjs";
-import { DECISION_EVENT, decisionEvent } from "../observability/decisionEvent.mjs";
+import { DECISION_EVENT, decisionEvent, present } from "../observability/decisionEvent.mjs";
 import type { DecisionMetrics } from "../observability/metrics.mjs";
 
 /** Config for `createVerifyRouter`. The `jwt.key` type is library-specific and is narrowed at call-time. */
@@ -82,7 +82,12 @@ export interface DecisionRequest {
  * form its own query, and the response has somewhere to put what decided.
  */
 export interface DecisionResponse {
-	/** JWT `sub` of the token presented. Absent when the token carries none. */
+	/**
+	 * JWT `sub` of the token presented. Absent when the token carries none — and
+	 * an empty `sub` counts as none, the disposition the audit line takes for the
+	 * same value (#158). `subject: ""` would name a subject that does not exist,
+	 * and every token without one would name the same one.
+	 */
 	subject?: string;
 	resource: string;
 	action: string;
@@ -243,10 +248,15 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 		const decision = evaluate(attrs, rules, config.evaluateOptions);
 		const durationMs = performance.now() - startedAt;
 
+		// Derived once and spent twice — on the audit line below and on the
+		// response returned at the end (#158). An empty `sub` is absent from both,
+		// and the only way the two dispositions of one value cannot drift apart
+		// again is for there to be one value.
+		const subject = typeof payload.sub === "string" ? present(payload.sub) : undefined;
+
 		// #111: one structured line per decision, and the counters beside it. Both
 		// are emitted here rather than at each route so a decision is reported
 		// exactly once whether it came through `/verify` or one entry of a batch.
-		const subject = typeof payload.sub === "string" ? payload.sub : undefined;
 		logger.info(
 			decisionEvent({
 				decision,
@@ -267,7 +277,7 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 			durationSeconds: durationMs / 1000,
 		});
 
-		return toResponse(payload, entry, decision);
+		return toResponse(subject, entry, decision);
 	}
 
 	const router = express.Router();
@@ -343,14 +353,20 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	return router;
 }
 
-/** Projects an engine `Decision` onto the wire contract, naming what it was about. */
+/**
+ * Projects an engine `Decision` onto the wire contract, naming what it was about.
+ *
+ * Takes the already-derived `subject` rather than the payload: the audit line
+ * and this response must agree about whether the decision had one, and reading
+ * `payload.sub` a second time here is what let them disagree (#158).
+ */
 function toResponse(
-	payload: VerifierPayload,
+	subject: string | undefined,
 	entry: DecisionRequest,
 	decision: Decision,
 ): DecisionResponse {
 	const base = {
-		...(typeof payload.sub === "string" ? { subject: payload.sub } : {}),
+		...(subject !== undefined ? { subject } : {}),
 		resource: entry.resource,
 		action: entry.action,
 		reason: decision.reason,


### PR DESCRIPTION
Four unrelated minors from the whole-campaign design-erosion review, swept in one pass. Each one was a place where the same thing had two answers.

## 1. Empty `sub`: picked absence, on the wire as well as the log

**Decision: the wire response now omits `subject` when `sub` is present but empty, matching the audit line and the field's own documentation.**

`1937293` made an empty `sub` absent from the audit line; `routes/verify.mts` still emitted `subject: ""` while `DecisionResponse.subject`'s doc said the field is absent when the token carries none. Three things settled which way to resolve it:

- **The response type does not require it.** `subject?: string` has been optional since it was written, so omission is inside the published contract rather than an extension of it — a consumer that handles a client-credentials token (no `sub` at all) already handles this.
- **`subject: ""` is the worse value on the wire, not the safer one.** It names a subject that does not exist, and it names *the same* non-existent subject for every token without one — the `requestId: ""` argument from `1937293`, which applies harder here because the wire is what consumers parse and key on.
- **They describe one decision.** A consumer joining a `/verify` response to its `decision` log line found the subject in one and not the other. That is the actual defect; matching the log is the fix, not the default.

Rather than restate the emptiness rule at the second site, the route now derives the subject **once** and hands it to both the log line and the response, through the `present` helper the log line already used (now exported from `observability/decisionEvent.mts` for that one caller). `toResponse` takes the derived `subject` instead of re-reading `payload.sub`, which is what let the two disagree. Structural, not remembered.

CHANGELOG entry under **Fixed**, flagged operator- and consumer-visible.

## 2. SPDX headers — the issue's claim was slightly off

The issue said `packages/server/src/config/defaults.mts` is the only source file missing its header. `git ls-files | xargs grep -L SPDX` found **three**:

- `packages/server/src/config/defaults.mts` (the one named)
- `packages/core/vitest.config.mts`
- `create-app/vitest.config.mts`

The two vitest configs are the odd ones out among six — `builtins`, `server`, `templates/standalone` and `tests/integration` all carry the header. All three fixed. After the sweep the only tracked files without an SPDX header are the five `LICENSE` files and the two `Makefile`s, which never had them and are consistent with each other.

## 3. `tokenType`: renamed the payload field, kept the config key

**Decision: `VerifierPayload.tokenType` → `VerifierPayload.authScheme`. The config key `tokenType` is unchanged.**

The collision is genuinely two-sided — RFC 9068 §2.1 calls `at+jwt` the token type, and RFC 6749 §5.1 literally names a field `token_type` whose value is `"Bearer"` — which is how it survived review. Three things decided which side gives up the name:

- **Which name is wrong.** In config, `tokenType` *is* a token type. On the payload it was the `Authorization` scheme, a fact about a request header sitting in an interface documented as "decoded JWT claims", next to `sub`/`iss`/`aud`. That one is the inaccurate name.
- **What each rename costs.** The config key appears in every deployment's HOCON, in `OAUTH_JWT_TOKEN_TYPE`, in both root READMEs and in the standalone template. Renaming it would break every config file in the field to correct a name that is already accurate. The payload field is written on exactly one line (`tokenAuthenticator.mts:483`) and read by nothing in this repo.
- **The value it carried is near-constant.** The verifier rejects every scheme but bearer before a payload exists, so the field was always `"Bearer"` in whatever casing the caller sent.

**Judgment call worth flagging — and corrected after review.** This break is a quiet one in two separate ways, and my first draft of the CHANGELOG got the second one wrong.

- `VerifierPayload` has an open index signature (`[key: string]: unknown`), so `payload.tokenType` still *compiles* in a consumer's collector. `tsc` will not flag a single call site; the migration note says to grep.
- The payload was built as `{ ...decoded, token, tokenType: scheme }` — claims spread **first**, the verifier's own value written over the top. A token carrying a `tokenType` claim therefore had it silently discarded and could not be observed at all. **Nothing writes that slot now**, so such a claim reaches the payload like any other custom claim. A consumer still reading `payload.tokenType` reads *the token*, not the verifier — or `undefined` when the token carries no such claim.

My first draft said the field is "always `undefined`", which would have told a consumer to delete their branch when in fact the slot can now hold token-supplied data. That is a **new exposure**, not a claim that was always visible under another name, and the entry now says which — the two read very differently to someone auditing. The shape rhymes with the `requestContext` boundary from #123/#153, though I have been careful not to overstate the trust level: in `mode = "verify"` these claims arrived under a verified signature from a pinned issuer, so this is issuer-attested data rather than the caller-typed body that `UntrustedRequestContext` brands; in `mode = "insecure-decode"` nothing was verified at all. Either way it is no longer the verifier's own value, and nothing validates a custom claim of that name.

Pinned by a new test (`no longer shadows a \`tokenType\` claim the token itself carries`), and noted on the `authScheme` doc comment in `core/src/types.mts` so the fact is findable from the API docs rather than only from the CHANGELOG.

CHANGELOG entry under **Changed**, marked **BREAKING**.

## 4. Stale-key list shared the way the message is

`["validate", "allowInsecureDecode"]` was written out literally in `config/application.schema.mts` and `app.mts` while `JWT_MODE_MIGRATION_MESSAGE` was shared between them. A third removed key added to one site only would be rejected for parsed configs and silently accepted for hand-built ones — precisely the silent reinterpretation #134 removed the keys to prevent.

Now `JWT_MODE_REMOVED_KEYS`, exported from `config/application.schema.mts` and consumed at both boundaries. **Deliberately not re-exported from the package index**, unlike the message: the message is what an operator reads and may match on; the list is only how the two boundaries agree with each other.

Both boundary test suites are now driven off the constant (`it.each([...JWT_MODE_REMOVED_KEYS])`) rather than off their own copies of the literal, so a key added to the constant is covered at both sites without anyone remembering to widen a test.

### `http.port` — confirmed already done, dropped from scope

The issue also listed `http.port` as the only numeric knob without `.int().positive()`. Verified on the current tree: **#160 already fixed this.** `application.schema.mts:104` reads `port: boundedNumber(NUMERIC_BOUNDS.port, "http")`, and `config/bounds.mts` holds it to `minimum: 1, maximum: MAX_TCP_PORT` (65535) — with `0` excluded deliberately and documented, because `listen(0)` binds an arbitrary free port that the enforcement layer cannot find. No change made.

## Tests

TDD for the behavioural items. Four new assertions, all confirmed failing before the implementation:

- `verify.test.mts` — an empty `sub` is absent from the decision response (failed: `expected { subject: '', …(4) } to not have property "subject"`)
- `tokenAuthenticator.test.mts` — the authenticated payload names the scheme `authScheme`, and carries no `tokenType` (failed: `undefined` ≠ `"Bearer"`); needed a real signed token, so the suite gained a 32-byte signing key and a `signToken` helper
- `tokenAuthenticator.test.mts` — a `tokenType` claim carried *by the token* now reaches the payload instead of being overwritten with `"Bearer"`, added after review to pin the exposure described above
- `app.test.mts` and `application.schema.test.mts` — both stale-key suites re-pointed at `JWT_MODE_REMOVED_KEYS` (failed to import until the constant existed), plus a new per-key `createApp` case

Full workspace, no `--coverage`:

```
pnpm lint         Checked 142 files. No fixes applied.
pnpm -r run build ok
pnpm run typecheck 6/6 projects Done
pnpm test         55 files, 1328 tests passed
                  create-app 78 · core 73 · builtins 474 · server 583
                  · templates/standalone 48 · tests/integration 72
```

Rebased onto `develop` at b310eba (#161/#163, AGENTS.md only) — clean, no conflicts.

No rule fixtures added, so the CI rule-purity grep gate is unaffected.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
