### PR TITLE
fix(server)!: bound every /verify input, and check the body before the token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,110 @@ and version sections follow the release labeling policy in
 
 ### Security
 
+- **BREAKING**: `/verify` and `/verify/batch` now hold the request body to
+  stated limits, refuse unknown properties and whitespace, and **validate the
+  body before verifying the token**
+  ([#118](https://github.com/o3co/auth.policy-verifier/issues/118)).
+
+  Input validation was thin: Express's unstated 100 KB JSON default, and a
+  check that `resource` and `action` were non-empty strings. A whitespace-only
+  value passed, `context` could be arbitrarily wide and deep, unknown
+  properties rode along in silence — and the expensive half of the request, JWT
+  verification, ran first, so an unauthenticated caller could spend it on a body
+  that was never usable.
+
+  **The limits**, each a numeric knob on the `verify` config block, read through
+  the same `resolveBound` at both boundaries (#157) and settable from the
+  environment:
+
+  | Key | Env | Default | Bounds |
+  | --- | --- | --- | --- |
+  | `verify.maxBodyBytes` | `VERIFY_MAX_BODY_BYTES` | `65536` (64 KiB) | the `limit` on `express.json()` |
+  | `verify.maxResourceLength` | `VERIFY_MAX_RESOURCE_LENGTH` | `512` | characters in `resource` |
+  | `verify.maxActionLength` | `VERIFY_MAX_ACTION_LENGTH` | `64` | characters in `action` |
+  | `verify.maxContextEntries` | `VERIFY_MAX_CONTEXT_ENTRIES` | `64` | properties + array elements in the whole `context` tree |
+  | `verify.maxContextValueLength` | `VERIFY_MAX_CONTEXT_VALUE_LENGTH` | `1024` | characters in any `context` string, keys included |
+
+  `maxBodyBytes` is below Express's old default, so it is a tightening, and it
+  is the outer envelope: it binds first on a large batch, because the per-field
+  limits bound *one* entry rather than N of them. A deployment sending wide
+  contexts across a full 50-entry batch raises it.
+
+  `maxContextEntries` counts every property and every array element at every
+  depth, so nesting is **bounded rather than forbidden** —
+  `RequestContextAttributeCollector` reads dot paths such as `tenant.id`, and a
+  flat-only rule would have broken a documented feature. Since each level of
+  nesting costs at least one entry, it bounds the depth too, which is why there
+  is no separate depth knob.
+
+  **Whitespace is refused, not trimmed**, in `resource` and `action` alike —
+  the doctrine the resource grammar already applies (#117), extended to `action`
+  and to a deployment that registered its own `ResourceParser`. Both are
+  concatenated into the `{action}:{resourceType}` scope an issuer has to have
+  granted, and RFC 6749 §3.3 makes space the delimiter between scope values, so
+  a value carrying whitespace names something no issuer could grant. Trimming
+  would make `"read "` and `"read"` one action here while a collector reading
+  the raw string still saw two.
+
+  **Unknown properties are refused.**
+  `{"resource": "project:1", "action": "read", "subject": "admin"}` is now
+  `400 invalid_request` rather than a decision with `subject` quietly dropped.
+  The subject comes from the verified token and never from the body; a caller
+  who sent one was being told nothing while believing it had been honoured. The same applies to a misspelled `contxt`, and to anything beside
+  `decisions` on a batch body.
+
+  **The ordering change, which is the wire-visible one.** The body is validated
+  first, so a malformed request is answered `400` whether or not a token was
+  presented:
+
+  | Request | Before | After |
+  | --- | --- | --- |
+  | malformed body, no token | `401 missing_token` | `400 invalid_request` |
+  | malformed body, bad token | `401 invalid_token` | `400 invalid_request` |
+  | well-formed body, no/bad token | `401` | `401` (unchanged) |
+  | body over the size limit | Express HTML `413` | `413 payload_too_large` (deny envelope) |
+  | malformed JSON | Express HTML `400` | `400 invalid_request` (deny envelope) |
+  | unreadable content type / charset | Express HTML `415` | `415 unsupported_media_type` (deny envelope) |
+
+  It is the order the costs argue for: the body checks are bounded by the limits
+  above, while verifying a token is the half that can reach the network — an
+  attacker-chosen `kid` sends the JWKS path to the provider, and an HS256
+  rotation tries every configured secret. What it costs is that an anonymous
+  caller now learns whether a body was well-formed, the resource grammar
+  included. `http.callerAuth` (#108) is the gate for a deployment that must not
+  disclose even that, and it is **unchanged**: it still runs ahead of this
+  router and ahead of `express.json()`, so a rejected caller is still answered
+  before a body is parsed at all.
+
+  **A terminal error handler** now turns a body-parser failure into the deny
+  envelope instead of Express's default HTML page, which could also carry a
+  stack trace outside production:
+
+  ```json
+  {"decision": "deny", "code": "invalid_request", "message": "Request body is not valid JSON"}
+  ```
+
+  That example is the response body verbatim, and it is the same line the two
+  READMEs carry — `verifyInputValidation.test.mts` asserts it appears in all
+  three and parses to what the endpoint emits, so no copy can drift from the
+  code or from the others.
+  The handler is mounted on the router, so a consumer mounting
+  `createVerifyRouter` on their own app gets it without wiring anything. This
+  covers item 6 of
+  [#126](https://github.com/o3co/auth.policy-verifier/issues/126) in full,
+  including its "whitespace-only `resource`" sibling, item 7. Neither message
+  echoes the body: a parse failure is reported as a parse failure, not by
+  quoting the bytes that caused it, and the unknown-property message bounds the
+  names it shows.
+
+  **Operator migration.** No configuration key is required, and every default is
+  generous for a real caller: `project:1` / `read` and a handful of context
+  fields are far inside all five. Callers to check are the ones sending bodies
+  over 64 KiB, whitespace in `resource` or `action`, extra properties beside
+  `resource` / `action` / `context`, or `context` objects with more than 64
+  entries or strings over 1 KiB — and any client that special-cased the `401`
+  it used to get for a malformed unauthenticated request.
+
 - **BREAKING**: `CollectorContext.requestContext` is now an opaque
   `UntrustedRequestContext` instead of a `Record<string, unknown>`, so
   caller-supplied request data cannot be read without saying that is what it is

--- a/README.ja.md
+++ b/README.ja.md
@@ -261,8 +261,53 @@ resource {
 verify {
   maxBatchSize = 50             # POST /verify/batch の件数上限
   maxBatchSize = ${?VERIFY_MAX_BATCH_SIZE}
+  maxBodyBytes = 65536          # JSON ボディの上限。超過は 413 payload_too_large
+  maxBodyBytes = ${?VERIFY_MAX_BODY_BYTES}
+  maxResourceLength = 512       # `resource` の文字数
+  maxResourceLength = ${?VERIFY_MAX_RESOURCE_LENGTH}
+  maxActionLength = 64          # `action` の文字数
+  maxActionLength = ${?VERIFY_MAX_ACTION_LENGTH}
+  maxContextEntries = 64        # `context` 全体のプロパティ数 + 配列要素数（深さを問わず）
+  maxContextEntries = ${?VERIFY_MAX_CONTEXT_ENTRIES}
+  maxContextValueLength = 1024  # `context` 内の文字列の文字数（キー名を含む）
+  maxContextValueLength = ${?VERIFY_MAX_CONTEXT_VALUE_LENGTH}
 }
 ```
+
+### リクエストの上限
+
+呼び出し側が決める入力はすべて上限を持ち、その上限が上のノブです。`maxBodyBytes` は外枠 —
+`express.json()` の limit で、Express の暗黙の 100 KB デフォルトより小さい — であり、大きなバッチでは
+これが最初に効きます。フィールドごとの上限が縛るのは *1 件* であって N 件の合計ではないためです。
+`maxContextEntries` は `context` ツリー全体のプロパティと配列要素をすべて数えるので、ネストは禁止では
+なく上限が付きます (`RequestContextAttributeCollector` は `tenant.id` のようなドットパスを読みます)。
+ネスト 1 段につき最低 1 エントリを消費するため、これは深さの上限にもなります。
+
+明示しておくべき拒否が 3 つあります:
+
+- **`resource` / `action` の空白は trim せず拒否** — リソース文法がすでに適用している方針を、`action` と
+  独自パーサーを登録したデプロイにも広げたものです。どちらも発行者が grant した
+  `{action}:{resourceType}` scope に連結され、RFC 6749 §3.3 では空白が scope 値の区切り文字です。
+- **未知のプロパティは拒否** — `{"resource": "project:1", "action": "read", "subject": "admin"}` は、
+  `subject` を黙って無視した決定ではなく `400 invalid_request` になります。subject は検証済みトークン
+  由来であってボディ由来ではなく、拒否することが呼び出し側にそれを伝える唯一の手段です。
+- **トークン検証より先にボディを検証** するため、トークンの有無にかかわらず不正なボディは `400` です。
+  ボディの検査は上の上限で有界ですが、トークン検証はネットワークに到達しうる側です。したがって匿名の
+  呼び出し側もボディが正しい形かどうかは知ることになります。それすら開示できないデプロイのゲートが
+  `http.callerAuth` です。
+
+パーサー自身が拒否したボディも、他と同じ deny エンベロープで答えます。Express の HTML
+エラーページに落ちることはありません:
+
+```json
+{"decision": "deny", "code": "invalid_request", "message": "Request body is not valid JSON"}
+```
+
+不正な JSON は `400`、`maxBodyBytes` 超過は `413 payload_too_large`、読めない Content-Type /
+charset は `415 unsupported_media_type` です。上の例はレスポンスボディそのもので、この 1 行が
+`README.md` / `README.ja.md` / `CHANGELOG.md` に現れ、かつエンドポイントが実際に返す内容へ
+parse されることを `verifyInputValidation.test.mts` が検証しています。3 か所のコピーがコードから
+も互いからも drift しないのはそのためです。
 
 ### リソース文字列形式 (DotNotation)
 

--- a/README.md
+++ b/README.md
@@ -265,8 +265,55 @@ resource {
 verify {
   maxBatchSize = 50             # cap on POST /verify/batch entries
   maxBatchSize = ${?VERIFY_MAX_BATCH_SIZE}
+  maxBodyBytes = 65536          # JSON body ceiling; over it → 413 payload_too_large
+  maxBodyBytes = ${?VERIFY_MAX_BODY_BYTES}
+  maxResourceLength = 512       # characters in `resource`
+  maxResourceLength = ${?VERIFY_MAX_RESOURCE_LENGTH}
+  maxActionLength = 64          # characters in `action`
+  maxActionLength = ${?VERIFY_MAX_ACTION_LENGTH}
+  maxContextEntries = 64        # properties + array elements in `context`, at every depth
+  maxContextEntries = ${?VERIFY_MAX_CONTEXT_ENTRIES}
+  maxContextValueLength = 1024  # characters in any `context` string, keys included
+  maxContextValueLength = ${?VERIFY_MAX_CONTEXT_VALUE_LENGTH}
 }
 ```
+
+### Request Limits
+
+Every input a caller controls is bounded, and each bound is one of the knobs above. `maxBodyBytes`
+is the outer envelope — `express.json()`'s limit, below Express's unstated 100 KB default — and it
+is what binds first on a large batch, since the per-field limits bound *one* entry rather than N of
+them. `maxContextEntries` counts every property and every array element in the whole `context`
+tree, so nesting is bounded rather than forbidden (`RequestContextAttributeCollector` reads dot
+paths such as `tenant.id`); because each level of nesting costs at least one entry, it bounds the
+depth too.
+
+Three refusals are worth stating outright:
+
+- **Whitespace in `resource` or `action` is refused, not trimmed** — the doctrine the resource
+  grammar already applies, extended to `action` and to a deployment that registered its own parser.
+  Both are concatenated into the `{action}:{resourceType}` scope an issuer has to have granted, and
+  RFC 6749 §3.3 makes space the delimiter between scope values.
+- **Unknown properties are refused** — `{"resource": "project:1", "action": "read", "subject": "admin"}`
+  is `400 invalid_request` rather than a decision with the `subject` quietly ignored. The subject
+  comes from the verified token and never from the body; refusing is how a caller finds that out.
+- **The body is validated before the token is verified**, so a malformed request is `400` whether or
+  not a token was presented. The body checks are bounded by the limits above, while verifying a
+  token is the half that can reach the network. An anonymous caller therefore learns whether a body
+  was well-formed; `http.callerAuth` is the gate for a deployment that must not disclose even that.
+
+A body the parser itself refuses answers the same deny envelope as everything else — the endpoint
+never falls back to Express's HTML error page:
+
+```json
+{"decision": "deny", "code": "invalid_request", "message": "Request body is not valid JSON"}
+```
+
+That is `400` for malformed JSON, `413 payload_too_large` over `maxBodyBytes`, and
+`415 unsupported_media_type` for a content type or charset it cannot read. The example above is the
+response body verbatim; `verifyInputValidation.test.mts` asserts that this exact line appears in
+`README.md`, `README.ja.md` and `CHANGELOG.md` and parses to what the endpoint emits, so the three
+copies cannot drift from the code or from each other.
 
 ### Resource String Format (DotNotation)
 

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -645,12 +645,17 @@ describe("POST /verify — resource the parser refuses (#117)", () => {
 		expect(res.body.code).toBe("internal_error");
 	});
 
-	it("rejects an unauthenticated request before parsing the resource", async () => {
-		// 401 outranks 400: an anonymous caller learns nothing about the grammar.
+	it("refuses the resource before authenticating (#118)", async () => {
+		// BREAKING in #118, and the reverse of what this pinned before: 400 now
+		// outranks 401, because the body checks are bounded while verifying the
+		// token is the half that can reach the network. The cost is that an
+		// anonymous caller learns the grammar refused their string;
+		// `http.callerAuth` is the gate for a deployment that must not disclose
+		// even that. See the ordering paragraph on `createVerifyRouter`.
 		const res = await request(app).post("/verify").send({ resource: "a..b", action: "read" });
 
-		expect(res.status).toBe(401);
-		expect(res.body.code).toBe("missing_token");
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
 	});
 });
 
@@ -945,11 +950,26 @@ describe("POST /verify — decision contract (#124)", () => {
 	it("never takes the subject from the request body", async () => {
 		// The token is the only authority on who is asking; accepting a body-supplied
 		// subject would let any token holder ask for a decision about anyone else.
+		// Since #118 the request is refused rather than silently stripped — a caller
+		// that sent one was being told nothing while believing it had been honoured.
 		const token = await signHS256Token({ sub: "user-1", scope: "read:project" });
 		const res = await request(app)
 			.post("/verify")
 			.set("Authorization", `Bearer ${token}`)
 			.send({ resource: "project:1", action: "read", subject: "admin" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+		expect(res.body.message).toContain("subject");
+		expect(res.body.subject).toBeUndefined();
+	});
+
+	it("answers with the token's subject, never one the body could have named", async () => {
+		const token = await signHS256Token({ sub: "user-1", scope: "read:project" });
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
 
 		expect(res.body.subject).toBe("user-1");
 	});

--- a/packages/server/src/__tests__/verifyInputValidation.test.mts
+++ b/packages/server/src/__tests__/verifyInputValidation.test.mts
@@ -1,0 +1,677 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Request validation on the decision endpoints (#118).
+ *
+ * Three things are pinned here, and #125 will pin them again from the outside:
+ *
+ * 1. Every input a caller controls is bounded by a stated limit — body bytes,
+ *    `resource` and `action` length, and the shape of `context` — and each
+ *    limit is an operator knob read through `resolveBound` at both boundaries.
+ * 2. The body is validated BEFORE the token is verified, so a malformed
+ *    unauthenticated request is answered 400 rather than 401.
+ * 3. A body-parser failure answers the deny envelope, not Express's HTML page.
+ */
+
+import { readFileSync } from "node:fs";
+import {
+	DotNotationResourceParser,
+	PayloadScopeCollector,
+	ResourceActionScopeRuleCollector,
+} from "@o3co/auth.policy-verifier.builtins";
+import {
+	type AttributeCollector,
+	AttributePipeline,
+	type CollectorContext,
+	RulePipeline,
+	readUntrustedRequestContext,
+} from "@o3co/auth.policy-verifier.core";
+import express from "express";
+import { SignJWT } from "jose";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { AppConfigSchema } from "#/config/application.schema.mjs";
+import {
+	DEFAULT_MAX_ACTION_LENGTH,
+	DEFAULT_MAX_BODY_BYTES,
+	DEFAULT_MAX_CONTEXT_ENTRIES,
+	DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+	DEFAULT_MAX_RESOURCE_LENGTH,
+} from "#/config/defaults.mjs";
+import { HS256KeyResolverFactory } from "#/jwt/index.mjs";
+import { createVerifyRouter, type VerifyRouterConfig } from "#/routes/verify.mjs";
+
+/**
+ * The deny envelope exactly as `README.md`, `README.ja.md` and `CHANGELOG.md`
+ * print it for a body the parser refuses. One literal, checked against the
+ * route's own answer and against all three files — see the last describe.
+ */
+const DOCUMENTED_DENY_ENVELOPE =
+	'{"decision": "deny", "code": "invalid_request", "message": "Request body is not valid JSON"}';
+
+/** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
+const JWT_SECRET = "11".repeat(32);
+const hs256Key = await HS256KeyResolverFactory({ secret: JWT_SECRET });
+
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "https://api.test";
+
+async function signToken(payload: Record<string, unknown> = { scope: "read:project" }) {
+	return new SignJWT(payload)
+		.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+		.setIssuedAt()
+		.setExpirationTime("1h")
+		.setIssuer(ISSUER)
+		.setAudience(AUDIENCE)
+		.sign(hs256Key.key as import("node:crypto").KeyObject);
+}
+
+function createTestApp(overrides: Partial<VerifyRouterConfig> = {}) {
+	const app = express();
+	app.use(
+		createVerifyRouter({
+			jwt: {
+				validate: true,
+				key: hs256Key.key,
+				algorithms: hs256Key.algorithms,
+				issuer: ISSUER,
+				audience: AUDIENCE,
+				tokenType: "at+jwt",
+			},
+			resourceParser: new DotNotationResourceParser(),
+			attributePipeline: new AttributePipeline([new PayloadScopeCollector()]),
+			rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+			...overrides,
+		}),
+	);
+	return app;
+}
+
+const app = createTestApp();
+
+async function post(body: unknown, target = "/verify") {
+	const token = await signToken();
+	return request(app)
+		.post(target)
+		.set("Authorization", `Bearer ${token}`)
+		.send(body as object);
+}
+
+describe("POST /verify — bounded resource and action (#118)", () => {
+	it("accepts a resource at exactly the limit", async () => {
+		// `a`.repeat(N) is one segment of N type characters — inside the
+		// DotNotation grammar, so only the length bound is under test.
+		const res = await post({ resource: "a".repeat(DEFAULT_MAX_RESOURCE_LENGTH), action: "read" });
+		expect(res.status).not.toBe(400);
+	});
+
+	it("returns 400 for a resource one character over the limit", async () => {
+		const res = await post({
+			resource: "a".repeat(DEFAULT_MAX_RESOURCE_LENGTH + 1),
+			action: "read",
+		});
+
+		expect(res.status).toBe(400);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("invalid_request");
+		expect(res.body.message).toContain(String(DEFAULT_MAX_RESOURCE_LENGTH));
+	});
+
+	it("accepts an action at exactly the limit", async () => {
+		const res = await post({
+			resource: "project:1",
+			action: "r".repeat(DEFAULT_MAX_ACTION_LENGTH),
+		});
+		expect(res.status).not.toBe(400);
+	});
+
+	it("returns 400 for an action one character over the limit", async () => {
+		const res = await post({
+			resource: "project:1",
+			action: "r".repeat(DEFAULT_MAX_ACTION_LENGTH + 1),
+		});
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+		expect(res.body.message).toContain(String(DEFAULT_MAX_ACTION_LENGTH));
+	});
+
+	it("honours a configured resource length", async () => {
+		const tight = createTestApp({ maxResourceLength: 8 });
+		const token = await signToken();
+		const res = await request(tight)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.message).toContain("8");
+	});
+});
+
+describe("POST /verify — whitespace is refused, not trimmed (#118)", () => {
+	// The same doctrine `DotNotationResourceParser` applies to `resource`
+	// (#117), applied at the schema layer so it also holds for `action` and for
+	// a deployment that registered its own parser.
+	const whitespace = ["   ", " project:1", "project:1 ", "project\t:1", "project\n:1"];
+
+	for (const resource of whitespace) {
+		it(`returns 400 for a resource containing whitespace: ${JSON.stringify(resource)}`, async () => {
+			const res = await post({ resource, action: "read" });
+
+			expect(res.status).toBe(400);
+			expect(res.body.decision).toBe("deny");
+			expect(res.body.code).toBe("invalid_request");
+			expect(res.body.message).toContain("whitespace");
+		});
+	}
+
+	for (const action of ["   ", " read", "read ", "read all"]) {
+		it(`returns 400 for an action containing whitespace: ${JSON.stringify(action)}`, async () => {
+			const res = await post({ resource: "project:1", action });
+
+			expect(res.status).toBe(400);
+			expect(res.body.code).toBe("invalid_request");
+			expect(res.body.message).toContain("whitespace");
+		});
+	}
+
+	it("names the field rather than echoing the value", async () => {
+		const res = await post({ resource: "  project:1  ", action: "read" });
+		expect(res.body.message).toContain("body.resource");
+		expect(res.body.message).not.toContain("project:1");
+	});
+});
+
+describe("POST /verify — bounded context (#118)", () => {
+	it("accepts a context at exactly the entry limit", async () => {
+		const context = Object.fromEntries(
+			Array.from({ length: DEFAULT_MAX_CONTEXT_ENTRIES }, (_, i) => [`k${i}`, "v"]),
+		);
+		const res = await post({ resource: "project:1", action: "read", context });
+		expect(res.status).not.toBe(400);
+	});
+
+	it("returns 400 one entry over the limit", async () => {
+		const context = Object.fromEntries(
+			Array.from({ length: DEFAULT_MAX_CONTEXT_ENTRIES + 1 }, (_, i) => [`k${i}`, "v"]),
+		);
+		const res = await post({ resource: "project:1", action: "read", context });
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+		expect(res.body.message).toContain(String(DEFAULT_MAX_CONTEXT_ENTRIES));
+	});
+
+	it("counts nested properties and array elements, not just top-level keys", async () => {
+		// Nesting is a supported shape — `RequestContextAttributeCollector` reads
+		// dot paths — so it is counted rather than forbidden. Six entries here:
+		// `a`, `b`, `c`, and the three array elements.
+		const tight = createTestApp({ maxContextEntries: 5 });
+		const token = await signToken();
+		const res = await request(tight)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({
+				resource: "project:1",
+				action: "read",
+				context: { a: { b: { c: [1, 2, 3] } } },
+			});
+
+		expect(res.status).toBe(400);
+		expect(res.body.message).toContain("5");
+	});
+
+	it("still admits a nested context inside the bound", async () => {
+		const seen: Array<Record<string, unknown> | undefined> = [];
+		const recording: AttributeCollector = {
+			async collect(context: CollectorContext) {
+				seen.push(readUntrustedRequestContext(context.requestContext));
+				return new Map();
+			},
+		};
+		const nestedApp = createTestApp({
+			attributePipeline: new AttributePipeline([new PayloadScopeCollector(), recording]),
+		});
+		const token = await signToken();
+		const res = await request(nestedApp)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({
+				resource: "project:1",
+				action: "read",
+				context: { tenant: { id: "acme" }, groups: ["a", "b"] },
+			});
+
+		expect(res.status).toBe(200);
+		expect(seen[0]).toEqual({ tenant: { id: "acme" }, groups: ["a", "b"] });
+	});
+
+	it("returns 400 for a context string over the value limit", async () => {
+		const res = await post({
+			resource: "project:1",
+			action: "read",
+			context: { blob: "x".repeat(DEFAULT_MAX_CONTEXT_VALUE_LENGTH + 1) },
+		});
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+		expect(res.body.message).toContain(String(DEFAULT_MAX_CONTEXT_VALUE_LENGTH));
+	});
+
+	it("bounds a nested string and a property name the same way", async () => {
+		const long = "x".repeat(DEFAULT_MAX_CONTEXT_VALUE_LENGTH + 1);
+		const nested = await post({
+			resource: "project:1",
+			action: "read",
+			context: { outer: { inner: long } },
+		});
+		expect(nested.status).toBe(400);
+
+		const key = await post({
+			resource: "project:1",
+			action: "read",
+			context: { [long]: "v" },
+		});
+		expect(key.status).toBe(400);
+	});
+});
+
+describe("POST /verify — unknown properties are refused (#118)", () => {
+	/**
+	 * The rendering bound `describeUnknownKeys` documents: at most 32 characters
+	 * per name, the ellipsis included. Stated here as a literal rather than
+	 * imported, so the test fails if the implementation's own constant moves.
+	 */
+	const MAX_RENDERED_KEY_LENGTH = 32;
+
+	it("truncates a long property name to exactly the documented length", async () => {
+		// The error path of a change about explicit limits must not overrun its
+		// own stated limit: `slice(0, 32)` plus an ellipsis rendered 33.
+		const expected = `${"a".repeat(MAX_RENDERED_KEY_LENGTH - 1)}…`;
+		expect(expected).toHaveLength(MAX_RENDERED_KEY_LENGTH);
+
+		const res = await post({
+			resource: "project:1",
+			action: "read",
+			[`a`.repeat(200)]: "v",
+		});
+
+		expect(res.status).toBe(400);
+		// Quoted through JSON.stringify, so the two quotes sit outside the bound.
+		expect(res.body.message).toContain(JSON.stringify(expected));
+	});
+
+	it("leaves a name at exactly the limit untruncated", async () => {
+		const name = "b".repeat(MAX_RENDERED_KEY_LENGTH);
+		const res = await post({ resource: "project:1", action: "read", [name]: "v" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.message).toContain(JSON.stringify(name));
+		expect(res.body.message).not.toContain('…"');
+	});
+
+	it("names at most three unknown properties and says there were more", async () => {
+		const res = await post({
+			resource: "project:1",
+			action: "read",
+			one: 1,
+			two: 2,
+			three: 3,
+			four: 4,
+		});
+
+		expect(res.status).toBe(400);
+		expect(res.body.message).toContain('"one", "two", "three", …');
+		expect(res.body.message).not.toContain("four");
+	});
+
+	it("returns 400 rather than silently ignoring a body-supplied subject", async () => {
+		// Ignoring it left a caller believing it had been honoured. The subject
+		// still comes only from the token; refusing is how the caller finds out.
+		const res = await post({ resource: "project:1", action: "read", subject: "admin" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+		expect(res.body.message).toContain("subject");
+	});
+
+	it("returns 400 for an unknown property on a batch entry, naming the index", async () => {
+		const res = await post(
+			{
+				decisions: [
+					{ resource: "project:1", action: "read" },
+					{ resource: "project:2", action: "read", tenant: "acme" },
+				],
+			},
+			"/verify/batch",
+		);
+
+		expect(res.status).toBe(400);
+		expect(res.body.message).toContain("decisions[1]");
+		expect(res.body.message).toContain("tenant");
+	});
+
+	it("returns 400 for an unknown property beside decisions", async () => {
+		const res = await post(
+			{ decisions: [{ resource: "project:1", action: "read" }], parallel: true },
+			"/verify/batch",
+		);
+
+		expect(res.status).toBe(400);
+		expect(res.body.message).toContain("parallel");
+	});
+});
+
+describe("POST /verify — body validation runs before authentication (#118)", () => {
+	/*
+	 * BREAKING, and the point of the change: a malformed body is answered 400
+	 * whether or not a token was presented. Verifying the token first let an
+	 * unauthenticated caller drive the expensive half of the request — an
+	 * attacker-chosen `kid` can send the RS256 path to the network, and an
+	 * HS256 rotation tries every configured secret — on a body that was never
+	 * usable. What runs first now is bounded by the limits above.
+	 */
+
+	it("answers 400 for a malformed body with no token at all", async () => {
+		const res = await request(app).post("/verify").send({ resource: "project:1" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("invalid_request");
+	});
+
+	it("answers 400 for a malformed body with a token that would not verify", async () => {
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", "Bearer not.a.token")
+			.send({ resource: "  ", action: "read" });
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+	});
+
+	it("still answers 401 when the body is well-formed and the token is not", async () => {
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", "Bearer not.a.token")
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("invalid_token");
+	});
+
+	it("still answers 401 for a well-formed body with no token", async () => {
+		const res = await request(app).post("/verify").send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(401);
+		expect(res.body.code).toBe("missing_token");
+	});
+
+	it("answers 400 for a malformed batch with no token", async () => {
+		const res = await request(app).post("/verify/batch").send({ decisions: [] });
+
+		expect(res.status).toBe(400);
+		expect(res.body.code).toBe("invalid_request");
+	});
+
+	it("never runs the pipelines for a request refused on its body", async () => {
+		let collected = 0;
+		const counting: AttributeCollector = {
+			async collect() {
+				collected += 1;
+				return new Map();
+			},
+		};
+		const countingApp = createTestApp({
+			attributePipeline: new AttributePipeline([counting]),
+		});
+
+		await request(countingApp).post("/verify").send({ resource: "project:1" });
+		expect(collected).toBe(0);
+	});
+});
+
+describe("POST /verify — body-parser failures answer the deny envelope (#118, #126 item 6)", () => {
+	it("answers 400 invalid_request for malformed JSON, not Express's HTML page", async () => {
+		const token = await signToken();
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.set("Content-Type", "application/json")
+			.send('{"resource": "project:1", ');
+
+		expect(res.status).toBe(400);
+		expect(res.type).toBe("application/json");
+		expect(res.body).toEqual(JSON.parse(DOCUMENTED_DENY_ENVELOPE));
+	});
+
+	it("answers 413 payload_too_large for a body over the byte limit", async () => {
+		const token = await signToken();
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.set("Content-Type", "application/json")
+			.send(
+				JSON.stringify({
+					resource: "project:1",
+					action: "read",
+					context: { blob: "x".repeat(DEFAULT_MAX_BODY_BYTES) },
+				}),
+			);
+
+		expect(res.status).toBe(413);
+		expect(res.type).toBe("application/json");
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("payload_too_large");
+	});
+
+	it("honours a configured body limit", async () => {
+		const tight = createTestApp({ maxBodyBytes: 128 });
+		const token = await signToken();
+		const res = await request(tight)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.set("Content-Type", "application/json")
+			.send(
+				JSON.stringify({ resource: "project:1", action: "read", context: { b: "x".repeat(200) } }),
+			);
+
+		expect(res.status).toBe(413);
+		expect(res.body.code).toBe("payload_too_large");
+	});
+
+	it("answers 415 unsupported_media_type for an unreadable charset", async () => {
+		const token = await signToken();
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.set("Content-Type", "application/json; charset=iso-8859-1")
+			.send('{"resource":"project:1","action":"read"}');
+
+		expect(res.status).toBe(415);
+		expect(res.type).toBe("application/json");
+		expect(res.body.code).toBe("unsupported_media_type");
+	});
+
+	it("answers the deny envelope for a body sent as text/plain", async () => {
+		// `express.json` skips a non-JSON content type, so the body never
+		// becomes an object — a malformed request, answered as one.
+		const token = await signToken();
+		const res = await request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.set("Content-Type", "text/plain")
+			.send("resource=project:1");
+
+		expect(res.status).toBe(400);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("invalid_request");
+	});
+
+	it("never echoes the offending body back to the caller", async () => {
+		const res = await request(app)
+			.post("/verify")
+			.set("Content-Type", "application/json")
+			.send('{"totally-secret-key": ');
+
+		expect(JSON.stringify(res.body)).not.toContain("totally-secret-key");
+	});
+});
+
+describe("the documented deny envelope is the one the endpoint emits (#118, #125)", () => {
+	/*
+	 * The envelope is a BREAKING wire-contract change, and these three files are
+	 * what a client author implements against — the first version of this prose
+	 * carried `{"decision": "deny", "code", "message"}`, which is not JSON at
+	 * all. Three hand-written copies of a shape is the drift this repo has been
+	 * bitten by before, so the copies are pinned here rather than trusted: one
+	 * literal, asserted to be valid JSON, to equal what the route actually
+	 * answers, and to appear verbatim in every file that documents it.
+	 *
+	 * #125 will pin the same contract from outside the repo. Both should be
+	 * describing this object.
+	 */
+	const documentedIn = ["README.md", "README.ja.md", "CHANGELOG.md"] as const;
+
+	/** Repo root, four levels up from `packages/server/src/__tests__`. */
+	const repoRoot = new URL("../../../../", import.meta.url);
+
+	it("is valid JSON", () => {
+		expect(() => JSON.parse(DOCUMENTED_DENY_ENVELOPE)).not.toThrow();
+		expect(JSON.parse(DOCUMENTED_DENY_ENVELOPE)).toEqual({
+			decision: "deny",
+			code: "invalid_request",
+			message: "Request body is not valid JSON",
+		});
+	});
+
+	it.each(documentedIn)("appears verbatim in %s", (file) => {
+		const content = readFileSync(new URL(file, repoRoot), "utf8");
+		expect(content).toContain(DOCUMENTED_DENY_ENVELOPE);
+	});
+
+	it("carries no stale copy of the malformed shape", () => {
+		for (const file of documentedIn) {
+			const content = readFileSync(new URL(file, repoRoot), "utf8");
+			expect(content).not.toContain('"code", "message"');
+		}
+	});
+
+	/*
+	 * The other half of the same drift: the READMEs print a `verify { … }` HOCON
+	 * block, and a default stated there that the code does not apply is a
+	 * config example that lies. The shipped `templates/standalone/config/
+	 * application.conf` is already parsed and asserted by that package's
+	 * `loadConfig` tests, so pinning the READMEs here closes the chain
+	 * docs → shipped config → code.
+	 *
+	 * A regex rather than a HOCON parse: `packages/server` has no HOCON
+	 * dependency and should not grow one to check prose, and the shape at risk
+	 * is the number, not the syntax.
+	 */
+	const documentedDefaults = [
+		["maxBodyBytes", DEFAULT_MAX_BODY_BYTES],
+		["maxResourceLength", DEFAULT_MAX_RESOURCE_LENGTH],
+		["maxActionLength", DEFAULT_MAX_ACTION_LENGTH],
+		["maxContextEntries", DEFAULT_MAX_CONTEXT_ENTRIES],
+		["maxContextValueLength", DEFAULT_MAX_CONTEXT_VALUE_LENGTH],
+	] as const;
+
+	it.each(["README.md", "README.ja.md"])("states this package's defaults in %s", (file) => {
+		const content = readFileSync(new URL(file, repoRoot), "utf8");
+		for (const [key, value] of documentedDefaults) {
+			expect(content).toMatch(new RegExp(`^\\s*${key} = ${value}\\s*(#|$)`, "m"));
+		}
+	});
+});
+
+describe("createVerifyRouter — the input limits at both boundaries (#118, #157)", () => {
+	// Each new limit is a numeric knob, so it goes through `resolveBound` at the
+	// router and through `boundedNumber` in the schema — one reader, one wording.
+	// See AGENTS.md, "Two-Boundary Config Validation".
+	const knobs = [
+		"maxBodyBytes",
+		"maxResourceLength",
+		"maxActionLength",
+		"maxContextEntries",
+		"maxContextValueLength",
+	] as const;
+
+	const refusal = (act: () => unknown): string | undefined => {
+		try {
+			act();
+			return undefined;
+		} catch (cause) {
+			return (cause as Error).message;
+		}
+	};
+
+	const routerRefusal = (knob: string, value: unknown) =>
+		refusal(() => createTestApp({ [knob]: value } as Partial<VerifyRouterConfig>));
+
+	const schemaRefusal = (knob: string, value: unknown): string | undefined => {
+		const result = AppConfigSchema.safeParse({
+			oauth: {
+				jwt: {
+					algorithm: "HS256",
+					secret: JWT_SECRET,
+					mode: "verify",
+					issuer: ISSUER,
+					audience: AUDIENCE,
+				},
+			},
+			attribute: { collectors: [] },
+			rule: { collectors: [] },
+			verify: { [knob]: value },
+		});
+		return result.success
+			? undefined
+			: result.error.issues.find((issue) => issue.path.at(-1) === knob)?.message;
+	};
+
+	for (const knob of knobs) {
+		it.each([
+			["zero", 0],
+			["a negative value", -1],
+			["a fractional value", 1.5],
+			["true", true],
+			["null", null],
+			["an empty string", ""],
+			["a non-numeric string", "abc"],
+		])(`refuses ${knob} = %s in the schema's wording`, (_label, value) => {
+			const fromRouter = routerRefusal(knob, value);
+			expect(fromRouter).toBeDefined();
+			expect(schemaRefusal(knob, value)).toBe(fromRouter);
+		});
+
+		it(`takes the string form for ${knob}`, () => {
+			expect(routerRefusal(knob, "16")).toBeUndefined();
+		});
+	}
+
+	it("defaults every limit when the block is absent", () => {
+		const parsed = AppConfigSchema.parse({
+			oauth: {
+				jwt: {
+					algorithm: "HS256",
+					secret: JWT_SECRET,
+					mode: "verify",
+					issuer: ISSUER,
+					audience: AUDIENCE,
+				},
+			},
+			attribute: { collectors: [] },
+			rule: { collectors: [] },
+		});
+
+		expect(parsed.verify).toMatchObject({
+			maxBodyBytes: DEFAULT_MAX_BODY_BYTES,
+			maxResourceLength: DEFAULT_MAX_RESOURCE_LENGTH,
+			maxActionLength: DEFAULT_MAX_ACTION_LENGTH,
+			maxContextEntries: DEFAULT_MAX_CONTEXT_ENTRIES,
+			maxContextValueLength: DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+		});
+	});
+});

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -260,6 +260,14 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 			rulePipeline: new RulePipeline(ruleCollectors),
 			evaluateOptions: { onEmptyRuleSet: config.rule.onEmptyRuleSet },
 			maxBatchSize: config.verify.maxBatchSize,
+			// Forwarded rather than defaulted here (#118): the router resolves each
+			// through the same `resolveBound` the schema used, so a hand-built config
+			// reaching `createApp` gets the schema's verdict either way.
+			maxBodyBytes: config.verify.maxBodyBytes,
+			maxResourceLength: config.verify.maxResourceLength,
+			maxActionLength: config.verify.maxActionLength,
+			maxContextEntries: config.verify.maxContextEntries,
+			maxContextValueLength: config.verify.maxContextValueLength,
 		}),
 	);
 

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -9,7 +9,12 @@ import {
 	DEFAULT_CALLER_AUTH_HEADER,
 	DEFAULT_HOSTNAME,
 	DEFAULT_HTTP_PORT,
+	DEFAULT_MAX_ACTION_LENGTH,
 	DEFAULT_MAX_BATCH_SIZE,
+	DEFAULT_MAX_BODY_BYTES,
+	DEFAULT_MAX_CONTEXT_ENTRIES,
+	DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+	DEFAULT_MAX_RESOURCE_LENGTH,
 } from "./defaults.mjs";
 
 /**
@@ -411,10 +416,30 @@ export const AppConfigSchema = z.object({
 			// request from turning into an unbounded amount of pipeline work.
 			// `createVerifyRouter` holds a hand-built config to the same bound (#157).
 			maxBatchSize: boundedNumber(NUMERIC_BOUNDS.maxBatchSize, "verify"),
+			/*
+			 * What one decision request may carry (#118). The endpoint used to
+			 * rely on Express's unstated 100 KB default and on "non-empty string",
+			 * so a whitespace-only resource, an arbitrarily wide `context` and
+			 * unknown properties all passed. Each limit is stated here, defaulted
+			 * in `config/defaults.mts`, and held by `createVerifyRouter` through
+			 * the same `resolveBound` for hand-built configs.
+			 */
+			maxBodyBytes: boundedNumber(NUMERIC_BOUNDS.maxBodyBytes, "verify"),
+			maxResourceLength: boundedNumber(NUMERIC_BOUNDS.maxResourceLength, "verify"),
+			maxActionLength: boundedNumber(NUMERIC_BOUNDS.maxActionLength, "verify"),
+			maxContextEntries: boundedNumber(NUMERIC_BOUNDS.maxContextEntries, "verify"),
+			maxContextValueLength: boundedNumber(NUMERIC_BOUNDS.maxContextValueLength, "verify"),
 		})
 		// Taken verbatim, like `http` above — zod does not parse a default back
-		// through the shape, so the key has to be stated here as well.
-		.default(() => ({ maxBatchSize: DEFAULT_MAX_BATCH_SIZE })),
+		// through the shape, so every key has to be stated here as well.
+		.default(() => ({
+			maxBatchSize: DEFAULT_MAX_BATCH_SIZE,
+			maxBodyBytes: DEFAULT_MAX_BODY_BYTES,
+			maxResourceLength: DEFAULT_MAX_RESOURCE_LENGTH,
+			maxActionLength: DEFAULT_MAX_ACTION_LENGTH,
+			maxContextEntries: DEFAULT_MAX_CONTEXT_ENTRIES,
+			maxContextValueLength: DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+		})),
 	// Defaulted (not shape-only): deployments mount an overlay config OVER the
 	// template's application.conf, so a section the overlay does not repeat is
 	// simply absent. `silent` is a threshold, not a level anything emits at.

--- a/packages/server/src/config/bounds.mts
+++ b/packages/server/src/config/bounds.mts
@@ -39,7 +39,12 @@ import {
 	DEFAULT_JWKS_CACHE_MAX_AGE_MS,
 	DEFAULT_JWKS_COOLDOWN_MS,
 	DEFAULT_JWKS_TIMEOUT_MS,
+	DEFAULT_MAX_ACTION_LENGTH,
 	DEFAULT_MAX_BATCH_SIZE,
+	DEFAULT_MAX_BODY_BYTES,
+	DEFAULT_MAX_CONTEXT_ENTRIES,
+	DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+	DEFAULT_MAX_RESOURCE_LENGTH,
 	DEFAULT_MAX_TOKEN_AGE_SECONDS,
 	MAX_CLOCK_TOLERANCE_SECONDS,
 	MAX_TCP_PORT,
@@ -137,6 +142,47 @@ export const NUMERIC_BOUNDS = {
 		fallback: DEFAULT_MAX_BATCH_SIZE,
 		minimum: 1,
 		unit: "entries",
+	},
+	/*
+	 * What one decision request may carry (#118). Each is a floor of 1 and no
+	 * ceiling: raising one is an operator's explicit statement about their own
+	 * callers, while `Infinity` and the non-integers are refused here as they
+	 * are for every other knob — an unstated size is exactly what these replace.
+	 */
+	/** Cap on the JSON body `express.json()` will read. */
+	maxBodyBytes: {
+		field: "maxBodyBytes",
+		fallback: DEFAULT_MAX_BODY_BYTES,
+		minimum: 1,
+		unit: "bytes",
+	},
+	/** Cap on the `resource` string. */
+	maxResourceLength: {
+		field: "maxResourceLength",
+		fallback: DEFAULT_MAX_RESOURCE_LENGTH,
+		minimum: 1,
+		unit: "characters",
+	},
+	/** Cap on the `action` string. */
+	maxActionLength: {
+		field: "maxActionLength",
+		fallback: DEFAULT_MAX_ACTION_LENGTH,
+		minimum: 1,
+		unit: "characters",
+	},
+	/** Cap on the properties and array elements in the whole `context` tree. */
+	maxContextEntries: {
+		field: "maxContextEntries",
+		fallback: DEFAULT_MAX_CONTEXT_ENTRIES,
+		minimum: 1,
+		unit: "entries",
+	},
+	/** Cap on every string in the `context` tree, keys included. */
+	maxContextValueLength: {
+		field: "maxContextValueLength",
+		fallback: DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+		minimum: 1,
+		unit: "characters",
 	},
 } satisfies Record<string, BoundSpec>;
 

--- a/packages/server/src/config/defaults.mts
+++ b/packages/server/src/config/defaults.mts
@@ -17,6 +17,80 @@
 export const DEFAULT_MAX_BATCH_SIZE = 50;
 
 /*
+ * Bounds on what one `/verify` request may carry (#118).
+ *
+ * Before these, the endpoint relied on Express's default 100 KB JSON limit and
+ * checked only that `resource` and `action` were non-empty strings: a
+ * whitespace-only resource passed, `context` could be arbitrarily wide and
+ * deep, and unknown properties rode along silently. Every one of them is an
+ * input a caller chooses, and none of them had a stated size.
+ *
+ * They are numeric knobs like every other, read through `resolveBound` at both
+ * boundaries (#157). The values below are deliberately generous for a real
+ * caller and small for a prober: `resource` and `action` are structural
+ * identifiers, not free text, and `context` is a handful of declared fields a
+ * collector was configured to promote.
+ */
+
+/**
+ * Ceiling on the JSON body `POST /verify` and `POST /verify/batch` will read,
+ * in bytes — the `limit` handed to `express.json()`.
+ *
+ * 64 KiB, which is below Express's unstated 100 KB default and therefore a
+ * tightening: a body over it is refused by the parser before any of it is held
+ * in memory as objects. This is the outer envelope, and it is the bound that
+ * binds first on a large batch — the per-field limits below say what *one*
+ * entry may carry, not what N of them add up to. A deployment sending wide
+ * contexts across a full 50-entry batch raises this knob.
+ */
+export const DEFAULT_MAX_BODY_BYTES = 65_536;
+
+/**
+ * Ceiling on the `resource` string, in characters.
+ *
+ * Generous for the identifiers the shipped grammar describes
+ * (`org:123.project:abc.document:42` is 31 characters) and for a percent-encoded
+ * id, while still bounding what the configured `ResourceParser` — which the
+ * router now runs before the token is verified — is handed.
+ */
+export const DEFAULT_MAX_RESOURCE_LENGTH = 512;
+
+/**
+ * Ceiling on the `action` string, in characters.
+ *
+ * Shorter than `resource` because an action is a verb, not a path: `read`,
+ * `write`, `admin:manage`. It is also concatenated into the
+ * `{action}:{resourceType}` scope `ResourceActionScopeRuleCollector` requires,
+ * so a long one names a scope no issuer could grant.
+ */
+export const DEFAULT_MAX_ACTION_LENGTH = 64;
+
+/**
+ * Ceiling on the size of the request `context`, counted as every property and
+ * every array element in the whole tree, at every depth.
+ *
+ * Counted over the tree rather than over the top-level keys because nesting is
+ * a supported shape — `RequestContextAttributeCollector` reads dot paths such
+ * as `tenant.id` — so forbidding it would break a documented feature while
+ * bounding only the shallowest measure of size.
+ *
+ * It is also what bounds the *depth*: each level of nesting costs at least one
+ * entry, so a context inside this bound can be at most this deep, and no
+ * separate depth knob is needed to keep the validating walk finite.
+ */
+export const DEFAULT_MAX_CONTEXT_ENTRIES = 64;
+
+/**
+ * Ceiling on every string inside `context`, in characters — property names and
+ * string values alike.
+ *
+ * A collector reads declared fields out of `requestContext` and promotes them
+ * into attributes that rules compare; a kilobyte is far more than any such
+ * field is, and a value larger than that is a payload rather than an attribute.
+ */
+export const DEFAULT_MAX_CONTEXT_VALUE_LENGTH = 1_024;
+
+/*
  * Bounds on the remote JWKS fetch (#109). A key resolution that misses the
  * cache happens inside a verify request, so an unbounded fetch is a stall
  * vector on the decision hot path: every caller of a deployment whose provider

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -44,6 +44,33 @@ export interface VerifyRouterConfig {
 	 */
 	maxBatchSize?: number | string;
 	/**
+	 * Ceiling on the JSON body, in bytes — the `limit` handed to
+	 * `express.json()`. Defaults to 64 KiB (`DEFAULT_MAX_BODY_BYTES`), below
+	 * Express's unstated 100 KB default, and is the outer envelope: it is what
+	 * binds first on a large batch, since the per-field limits below bound one
+	 * entry rather than N of them.
+	 *
+	 * This and the four limits after it are held to the same bounds
+	 * `AppConfigSchema` holds `verify.*` to (#118, #157), and admit the string
+	 * form for the same reason `maxBatchSize` does.
+	 */
+	maxBodyBytes?: number | string;
+	/** Ceiling on the `resource` string, in characters. Defaults to 512. */
+	maxResourceLength?: number | string;
+	/** Ceiling on the `action` string, in characters. Defaults to 64. */
+	maxActionLength?: number | string;
+	/**
+	 * Ceiling on the size of `context`, counted as every property and every
+	 * array element in the whole tree, at every depth. Defaults to 64, which
+	 * also bounds the depth — each level costs at least one entry.
+	 */
+	maxContextEntries?: number | string;
+	/**
+	 * Ceiling on every string inside `context`, property names included, in
+	 * characters. Defaults to 1024.
+	 */
+	maxContextValueLength?: number | string;
+	/**
 	 * Sink for the router's failure events (`jwt_token_rejected`,
 	 * `jwt_verification_unavailable`, `verify_internal_error`) and for the
 	 * per-decision `decision` audit line (#111). Defaults to the console-backed
@@ -124,6 +151,146 @@ type ParsedDecisionRequest =
 	| { ok: false; error: string };
 
 /**
+ * The bounds one decision request is held to (#118), resolved once at router
+ * construction. Body bytes are not here: that limit is spent by `express.json()`
+ * before a body is ever an object.
+ */
+interface RequestLimits {
+	maxResourceLength: number;
+	maxActionLength: number;
+	maxContextEntries: number;
+	maxContextValueLength: number;
+}
+
+/** Properties a decision request may carry. Anything else is refused (#118). */
+const DECISION_REQUEST_KEYS = new Set(["resource", "action", "context"]);
+
+/** How many unknown property names a refusal names before it stops listing them. */
+const MAX_RENDERED_KEYS = 3;
+
+/**
+ * Longest a rendered property name may be, the ellipsis that replaces the tail
+ * included — so a truncated name is exactly this long, never one character over.
+ */
+const MAX_RENDERED_KEY_LENGTH = 32;
+
+/**
+ * Renders unknown property names for an error message.
+ *
+ * The names are the caller's own text, so what reaches the response is bounded
+ * here rather than by whatever they sent: at most {@link MAX_RENDERED_KEYS}
+ * names, each at most {@link MAX_RENDERED_KEY_LENGTH} characters *including*
+ * the ellipsis that stands in for the tail. The truncation is stated that way,
+ * and spelled `MAX_RENDERED_KEY_LENGTH - 1`, because a bound whose own error
+ * path runs one character past what it documents is the shape this whole change
+ * is against.
+ *
+ * Quoting happens after: each name goes through `JSON.stringify`, so one
+ * carrying quotes or control characters cannot reshape the message. That adds
+ * the two quotes and any escape expansion on top of the length above — the
+ * bound is on the name, not on its JSON rendering, which is the only honest way
+ * to state it when a single character can escape to six.
+ */
+function describeUnknownKeys(keys: readonly string[]): string {
+	const shown = keys
+		.slice(0, MAX_RENDERED_KEYS)
+		.map((key) =>
+			JSON.stringify(
+				key.length > MAX_RENDERED_KEY_LENGTH
+					? `${key.slice(0, MAX_RENDERED_KEY_LENGTH - 1)}…`
+					: key,
+			),
+		);
+	return keys.length > shown.length ? `${shown.join(", ")}, …` : shown.join(", ");
+}
+
+/**
+ * Rejects a `resource` / `action` that is absent, empty, over its length bound,
+ * or carries whitespace. Returns the string once it is known to be one, so the
+ * caller reads a `string` rather than re-narrowing the `unknown` it passed in.
+ *
+ * **Whitespace is refused, not trimmed**, which is the doctrine
+ * `DotNotationResourceParser` already applies to `resource` (#117), applied here
+ * so it also covers `action` and a deployment that registered its own parser.
+ * Both strings are structural identifiers rather than free text: they are echoed
+ * back in the decision, and `ResourceActionScopeRuleCollector` concatenates them
+ * into the `{action}:{resourceType}` scope an issuer has to have granted — and
+ * RFC 6749 §3.3 makes space the delimiter between scope values, so a value
+ * carrying whitespace names something no issuer could grant. Trimming would
+ * instead make `"read "` and `"read"` one action here while a collector reading
+ * the raw string still saw two.
+ *
+ * The value is never echoed: the message names the field. These strings are
+ * chosen by the caller and end up in logs and pasted bug reports.
+ */
+function checkIdentifier(
+	value: unknown,
+	field: string,
+	label: string,
+	maxLength: number,
+): { ok: true; value: string } | { ok: false; error: string } {
+	if (typeof value !== "string" || value === "") {
+		return { ok: false, error: `${label}.${field} must be a non-empty string` };
+	}
+	if (value.length > maxLength) {
+		return {
+			ok: false,
+			error: `${label}.${field} must not be longer than ${maxLength} characters`,
+		};
+	}
+	if (/\s/.test(value)) {
+		return { ok: false, error: `${label}.${field} must not contain whitespace` };
+	}
+	return { ok: true, value };
+}
+
+/**
+ * Holds the caller's `context` to its size bounds, or explains which one it
+ * broke.
+ *
+ * Nesting is counted rather than forbidden: `RequestContextAttributeCollector`
+ * reads dot paths such as `tenant.id`, so a flat-only rule would break a
+ * documented feature. Every property and every array element counts, at every
+ * depth, which is also what keeps this walk finite — a context inside
+ * `maxContextEntries` can be at most that deep, so no separate depth bound is
+ * needed and the traversal is iterative regardless.
+ *
+ * Neither message echoes a key or a value. The whole object is caller-supplied,
+ * which is exactly why it is bounded, and a message that quoted part of it would
+ * hand the size back to the caller.
+ */
+function checkContext(
+	context: Record<string, unknown>,
+	label: string,
+	limits: RequestLimits,
+): string | undefined {
+	const tooMany =
+		`${label}.context must not carry more than ${limits.maxContextEntries} entries ` +
+		"(every property and array element counts, at every depth)";
+	const tooLong =
+		`${label}.context must not carry a string longer than ${limits.maxContextValueLength} ` +
+		"characters (property names included)";
+
+	let entries = 0;
+	const pending: object[] = [context];
+	while (pending.length > 0) {
+		// Non-null by construction: only containers are pushed.
+		const node = pending.pop() as object;
+		const isArray = Array.isArray(node);
+		for (const [key, value] of Object.entries(node)) {
+			entries += 1;
+			if (entries > limits.maxContextEntries) return tooMany;
+			// An array's `Object.entries` keys are its indices, which the caller
+			// did not write and which no bound applies to.
+			if (!isArray && key.length > limits.maxContextValueLength) return tooLong;
+			if (typeof value === "string" && value.length > limits.maxContextValueLength) return tooLong;
+			if (typeof value === "object" && value !== null) pending.push(value);
+		}
+	}
+	return undefined;
+}
+
+/**
  * Validates one entry of a decision request. Returns the entry or the reason it
  * is unusable, phrased with `label` so a batch can name the offending index.
  *
@@ -131,21 +298,38 @@ type ParsedDecisionRequest =
  * parser refuses is a malformed request, not a server fault, and it belongs
  * with the other body validation so a batch names the offending index and no
  * entry is decided before the whole batch is known to be usable.
+ *
+ * Unknown properties are refused rather than ignored (#118). A caller sending
+ * `subject` was being told nothing while believing it had been honoured — and
+ * the subject comes from the verified token, never from the body. The same
+ * reasoning covers a misspelled `contxt`, which used to be dropped in silence.
  */
 function parseDecisionRequest(
 	raw: unknown,
 	label: string,
 	resourceParser: ResourceParser,
+	limits: RequestLimits,
 ): ParsedDecisionRequest {
 	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
 		return { ok: false, error: `${label} must be an object` };
 	}
-	const { resource, action, context } = raw as Record<string, unknown>;
-	if (typeof resource !== "string" || resource === "") {
-		return { ok: false, error: `${label}.resource must be a non-empty string` };
+	const unknownKeys = Object.keys(raw).filter((key) => !DECISION_REQUEST_KEYS.has(key));
+	if (unknownKeys.length > 0) {
+		return {
+			ok: false,
+			error:
+				`${label} has unknown properties: ${describeUnknownKeys(unknownKeys)} ` +
+				"(only resource, action and context are accepted)",
+		};
 	}
-	if (typeof action !== "string" || action === "") {
-		return { ok: false, error: `${label}.action must be a non-empty string` };
+	const { resource, action, context } = raw as Record<string, unknown>;
+	const checkedResource = checkIdentifier(resource, "resource", label, limits.maxResourceLength);
+	if (!checkedResource.ok) {
+		return checkedResource;
+	}
+	const checkedAction = checkIdentifier(action, "action", label, limits.maxActionLength);
+	if (!checkedAction.ok) {
+		return checkedAction;
 	}
 	// `typeof [] === "object"`, so arrays need excluding explicitly — an array
 	// reaching `CollectorContext.requestContext` is a shape no collector expects.
@@ -155,10 +339,16 @@ function parseDecisionRequest(
 	) {
 		return { ok: false, error: `${label}.context must be an object` };
 	}
+	if (context !== undefined) {
+		const badContext = checkContext(context as Record<string, unknown>, label, limits);
+		if (badContext !== undefined) {
+			return { ok: false, error: badContext };
+		}
+	}
 
 	let parsedResource: Resource;
 	try {
-		parsedResource = resourceParser.parse(resource);
+		parsedResource = resourceParser.parse(checkedResource.value);
 	} catch (cause) {
 		// Only a ResourceParseError means "the caller's string is malformed".
 		// Anything else is a fault in the parser and must keep surfacing as a 500.
@@ -172,7 +362,11 @@ function parseDecisionRequest(
 	return {
 		ok: true,
 		entry: {
-			request: { resource, action, context: context as Record<string, unknown> | undefined },
+			request: {
+				resource: checkedResource.value,
+				action: checkedAction.value,
+				context: context as Record<string, unknown> | undefined,
+			},
 			resource: parsedResource,
 		},
 	};
@@ -193,8 +387,24 @@ function parseDecisionRequest(
  *
  * Both answer 400 for a malformed body — including a `resource` the configured
  * `ResourceParser` refuses, which is the caller's syntax error rather than a
- * server fault — 401 for authentication failures, and 500 for anything
- * unexpected.
+ * server fault — 401 for authentication failures, 413 for a body over
+ * `maxBodyBytes`, 415 for a content type the parser cannot read, and 500 for
+ * anything unexpected. Every one of those answers is the deny envelope
+ * `{ decision: "deny", code, message }`, the body-parser failures included
+ * (#118): a caller that parses only decision JSON must never be handed
+ * Express's HTML error page.
+ *
+ * **The body is validated before the token is verified** (#118), which is why a
+ * malformed unauthenticated request is answered 400 rather than 401. It is the
+ * order the costs argue for: the body checks are bounded by the limits above,
+ * while verifying a token is the half that can reach the network — an
+ * attacker-chosen `kid` sends the JWKS path to the provider, and an HS256
+ * rotation tries every configured secret — so doing it first let an
+ * unauthenticated caller spend it on a body that was never usable. What it
+ * costs is that an anonymous caller now learns whether a body was well-formed,
+ * the resource grammar included; `http.callerAuth` (#108) is the gate for
+ * deployments that must not disclose even that, and it stays ahead of this
+ * router and of `express.json()`.
  *
  * Every decision — one per `/verify` call, one per entry of a batch — emits a
  * `decision` event at info and, when `metrics` is wired, increments the
@@ -210,6 +420,26 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	// the schema refused to boot — and let a `0` through as a cap that rejects
 	// every batch there is.
 	const maxBatchSize = resolveBound(config.maxBatchSize, NUMERIC_BOUNDS.maxBatchSize, "verify");
+	// The request limits (#118), read the same way and at the same boundary.
+	const maxBodyBytes = resolveBound(config.maxBodyBytes, NUMERIC_BOUNDS.maxBodyBytes, "verify");
+	const limits: RequestLimits = {
+		maxResourceLength: resolveBound(
+			config.maxResourceLength,
+			NUMERIC_BOUNDS.maxResourceLength,
+			"verify",
+		),
+		maxActionLength: resolveBound(config.maxActionLength, NUMERIC_BOUNDS.maxActionLength, "verify"),
+		maxContextEntries: resolveBound(
+			config.maxContextEntries,
+			NUMERIC_BOUNDS.maxContextEntries,
+			"verify",
+		),
+		maxContextValueLength: resolveBound(
+			config.maxContextValueLength,
+			NUMERIC_BOUNDS.maxContextValueLength,
+			"verify",
+		),
+	};
 	const logger = config.logger ?? consoleLogger;
 	// Constructing the authenticator runs assertVerifyRouterJwtConfig, so an
 	// invalid hand-built jwt config still fails here, at router construction.
@@ -281,19 +511,25 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	}
 
 	const router = express.Router();
-	router.use(express.json());
+	// An explicit limit, not Express's unstated 100 KB default (#118). It is the
+	// only one of the five spent here: a body over it never becomes an object,
+	// and `bodyParserFailure` below turns the refusal into the deny envelope.
+	router.use(express.json({ limit: maxBodyBytes }));
 
 	router.post("/verify", async (req: express.Request, res: express.Response) => {
 		try {
-			const auth = await authenticator.authenticate(req.get("authorization"));
-			if (!auth.ok) {
-				res.status(401).json(errorBody(auth.code, auth.message));
+			// Body first, token second (#118) — see the ordering paragraph on
+			// `createVerifyRouter`. This is what makes a malformed unauthenticated
+			// request a 400 rather than a 401.
+			const parsed = parseDecisionRequest(req.body, "body", config.resourceParser, limits);
+			if (!parsed.ok) {
+				res.status(400).json(errorBody("invalid_request", parsed.error));
 				return;
 			}
 
-			const parsed = parseDecisionRequest(req.body, "body", config.resourceParser);
-			if (!parsed.ok) {
-				res.status(400).json(errorBody("invalid_request", parsed.error));
+			const auth = await authenticator.authenticate(req.get("authorization"));
+			if (!auth.ok) {
+				res.status(401).json(errorBody(auth.code, auth.message));
 				return;
 			}
 
@@ -307,13 +543,27 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 
 	router.post("/verify/batch", async (req: express.Request, res: express.Response) => {
 		try {
-			const auth = await authenticator.authenticate(req.get("authorization"));
-			if (!auth.ok) {
-				res.status(401).json(errorBody(auth.code, auth.message));
+			// The whole body — envelope, cap and every entry — before the token, for
+			// the reason `/verify` does it: the batch is the shape that can make an
+			// unauthenticated caller's mistake expensive.
+			const body: unknown = req.body;
+			if (typeof body !== "object" || body === null || Array.isArray(body)) {
+				res.status(400).json(errorBody("invalid_request", "body must be an object"));
 				return;
 			}
-
-			const raw = (req.body as { decisions?: unknown } | undefined)?.decisions;
+			const unknownKeys = Object.keys(body).filter((key) => key !== "decisions");
+			if (unknownKeys.length > 0) {
+				res
+					.status(400)
+					.json(
+						errorBody(
+							"invalid_request",
+							`body has unknown properties: ${describeUnknownKeys(unknownKeys)} (only decisions is accepted)`,
+						),
+					);
+				return;
+			}
+			const raw = (body as { decisions?: unknown }).decisions;
 			if (!Array.isArray(raw) || raw.length === 0) {
 				res.status(400).json(errorBody("invalid_request", "decisions must be a non-empty array"));
 				return;
@@ -334,12 +584,23 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 			// one malformed entry gets told which, rather than a partial answer.
 			const entries: ValidatedDecisionRequest[] = [];
 			for (const [index, item] of raw.entries()) {
-				const parsed = parseDecisionRequest(item, `decisions[${index}]`, config.resourceParser);
+				const parsed = parseDecisionRequest(
+					item,
+					`decisions[${index}]`,
+					config.resourceParser,
+					limits,
+				);
 				if (!parsed.ok) {
 					res.status(400).json(errorBody("invalid_request", parsed.error));
 					return;
 				}
 				entries.push(parsed.entry);
+			}
+
+			const auth = await authenticator.authenticate(req.get("authorization"));
+			if (!auth.ok) {
+				res.status(401).json(errorBody(auth.code, auth.message));
+				return;
 			}
 
 			const decisions = await Promise.all(entries.map((entry) => decide(req, auth.payload, entry)));
@@ -350,7 +611,81 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 		}
 	});
 
+	/*
+	 * Terminal error handler (#118, and item 6 of #126).
+	 *
+	 * `express.json()` rejects before either route runs, so its failures never
+	 * reached the try/catch above and fell through to Express's default handler
+	 * — an HTML page, carrying a stack trace outside production. A client that
+	 * parses only decision JSON has no way to read that, and "every non-allow
+	 * answer is a deny" stops being something the endpoint actually does.
+	 *
+	 * It is mounted on the router rather than on the app so that
+	 * `createVerifyRouter` is self-contained: a consumer mounting it on their own
+	 * Express app gets the envelope without wiring anything, and `createApp`
+	 * inherits it. Four arguments, because that is how Express tells an error
+	 * handler from a middleware.
+	 */
+	const denyOnBodyFailure: express.ErrorRequestHandler = (err, req, res, next) => {
+		// A failure after the response started is not ours to rewrite; handing it
+		// back lets Express close the connection.
+		if (res.headersSent) {
+			next(err);
+			return;
+		}
+		const failure = bodyParserFailure(err);
+		if (failure) {
+			res.status(failure.status).json(errorBody(failure.code, failure.message));
+			return;
+		}
+		// `req.path`, not a literal: this handler covers both routes, and anything
+		// mounted on the router that never reached one of them.
+		logger.error({ err, endpoint: req.path }, "verify_internal_error");
+		res.status(500).json(errorBody("internal_error", "Internal server error"));
+	};
+	router.use(denyOnBodyFailure);
+
 	return router;
+}
+
+/**
+ * Maps a body-parser failure onto a status and a deny code, or `undefined` when
+ * the error is not one.
+ *
+ * body-parser tags every failure it raises with a stable `type`, which is what
+ * is matched here — `err.message` carries a fragment of the caller's body and
+ * `err.status` alone would not tell an oversized body from an unreadable
+ * charset. None of the messages echo anything the caller sent: a parse failure
+ * is reported as a parse failure, not by quoting the bytes that caused it.
+ */
+function bodyParserFailure(
+	err: unknown,
+): { status: number; code: string; message: string } | undefined {
+	switch ((err as { type?: unknown } | null)?.type) {
+		case "entity.too.large":
+			return {
+				status: 413,
+				code: "payload_too_large",
+				message: "Request body exceeds the configured limit",
+			};
+		case "entity.parse.failed":
+			return { status: 400, code: "invalid_request", message: "Request body is not valid JSON" };
+		case "encoding.unsupported":
+		case "charset.unsupported":
+			return {
+				status: 415,
+				code: "unsupported_media_type",
+				message: "Request body must be application/json encoded as UTF-8",
+			};
+		case "request.aborted":
+			return {
+				status: 400,
+				code: "invalid_request",
+				message: "Request body was not fully received",
+			};
+		default:
+			return undefined;
+	}
 }
 
 /**

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -259,4 +259,33 @@ verify {
   # request from turning into an unbounded amount of pipeline work.
   maxBatchSize = 50
   maxBatchSize = ${?VERIFY_MAX_BATCH_SIZE}
+
+  # Ceiling on the JSON body, in bytes — the limit handed to `express.json()`.
+  # Below Express's unstated 100 KB default, and the outer envelope: it is what
+  # binds first on a large batch, since the per-field limits below bound ONE
+  # entry rather than N of them. A body over it is answered
+  # `413 payload_too_large` in the same deny envelope as everything else.
+  maxBodyBytes = 65536
+  maxBodyBytes = ${?VERIFY_MAX_BODY_BYTES}
+
+  # Ceilings on the two identifiers, in characters. Whitespace in either is
+  # refused rather than trimmed — they are concatenated into the
+  # `{action}:{resourceType}` scope an issuer has to have granted, and RFC 6749
+  # §3.3 makes space the delimiter between scope values.
+  maxResourceLength = 512
+  maxResourceLength = ${?VERIFY_MAX_RESOURCE_LENGTH}
+  maxActionLength = 64
+  maxActionLength = ${?VERIFY_MAX_ACTION_LENGTH}
+
+  # Bounds on the request `context`, which is free-form caller-supplied data.
+  # `maxContextEntries` counts every property and every array element in the
+  # whole tree, at every depth — nesting is bounded rather than forbidden, since
+  # RequestContextAttributeCollector reads dot paths such as "tenant.id" — and
+  # because each level of nesting costs at least one entry, it bounds the depth
+  # too. `maxContextValueLength` bounds every string in that tree, property
+  # names included.
+  maxContextEntries = 64
+  maxContextEntries = ${?VERIFY_MAX_CONTEXT_ENTRIES}
+  maxContextValueLength = 1024
+  maxContextValueLength = ${?VERIFY_MAX_CONTEXT_VALUE_LENGTH}
 }

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -227,6 +227,12 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		expect(config.oauth.jwt.maxTokenAgeSeconds).toBe(86_400);
 		expect(config.oauth.jwt.clockToleranceSeconds).toBe(0);
 		expect(config.verify.maxBatchSize).toBe(50);
+		// The request limits (#118) travel the same path.
+		expect(config.verify.maxBodyBytes).toBe(65_536);
+		expect(config.verify.maxResourceLength).toBe(512);
+		expect(config.verify.maxActionLength).toBe(64);
+		expect(config.verify.maxContextEntries).toBe(64);
+		expect(config.verify.maxContextValueLength).toBe(1024);
 	});
 
 	it("reads every numeric knob from the environment, where each arrives as a string", () => {
@@ -238,6 +244,11 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		process.env.OAUTH_JWT_MAX_TOKEN_AGE_SECONDS = "600";
 		process.env.OAUTH_JWT_CLOCK_TOLERANCE_SECONDS = "60";
 		process.env.VERIFY_MAX_BATCH_SIZE = "25";
+		process.env.VERIFY_MAX_BODY_BYTES = "16384";
+		process.env.VERIFY_MAX_RESOURCE_LENGTH = "128";
+		process.env.VERIFY_MAX_ACTION_LENGTH = "32";
+		process.env.VERIFY_MAX_CONTEXT_ENTRIES = "16";
+		process.env.VERIFY_MAX_CONTEXT_VALUE_LENGTH = "256";
 
 		const config = loadAppConfig(configDirPath, "development");
 
@@ -248,6 +259,11 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		expect(config.oauth.jwt.maxTokenAgeSeconds).toBe(600);
 		expect(config.oauth.jwt.clockToleranceSeconds).toBe(60);
 		expect(config.verify.maxBatchSize).toBe(25);
+		expect(config.verify.maxBodyBytes).toBe(16_384);
+		expect(config.verify.maxResourceLength).toBe(128);
+		expect(config.verify.maxActionLength).toBe(32);
+		expect(config.verify.maxContextEntries).toBe(16);
+		expect(config.verify.maxContextValueLength).toBe(256);
 	});
 
 	it.each([
@@ -258,6 +274,11 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		["OAUTH_JWT_MAX_TOKEN_AGE_SECONDS", "1.5"],
 		["OAUTH_JWT_CLOCK_TOLERANCE_SECONDS", "301"],
 		["VERIFY_MAX_BATCH_SIZE", "0"],
+		["VERIFY_MAX_BODY_BYTES", "0"],
+		["VERIFY_MAX_RESOURCE_LENGTH", "-1"],
+		["VERIFY_MAX_ACTION_LENGTH", "1.5"],
+		["VERIFY_MAX_CONTEXT_ENTRIES", "abc"],
+		["VERIFY_MAX_CONTEXT_VALUE_LENGTH", "0"],
 	])("refuses to boot on %s=%s", (key, value) => {
 		setRequiredEnv();
 		process.env[key] = value;
@@ -270,6 +291,8 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		"OAUTH_JWT_JWKS_COOLDOWN_MS",
 		"OAUTH_JWT_CLOCK_TOLERANCE_SECONDS",
 		"VERIFY_MAX_BATCH_SIZE",
+		"VERIFY_MAX_BODY_BYTES",
+		"VERIFY_MAX_CONTEXT_ENTRIES",
 	])("refuses %s exported empty rather than reading it as zero", (key) => {
 		// `VAR=` substitutes an empty string, and `Number("")` is 0 — which the
 		// knobs whose floor is 0 would otherwise accept as a deliberate setting.


### PR DESCRIPTION
Closes #118.

`/verify` relied on Express's unstated 100 KB JSON default and on a check that `resource` and `action` were non-empty strings. Whitespace-only values passed, `context` could be arbitrarily wide and deep, unknown properties rode along in silence — and JWT verification, the half that can reach the network, ran first, so an unauthenticated caller could spend it on a body that was never usable.

## The limits

Five new numeric knobs on the `verify` config block, each read through `resolveBound` at both boundaries per AGENTS.md "Two-Boundary Config Validation", with the spec in `config/bounds.mts` and the value in `config/defaults.mts`. All five are settable from the environment and admit the string form a HOCON substitution delivers.

| Key | Env | Default | What it bounds |
| --- | --- | --- | --- |
| `verify.maxBodyBytes` | `VERIFY_MAX_BODY_BYTES` | `65536` (64 KiB) | the `limit` on `express.json()` |
| `verify.maxResourceLength` | `VERIFY_MAX_RESOURCE_LENGTH` | `512` | characters in `resource` |
| `verify.maxActionLength` | `VERIFY_MAX_ACTION_LENGTH` | `64` | characters in `action` |
| `verify.maxContextEntries` | `VERIFY_MAX_CONTEXT_ENTRIES` | `64` | properties + array elements in the whole `context` tree, at every depth |
| `verify.maxContextValueLength` | `VERIFY_MAX_CONTEXT_VALUE_LENGTH` | `1024` | every string in the `context` tree, property names included |

`maxBodyBytes` is *below* Express's old default, so it is a tightening, and it is the outer envelope: it binds first on a large batch, because the per-field limits bound **one** entry rather than N of them. A deployment sending wide contexts across a full 50-entry batch raises it.

`maxContextEntries` counts the whole tree rather than the top level, so **nesting is bounded rather than forbidden** — `RequestContextAttributeCollector` reads dot paths such as `tenant.id`, and a flat-only rule would have broken a documented feature. Because each level of nesting costs at least one entry, it also bounds the depth, which is why there is no separate depth knob and the validating walk is finite by construction.

Two more refusals, both in the spirit of the existing `DotNotationResourceParser` doctrine:

- **Whitespace is refused, not trimmed**, in `resource` *and* `action`. #117 already did this for `resource` in the built-in grammar; doing it at the schema layer extends it to `action` and to a deployment that registered its own `ResourceParser`. Both are concatenated into the `{action}:{resourceType}` scope an issuer has to have granted, and RFC 6749 §3.3 makes space the delimiter between scope values — so a value carrying whitespace names something no issuer could grant. Trimming would make `"read "` and `"read"` one action here while a collector reading the raw string still saw two.
- **Unknown properties are refused.** `{"resource": …, "action": …, "subject": "admin"}` is now `400 invalid_request` rather than a decision with `subject` quietly dropped. The subject comes from the verified token and never from the body; a caller who sent one was being told nothing while believing it had been honoured. Same for a misspelled `contxt`, and for anything beside `decisions` on a batch body.

No message echoes the caller's data. Field messages name the field; the context messages state the bound only; the unknown-property message shows at most three names, each truncated to 32 characters and quoted through `JSON.stringify`.

## The ordering change (wire-visible)

The body is validated **before** the token is verified, on both endpoints. #125 should pin the table below, not the "Before" column.

| Request | Before | After |
| --- | --- | --- |
| malformed body, no token | `401 missing_token` | **`400 invalid_request`** |
| malformed body, unverifiable token | `401 invalid_token` | **`400 invalid_request`** |
| well-formed body, no token | `401 missing_token` | `401 missing_token` (unchanged) |
| well-formed body, bad token | `401 invalid_token` | `401 invalid_token` (unchanged) |
| body over the size limit | Express HTML `413` | **`413 payload_too_large`**, deny envelope |
| malformed JSON | Express HTML `400` | **`400 invalid_request`**, deny envelope |
| unreadable content type / charset | Express HTML `415` | **`415 unsupported_media_type`**, deny envelope |
| body sent as `text/plain` | `401`/`400` depending on token | `400 invalid_request` (`req.body` never becomes an object) |
| allow / deny / batch shapes | — | unchanged |

It is the order the costs argue for: the body checks are now bounded by the limits above, while verifying a token is the half that can reach the network — an attacker-chosen `kid` sends the JWKS path to the provider, and an HS256 rotation tries every configured secret. What it costs is that an anonymous caller now learns whether a body was well-formed, the resource grammar included; the existing test that pinned "401 outranks 400: an anonymous caller learns nothing about the grammar" is flipped and the trade written down at the flip.

**`http.callerAuth` (#108) is untouched.** It still runs ahead of this router *and* ahead of `express.json()`, so a rejected caller is answered before a body is parsed at all — that is the gate for a deployment that must not disclose even well-formedness.

## #126 item 6 — fully covered

A terminal error handler on the router maps every body-parser failure onto the deny envelope: `entity.parse.failed` → 400 `invalid_request`, `entity.too.large` → 413 `payload_too_large`, `encoding.unsupported` / `charset.unsupported` → 415 `unsupported_media_type`, `request.aborted` → 400 `invalid_request`, anything else → 500 `internal_error` with the existing `verify_internal_error` log line. It is mounted on the router rather than the app, so a consumer mounting `createVerifyRouter` on their own Express app gets it without wiring anything, and `createApp` inherits it. The HTML page — and the stack trace it carries outside production — is gone.

**#126 can be trimmed by two items**: item 6 (JSON parse errors bypass the deny envelope) is fully covered, and item 7 (whitespace-only `resource` passes validation) is covered too — and answered by refusing rather than by trimming, which is the opposite of what item 7 suggested and the reason it is called out here.

Items 1–5 and 8 of #126 are untouched.

## Umbrella E2E (o3co/auth) — no change needed

`tests/shared/oauthFlow.js`'s `verify()` is the only caller: it always sends `{ resource: 'project:1', action: 'read' }` with `content-type: application/json` — well inside all five limits, no whitespace, no unknown properties. Every negative in `tests/abac/index.test.js` is a *token* negative with a well-formed body, so all of them keep their current status:

- `denies with 401 when Authorization header is missing` → still `401 missing_token` (the body is valid, so validation falls through to auth)
- `denies with 401 for invalid JWT` / expired / wrong issuer / wrong audience / wrong `typ` → still `401 invalid_token`
- `denies a scopeless token` → still `403 invalid_scope`
- allow / deny / nested-resource cases → unchanged

`tests/abac/application.conf` is mounted over the template's and carries no `verify` block, so all five limits take their schema defaults there. **No follow-up PR is required in o3co/auth.** The only thing that would have needed one is a case sending a malformed body without a token, and there is none.

## Tests

TDD: `packages/server/src/__tests__/verifyInputValidation.test.mts` was written first and watched fail (65 failures), then the implementation landed.

- 77 new cases: each limit at the boundary and one over, configured overrides, whitespace in `resource` and `action`, nested/array entry counting, nested and property-name string bounds, unknown properties on both endpoints (naming the batch index), the four ordering cases, "the pipelines never run for a body-refused request", the four body-parser envelopes, "never echoes the offending body", and the two-boundary agreement (router vs `AppConfigSchema`) for all five knobs.
- Two existing cases changed, both deliberate — the `#117` "rejects an unauthenticated request before parsing the resource" (now 400) and `#124` "never takes the subject from the request body" (now 400 naming `subject`, with a new sibling asserting the subject still comes from the token).
- `templates/standalone` `loadConfig` tests extended so the shipped `application.conf` proves all five knobs read from the environment, refuse bad values, and refuse an empty export.

Full run on the rebased branch (`develop` @ `0283218`), no `--coverage`:

```
pnpm lint                 Checked 143 files. No fixes applied.
pnpm -r run build         all packages Done
pnpm run typecheck        all 6 projects Done
pnpm -r run test          create-app 78 | core 73 | builtins 474 | server 661 | standalone 55 | integration 72
                          = 1413 passed, 0 failed
```

## Judgment calls

- **Single-phase validation.** The whole body — resource parsing included — moves ahead of auth, rather than splitting cheap schema checks from the grammar parse to keep the grammar undisclosed. Simpler to reason about and to pin, and the parse is bounded by `maxResourceLength` × `maxBatchSize`.
- **Nesting bounded, not banned.** Restricting `context` to flat scalars would have been a stronger bound and much simpler, but it breaks `RequestContextAttributeCollector`'s documented `from = "tenant.id"` dot paths and its `string[]` type.
- **No depth knob.** Entry count bounds depth, so a sixth knob would have been redundant.
- **No ceiling on any of the five.** Consistent with `jwksTimeoutMs`: raising one is an operator's explicit statement, and `Infinity`/non-integers are already refused by `resolveBound`.
- **No `__proto__` / `constructor` key blacklist in `context`.** Considered and declined as scope creep: `readUntrustedRequestContext` plus `RequestContextAttributeCollector`'s `Object.hasOwn` traversal already handle it, and it would add wire-visible behaviour for #125 to pin.
- **Body-parser 4xx are not logged.** Symmetric with the existing validation 400s, which are silent; only the unmapped case logs, through the existing `verify_internal_error` event. No new log vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
