### PR TITLE
fix(standalone): ship a config that decides, and test the config that ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1091,6 +1091,47 @@ and version sections follow the release labeling policy in
   at all were already answered this way, so a consumer handling that case
   correctly needs no change.
 
+- The standalone template shipped a config that **denied every request**, and
+  the smoke test did not notice because it exercised a different one
+  ([#113](https://github.com/o3co/auth.policy-verifier/issues/113)).
+
+  `templates/standalone/config/application.conf` enabled
+  `ResourceActionPermissionRuleCollector` alongside the scope rule. That
+  collector emits a `HasPermission` rule, rules are grouped by kind and every
+  group must pass — and no collector in the shipped `attribute.collectors`
+  produced permissions or roles. The permission group could not be satisfied by
+  any token, so the scaffolded product answered deny to everything an operator
+  ever asked it. The suite stayed green because `smoke.test.mts` assembled its
+  own config with that collector left out: the one difference between the tested
+  composition and the shipped one was the defect.
+
+  **The shipped policy is now the token's `scope` claim and nothing else.** A
+  request is allowed exactly when the bearer token carries
+  `<action>:<resourceType>`, which `ResourceActionScopeRuleCollector` derives
+  from the request. It is functional against any issuer that mints scopes with
+  no authorization store to stand up first, and it is still fail-closed: a token
+  carrying no scope or the wrong one is denied, and `rule.onEmptyRuleSet` stays
+  `"deny"`. Nothing was granted by wildcard to make this work — the permission
+  rule was removed, not satisfied.
+
+  **For operators**, the change is visible: a deployment on the shipped
+  `application.conf` went from denying everything to deciding on scopes. One that
+  had already edited the file — the only way it could have worked — is
+  unaffected, since a mounted or overlaid config replaces this one. A deployment
+  that does want permission rules enables the rule collector **and** its
+  supplier together; `application.conf` now carries that worked example beside
+  the collector, and both READMEs state why one without the other is a verifier
+  that denies everything.
+
+  **The smoke test now boots from `config/application.conf`** through
+  `loadAppConfig` — the same function `main.mts` calls — so the composition
+  under test is the composition that ships, and the hand-built variant is gone.
+  The HS256 secret, issuer and audience still come from the environment, as they
+  must: the file deliberately carries no credential. One config in the file is
+  still deliberately not the shipped one, the `allowBareScopeRewrite` opt-in, and
+  it is derived from the shipped config so the key under test is the only thing
+  that differs.
+
 - `@o3co/create-auth-policy-verifier` scaffolded an **empty directory** whenever
   it was run the documented way. Its template-copy filter excluded any path
   containing a `node_modules` or `dist` segment, matched against the absolute

--- a/README.ja.md
+++ b/README.ja.md
@@ -171,6 +171,12 @@ standalone → server   → core
 | `HasScope("read:project")` | `ResourceActionScopeRuleCollector` | JWT の `scope` クレームに `read:project` が含まれる |
 | `HasPermission("project:1.perm:read")` | `ResourceActionPermissionRuleCollector` | ユーザーの permissions/roles にマッチするパターンが含まれる（`*` ワイルドカード対応） |
 
+RuleCollector だけではポリシーになりません。ルールグループは AND で評価されるため、
+属性を供給する AttributeCollector なしに有効化すると、何をもってしても満たせない
+グループができ、全リクエストを拒否する verifier になります。
+`ResourceActionPermissionRuleCollector` は `permissions` / `roles` を書く
+コレクターと同じ編集でセットにしてください。
+
 ### 組み込み AttributeCollector
 
 | Collector | 読む | 書く |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ configured at all is rejected.
 | `HasScope("read:project")` | `ResourceActionScopeRuleCollector` | JWT `scope` claim contains `read:project` |
 | `HasPermission("project:1.perm:read")` | `ResourceActionPermissionRuleCollector` | User permissions/roles include matching pattern (supports `*` wildcards) |
 
+A rule collector is only half a policy: groups are ANDed, so one enabled without
+the attribute collector that feeds it is a group nothing can satisfy — a verifier
+that denies every request. Pair `ResourceActionPermissionRuleCollector` with a
+collector writing `permissions` / `roles` in the same edit.
+
 ### Built-in Attribute Collectors
 
 | Collector | Reads | Writes |

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -192,8 +192,27 @@ scrape_configs:
 
 **Rule collectors**（認可ルールを解決）:
 
-- `ResourceActionScopeRuleCollector` — リソース/アクションをスコープルールと照合する
-- `ResourceActionPermissionRuleCollector` — リソース/アクションをパーミッションルールと照合する
+- `ResourceActionScopeRuleCollector` — トークンがスコープ `<action>:<resourceType>` を持つことを要求する
+- `ResourceActionPermissionRuleCollector` — パーミッション `<resource.raw>.perm:<action>` を要求する（既定では未接続。下記参照）
+
+### 出荷時のポリシー
+
+`config/application.conf` はトークンの `scope` クレームだけで認可します。つまり、
+リクエスト対象の resource と action に対して `<action>:<resourceType>` を bearer
+トークンが持っているときにちょうど許可されます。スコープを発行する IdP があれば
+認可ストアを別途立てなくてもそのまま機能し、かつ fail-closed です — スコープを
+持たないトークンや誤ったスコープは拒否され、ルールが 1 つも集まらなかった
+リクエストも拒否されます（`rule.onEmptyRuleSet = "deny"`）。
+
+ルールは種類ごとにグループ化され、**すべてのグループが通る必要があります**。
+そのため、属性を供給する attribute collector なしに rule collector を有効化すると、
+何をもってしても満たせないグループができ、トークンの内容によらず全リクエストを
+拒否する verifier になります。`ResourceActionPermissionRuleCollector` が
+「未設定」ではなく明示的に無効なのはこのためです — このルールは permissions/roles
+属性を読みますが、出荷時の `attribute.collectors` はそれを生成しません。有効化する
+ときは供給側と同じ編集でセットにしてください（デプロイ単位の固定リストなら
+`StaticPermissionCollector`、サブジェクトごとに異なるなら独自の `AttributeCollector`）。
+`application.conf` の該当コレクターの隣に具体例があります。
 
 使用されるリソースパーサーは `DotNotationResourceParser` です。`segment *( "." segment )`
 （`segment = type [ ":" id ]`）を受け付け、セグメントの type を `.` で結合して `resourceType` を導出します

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -192,8 +192,28 @@ The following collectors are registered via `builtinCollectorsModule`:
 
 **Rule collectors** (resolve authorization rules):
 
-- `ResourceActionScopeRuleCollector` — matches resource/action against scope rules
-- `ResourceActionPermissionRuleCollector` — matches resource/action against permission rules
+- `ResourceActionScopeRuleCollector` — requires the token to carry the scope `<action>:<resourceType>`
+- `ResourceActionPermissionRuleCollector` — requires the permission `<resource.raw>.perm:<action>` (not wired by default; see below)
+
+### The shipped policy
+
+`config/application.conf` authorizes from the token's `scope` claim and nothing
+else: a request is allowed exactly when the bearer token carries
+`<action>:<resourceType>` for the resource and action it asks about. It is
+functional against any issuer that mints scopes, with no authorization store to
+stand up first, and it is fail-closed — a token with no scope, or the wrong one,
+is denied, and so is a request that collects no rule at all
+(`rule.onEmptyRuleSet = "deny"`).
+
+Rules are grouped by kind and **every group must pass**. A rule collector enabled
+without the attribute collector that feeds it therefore produces a group nothing
+can satisfy — a verifier that denies every request, whatever the token carries.
+That is why `ResourceActionPermissionRuleCollector` is off rather than merely
+unconfigured: it reads the permissions/roles attributes, and nothing in the
+shipped `attribute.collectors` produces them. Enable it and its supplier in the
+same edit — `StaticPermissionCollector` for a fixed per-deployment list, or your
+own `AttributeCollector` where permissions differ by subject. `application.conf`
+carries the worked example beside the collector.
 
 The resource parser in use is `DotNotationResourceParser`. It accepts
 `segment *( "." segment )` where `segment = type [ ":" id ]`, and derives `resourceType` by joining

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -219,11 +219,14 @@ rule {
     # `attribute.collectors` above produces. Enabled on its own it is a group no
     # token can satisfy, i.e. a verifier that answers deny to everything.
     #
-    # So enable it together with a supplier, in one edit — the two lines belong
-    # to the same decision:
+    # So enable it together with a supplier, in one edit — two list entries that
+    # are one decision. Add this entry to `attribute.collectors` above:
     #
-    #   attribute.collectors  { collector = "StaticPermissionCollector", permissions = ["project:1.perm:read"] }
-    #   rule.collectors       { collector = "ResourceActionPermissionRuleCollector" }
+    #   { collector = "StaticPermissionCollector", permissions = ["project:1.perm:read"] }
+    #
+    # and this entry to the list you are reading now:
+    #
+    #   { collector = "ResourceActionPermissionRuleCollector" }
     #
     # StaticPermissionCollector grants one fixed list to every subject, so it
     # suits a per-deployment capability, never a per-user one. Where permissions

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -171,10 +171,19 @@ logging {
 }
 
 attribute {
+  # What a request is described by. Every rule below decides from these
+  # attributes and nothing else, so a rule whose attribute nothing here produces
+  # can never pass — see the note in the rule block.
   collectors = [
+    # The token's `scope` claim, split into the list the scope rule reads.
     { collector = "PayloadScopeCollector" }
+    # The token's `sub`, which becomes the `subject` on the decision response
+    # and the `sub` field on the audit log line.
     { collector = "PayloadSubjectIdCollector" }
   ]
+  # Deliberately absent: anything supplying permissions or roles. This
+  # deployment authorizes from the token's scopes alone. Adding a permission
+  # rule means adding its supplier here in the same edit (#113).
 }
 
 rule {
@@ -183,6 +192,17 @@ rule {
   # any request that matches no rule succeed.
   onEmptyRuleSet = "deny"
   onEmptyRuleSet = ${?RULE_ON_EMPTY_RULE_SET}
+
+  # The shipped policy is the token's own `scope` claim and nothing else: the
+  # request is allowed exactly when the token carries "<action>:<resourceType>".
+  # It works against any issuer that mints scopes without an authorization store
+  # to stand up first, and it stays fail-closed — a token carrying no scope, or
+  # the wrong one, is denied, as is a request that collects no rule at all.
+  #
+  # Rules are grouped by kind and every GROUP must pass, so one group nothing can
+  # satisfy denies every request the deployment ever sees. That is what enabling
+  # a rule collector without the attribute collector feeding it does, and it is
+  # why the permission rule below is off rather than merely unconfigured (#113).
   collectors = [
     # Scope matching is exact and case-sensitive (RFC 6749 §3.3): the token must
     # carry "<action>:<resourceType>" verbatim. If your issuer emits bare resource
@@ -191,7 +211,25 @@ rule {
     # never wrote:
     #   { collector = "ResourceActionScopeRuleCollector", allowBareScopeRewrite = true }
     { collector = "ResourceActionScopeRuleCollector" }
-    { collector = "ResourceActionPermissionRuleCollector" }
+
+    # NOT enabled, and not an oversight. ResourceActionPermissionRuleCollector
+    # emits a rule requiring the permission "<resource.raw>.perm:<action>" —
+    # "project:1.perm:read" for resource "project:1", action "read" — and that
+    # rule reads the permissions/roles attributes, which nothing in the
+    # `attribute.collectors` above produces. Enabled on its own it is a group no
+    # token can satisfy, i.e. a verifier that answers deny to everything.
+    #
+    # So enable it together with a supplier, in one edit — the two lines belong
+    # to the same decision:
+    #
+    #   attribute.collectors  { collector = "StaticPermissionCollector", permissions = ["project:1.perm:read"] }
+    #   rule.collectors       { collector = "ResourceActionPermissionRuleCollector" }
+    #
+    # StaticPermissionCollector grants one fixed list to every subject, so it
+    # suits a per-deployment capability, never a per-user one. Where permissions
+    # differ by subject they live in your own store: write an AttributeCollector
+    # that reads it and register it in a module (README.md, "Adding Custom
+    # Modules", and docs/extending.md).
   ]
 }
 

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -92,9 +92,12 @@ describe("loadAppConfig", () => {
 			"PayloadScopeCollector",
 			"PayloadSubjectIdCollector",
 		]);
+		// Scope-only, and the two lists are one decision (#113). Rule groups are
+		// ANDed, so a rule reading an attribute no collector above produces is a
+		// group nothing satisfies — which is a verifier that denies every request.
+		// A permission rule may only join this list together with its supplier.
 		expect(config.rule.collectors.map((c) => c.collector)).toEqual([
 			"ResourceActionScopeRuleCollector",
-			"ResourceActionPermissionRuleCollector",
 		]);
 		expect(config.resource.parser).toBe("DotNotationResourceParser");
 	});

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -50,24 +50,42 @@ async function signToken(payload: Record<string, unknown>): Promise<string> {
 	);
 }
 
+/** The three values `application.conf` leaves to the deployment. */
+const DEPLOYMENT_ENV = {
+	OAUTH_JWT_SECRET: JWT_SECRET,
+	OAUTH_JWT_ISSUER: ISSUER,
+	OAUTH_JWT_AUDIENCE: AUDIENCE,
+} as const;
+
 /**
  * The shipped config, loaded the way the container loads it: the development
  * overlay resolved against `config/application.conf`, with the deployment's
  * three values in the environment.
  *
- * The variables are removed again immediately. They are inputs to this one
- * load, not ambient state some later assertion could come to depend on.
+ * `process.env` is process-wide, and a test file does not own it. So each
+ * variable's prior value is **restored**, not deleted — and "was absent" is
+ * restored as absent rather than as `""`, which is a different state this very
+ * config distinguishes (an exported-empty credential is refused rather than read
+ * as "unset"). Deleting unconditionally would hand any file sharing the worker a
+ * value this one happened to clear.
+ *
+ * The window is nil as well as tidy: every step here is synchronous —
+ * `loadAppConfig` parses and validates without awaiting — and this runs at module
+ * scope, so no other file's code can be scheduled between the assignment and the
+ * restore.
  */
 function loadShippedConfig(): AppConfig {
-	process.env.OAUTH_JWT_SECRET = JWT_SECRET;
-	process.env.OAUTH_JWT_ISSUER = ISSUER;
-	process.env.OAUTH_JWT_AUDIENCE = AUDIENCE;
+	const saved: Array<[key: string, previous: string | undefined]> = Object.keys(DEPLOYMENT_ENV).map(
+		(key) => [key, process.env[key]],
+	);
+	Object.assign(process.env, DEPLOYMENT_ENV);
 	try {
 		return loadAppConfig(configDirPath, "development");
 	} finally {
-		delete process.env.OAUTH_JWT_SECRET;
-		delete process.env.OAUTH_JWT_ISSUER;
-		delete process.env.OAUTH_JWT_AUDIENCE;
+		for (const [key, previous] of saved) {
+			if (previous === undefined) delete process.env[key];
+			else process.env[key] = previous;
+		}
 	}
 }
 

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -4,34 +4,38 @@
 /*
  * Smoke tests for the standalone template.
  *
- * These tests verify that the app created by the standalone template boots correctly
- * and that core HTTP endpoints respond as expected.
+ * These tests boot the app from `config/application.conf` — the file the image
+ * ships and an operator deploys — read through `loadAppConfig`, the same
+ * function `main.mts` calls. Nothing here restates the policy: the thing under
+ * test is the thing that ships.
  *
- * The composition here intentionally mirrors main.mts — using builtinCollectorsModule
- * and registry keys that match application.conf — so that renames or interface changes
- * in the builtins package are caught here before reaching production.
+ * That is the point of #113. The suite used to assemble its own config, minus
+ * the one collector that made the shipped file deny every request, and stayed
+ * green while the product was non-functional. A config the tests hand-write can
+ * agree with `application.conf` only by vigilance, and it stopped agreeing.
  *
- * Note: ResourceActionPermissionRuleCollector is omitted from the smoke config because
- * it requires a permission store (e.g. StaticPermissionCollector) to grant any access.
- * The scope-based check via ResourceActionScopeRuleCollector is sufficient to exercise
- * the allow/deny paths in isolation.
+ * The three values the file deliberately does not carry — the HS256 secret, the
+ * issuer and the audience — come from the environment here exactly as they do
+ * in a deployment. A credential must never be written in a config file, so
+ * supplying them is loading the shipped config, not editing it.
  */
+import { fileURLToPath } from "node:url";
 import { builtinCollectorsModule } from "@o3co/auth.policy-verifier.builtins";
 import { consoleLogger } from "@o3co/auth.policy-verifier.core";
-import {
-	AppConfigSchema,
-	builtinKeyResolversModule,
-	createApp,
-} from "@o3co/auth.policy-verifier.server";
+import type { AppConfig } from "@o3co/auth.policy-verifier.server";
+import { builtinKeyResolversModule, createApp } from "@o3co/auth.policy-verifier.server";
 import { SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
+import { loadAppConfig } from "../loadConfig.js";
 
 /** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
 const JWT_SECRET = "11".repeat(32);
 const secretKey = new TextEncoder().encode(JWT_SECRET);
 const ISSUER = "https://issuer.test";
 const AUDIENCE = "https://api.test";
+
+const configDirPath = fileURLToPath(new URL("../../config/", import.meta.url));
 
 async function signToken(payload: Record<string, unknown>): Promise<string> {
 	return (
@@ -46,51 +50,48 @@ async function signToken(payload: Record<string, unknown>): Promise<string> {
 	);
 }
 
-// Shared by every config below so a change to the jwt wire keys has one place
-// to land rather than drifting between the base config and the variants.
-const JWT_CONFIG = {
-	secret: JWT_SECRET,
-	mode: "verify",
-	issuer: ISSUER,
-	audience: AUDIENCE,
-} as const;
+/**
+ * The shipped config, loaded the way the container loads it: the development
+ * overlay resolved against `config/application.conf`, with the deployment's
+ * three values in the environment.
+ *
+ * The variables are removed again immediately. They are inputs to this one
+ * load, not ambient state some later assertion could come to depend on.
+ */
+function loadShippedConfig(): AppConfig {
+	process.env.OAUTH_JWT_SECRET = JWT_SECRET;
+	process.env.OAUTH_JWT_ISSUER = ISSUER;
+	process.env.OAUTH_JWT_AUDIENCE = AUDIENCE;
+	try {
+		return loadAppConfig(configDirPath, "development");
+	} finally {
+		delete process.env.OAUTH_JWT_SECRET;
+		delete process.env.OAUTH_JWT_ISSUER;
+		delete process.env.OAUTH_JWT_AUDIENCE;
+	}
+}
 
-// Config mirrors the structure of application.conf, using the same builtin registry keys.
-// PayloadScopeCollector extracts scopes from the JWT "scope" claim.
-// ResourceActionScopeRuleCollector requires scope "<action>:<resourceType>" to be present.
-// DotNotationResourceParser is the default and matches the omitted resource.parser in application.conf.
-const baseConfig = AppConfigSchema.parse({
-	oauth: { jwt: JWT_CONFIG },
-	attribute: {
-		collectors: [
-			{ collector: "PayloadScopeCollector" },
-			{ collector: "PayloadSubjectIdCollector" },
-		],
-	},
-	rule: {
-		collectors: [{ collector: "ResourceActionScopeRuleCollector" }],
-	},
-	// resource.parser defaults to "DotNotationResourceParser" — matches application.conf omission
-});
+const shippedConfig = loadShippedConfig();
+
+/** The composition `main.mts` builds, over whichever config is handed in. */
+function createShippedApp(config: AppConfig = shippedConfig) {
+	return createApp({
+		pathResolver: (s: string) => s,
+		config,
+		modules: [builtinCollectorsModule, builtinKeyResolversModule],
+	});
+}
 
 describe("standalone smoke", () => {
 	it("GET /healthcheck returns 200", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		const res = await request(app).get("/healthcheck");
 		expect(res.status).toBe(200);
 	});
 
 	it("POST /verify with sufficient scope returns 200 (allow)", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		// PayloadScopeCollector extracts "read:document" from the JWT scope claim.
 		// ResourceActionScopeRuleCollector requires scope "<action>:<resourceType>".
@@ -106,11 +107,7 @@ describe("standalone smoke", () => {
 	});
 
 	it("POST /verify with a scopeless token returns 403 (deny)", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		// A validly-signed token carrying no scope claim asserts no capability, so a
 		// scope-only pipeline must deny it rather than collect zero rules and allow.
@@ -125,11 +122,7 @@ describe("standalone smoke", () => {
 	});
 
 	it("POST /verify with an id_token signed by the same key returns 401", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		// The paired provider signs id_tokens with the same key as access tokens;
 		// only the typ header separates them.
@@ -150,11 +143,7 @@ describe("standalone smoke", () => {
 	});
 
 	it("POST /verify/batch decides every entry in one round trip", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		const token = await signToken({ sub: "user-1", scope: "read:document" });
 		const res = await request(app)
@@ -176,11 +165,7 @@ describe("standalone smoke", () => {
 	});
 
 	it("POST /verify with a differently-cased scope returns 403 (deny)", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		// Scope values are case-sensitive opaque strings (RFC 6749 §3.3), so
 		// "read:DOCUMENT" must not satisfy the required "read:document".
@@ -195,11 +180,7 @@ describe("standalone smoke", () => {
 	});
 
 	it("POST /verify with a bare scope returns 403 unless the rewrite is opted into", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		// A bare "document" is not rewritten to "read:document" by default.
 		const token = await signToken({ scope: "document" });
@@ -213,22 +194,21 @@ describe("standalone smoke", () => {
 	});
 
 	it("POST /verify allows a bare scope once allowBareScopeRewrite is configured", async () => {
-		// Proves the opt-in survives the config schema and reaches the collector,
-		// which is the only path a deployment has to re-enable the old rewrite.
-		const rewritingConfig = AppConfigSchema.parse({
-			oauth: { jwt: JWT_CONFIG },
-			attribute: { collectors: [{ collector: "PayloadScopeCollector" }] },
+		// The one config in this file that is deliberately NOT the shipped one:
+		// it exercises the opt-in application.conf documents in a comment beside
+		// the collector, which is the only path a deployment has to re-enable the
+		// old rewrite. It is derived from the shipped config rather than written
+		// out, so the single key under test is the single thing that differs.
+		const rewritingConfig: AppConfig = {
+			...shippedConfig,
 			rule: {
+				...shippedConfig.rule,
 				collectors: [
 					{ collector: "ResourceActionScopeRuleCollector", allowBareScopeRewrite: true },
 				],
 			},
-		});
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: rewritingConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		};
+		const app = await createShippedApp(rewritingConfig);
 
 		const token = await signToken({ scope: "document" });
 		const res = await request(app)
@@ -241,11 +221,7 @@ describe("standalone smoke", () => {
 	});
 
 	it("POST /verify with insufficient scope returns 403 (deny)", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		// Token has "write:document" but action is "read", so HasScope("read:document") fails.
 		const token = await signToken({ scope: "write:document" });
@@ -265,11 +241,7 @@ describe("standalone smoke", () => {
  */
 describe("standalone observability", () => {
 	it("GET /metrics serves the Prometheus text format with the decision counters", async () => {
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: baseConfig,
-			modules: [builtinCollectorsModule, builtinKeyResolversModule],
-		});
+		const app = await createShippedApp();
 
 		const token = await signToken({ sub: "user-1", scope: "read:document" });
 		await request(app)
@@ -290,7 +262,7 @@ describe("standalone observability", () => {
 		const lines: Array<{ obj: Record<string, unknown>; msg?: string }> = [];
 		const app = await createApp({
 			pathResolver: (s: string) => s,
-			config: baseConfig,
+			config: shippedConfig,
 			modules: [builtinCollectorsModule, builtinKeyResolversModule],
 			logger: {
 				...consoleLogger,


### PR DESCRIPTION
Closes #113

## The defect

`templates/standalone/config/application.conf` enabled
`ResourceActionPermissionRuleCollector` alongside the scope rule, while
`attribute.collectors` supplied only scopes and `sub`. Rules are grouped by kind
and **every group must pass**, so the permission group — which no token could
satisfy — denied every request the scaffolded product ever saw.

The smoke test stayed green because it assembled its own config with that one
collector left out. The single difference between the tested composition and the
shipped one was the defect itself.

## What the shipped config now grants

The token's `scope` claim, and nothing else:

```hocon
attribute {
  collectors = [
    { collector = "PayloadScopeCollector" }
    { collector = "PayloadSubjectIdCollector" }
  ]
}

rule {
  onEmptyRuleSet = "deny"
  collectors = [
    { collector = "ResourceActionScopeRuleCollector" }
  ]
}
```

A request is allowed exactly when the bearer token carries
`<action>:<resourceType>` for the resource and action it asks about —
`read:document` for `{ resource: "document", action: "read" }`. Nothing else has
to exist for that to work: no permission store, no role directory, no edit before
first boot. It is the scope-driven shape the issue recommends.

## Why it is still fail-closed

Nothing was granted to make it functional — the permission rule was **removed**,
not satisfied. There is no wildcard static permission anywhere in this change.

- A token carrying no `scope` claim is denied. `ResourceActionScopeRuleCollector`
  emits its rule regardless (`scopeless: "deny"` is the default), so a scopeless
  token fails it rather than dropping the group.
- A token carrying the wrong scope is denied. `HasScope` matches exactly and
  case-sensitively (#116/#140) — `read:DOCUMENT` and a bare `document` both fail
  `read:document`, and the bare-scope rewrite stays opt-in and off.
- A request that collects no rule at all is denied: `rule.onEmptyRuleSet = "deny"`
  is unchanged.
- The envelope still gates everything ahead of the rules: RFC 9068 `iss`/`aud`,
  the `at+jwt` `typ` pin, required `exp`, the `maxTokenAge` ceiling, the >=32-byte
  HS256 floor, loopback bind, optional `http.callerAuth`.

The grant went from "nothing, ever" to "what the issuer wrote in the token" —
never to "anything".

## The smoke-test change

`templates/standalone/src/__tests__/smoke.test.mts` now boots from
`config/application.conf` through `loadAppConfig`, the same function `main.mts`
calls. The hand-built `baseConfig` is deleted. A config the tests write out can
only agree with the shipped file by vigilance, and it had stopped agreeing.

The HS256 secret, issuer and audience come from the environment, as they do in a
deployment — the file deliberately carries no credential, so supplying them is
loading the shipped config rather than editing it.

One config in the file is still deliberately not the shipped one: the
`allowBareScopeRewrite` opt-in that `application.conf` documents in a comment.
It is now **derived** from the loaded shipped config instead of written out, so
the one key under test is the only thing that differs.

## Umbrella cross-component E2E: not affected

`o3co/auth`'s `tests/docker-compose.yml` bind-mounts
`tests/abac/application.conf` over the template's, so the file this PR edits is
not the file that suite loads. And that overlay already declares exactly one rule
collector:

```hocon
rule {
  collectors = [
    { collector = "ResourceActionScopeRuleCollector" }
  ]
}
```

— which is the shape this PR moves the template to. Its ABAC assertions
(`read:project` allows, `read:project.member` denies with `invalid_scope`, the
nested `project:1.member:2` allow, the scopeless deny) are all scope decisions
and are unchanged. The change removes drift between the template and the E2E
overlay rather than creating any. No change is needed in `o3co/auth`.

## Two-Boundary Config Validation

Nothing is added to the config surface — no new key, no numeric knob, no schema
or guard change. `AppConfigSchema` and the runtime guards are untouched, so the
invariant is unaffected. The change is to a config *document* and to which test
loads it.

## Test results

RED first, against the shipped config with the smoke test pointed at it — 4 of 11
failing, every allow path:

```
FAIL  POST /verify with sufficient scope returns 200 (allow)
FAIL  POST /verify/batch decides every entry in one round trip
FAIL  GET /metrics serves the Prometheus text format with the decision counters
FAIL  emits the per-decision audit line through the injected logger
      Tests  4 failed | 7 passed (11)
```

Each failed the same way: `expected 'deny' to be 'allow'`. GREEN after removing
the permission rule from `application.conf`.

Full sweep, no `--coverage`:

| Command | Result |
| --- | --- |
| `pnpm lint` | 142 files, no fixes applied |
| `pnpm -r run build` | all 6 projects |
| `pnpm run typecheck` | all 6 projects |
| `pnpm run test` | **1323 passed / 55 files** — core 73, builtins 474, server 578, create-app 78, templates/standalone 48, tests/integration 72 |
| rule-purity CI gate (run locally) | OK, 123 files scanned |

## Judgment calls

- **No boot-time coherence check** that would refuse a permission rule collector
  configured without a permission supplier. It is tempting, but the server cannot
  know the supplier set: any user module may write `ATTR_PERMISSIONS`, so the
  check would either miss real configurations or reject legitimate ones. The
  durable guard is instead the smoke test now exercising the shipped file — the
  matching-scope allow is what turns this defect class red.
- **`ResourceActionPermissionRuleCollector` is documented in place rather than
  deleted from the file.** It stays as a commented block naming the exact pair to
  enable together, because "why is this off" is the question the next reader will
  have, and an empty file answers it worse than a comment does.
- **The `allowBareScopeRewrite` test was kept**, derived rather than deleted.
  Deleting it would drop the only coverage that the opt-in survives the config
  layer and reaches the collector; deriving it keeps the shipped config as the
  baseline for everything else in the suite.
- **The `attribute` block grew a comment** saying that nothing there supplies
  permissions or roles, deliberately. The defect was a coupling between two lists
  that neither list mentioned; naming it at both ends is what makes the next edit
  see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
