### PR TITLE
fix(core,server)!: bound the collector fan-out, and deny when it runs out (#115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 The engine enforces a strict separation between the context-reading layer and the context-free layer.
 
-- **Collectors** (`AttributeCollector`, `RuleCollector`) are the only layer that reads `CollectorContext`. They transform the raw request into static outputs: attributes or rules.
+- **Collectors** (`AttributeCollector`, `RuleCollector`) are the only layer that reads `CollectorContext`. They transform the raw request into static outputs: attributes or rules. They are also the only layer that does I/O, which is why they are the only layer with deadlines — see `packages/core/src/collectorLimits.mts` and the `signal` note below.
 - **Attributes** are plain values (`Map<string, unknown>`). Once produced by collectors, they carry no reference to the originating request.
 - **Rules** are predicates over attributes (`verify(attrs): boolean`). `verify` must be a **deterministic, side-effect-free function of `attrs`**: equal attributes give equal answers, and it must not mutate its input, perform I/O, or observe anything the engine cannot see. `verify` is handed a `ReadonlyAttributes` (`ReadonlyMap<string, unknown>`), so the "must not mutate" half is a compile error rather than a request.
 
@@ -30,6 +30,8 @@ This contract guarantees that rules are pure functions of attributes: testable i
 **The deciding test:** collect the rule, discard the context, then call `verify(attrs)`. The answer must be unchanged. A rule that copied a string out at collect time answers identically; a rule that kept the request cannot answer at all.
 
 That test is executable, not rhetorical. `describeRulePurityConformance` in [`tests/integration/src/conformance/rulePurity.mts`](tests/integration/src/conformance/rulePurity.mts) collects the rules through a revocable view of the context, revokes it, and re-runs `verify` — so a rule holding the request throws on the access, and one holding a copied value does not. Apply it to every rule collector you add. `.github/workflows/ci.yml` also greps `verify` bodies for context reads, but that is a backstop for the obvious shape; the conformance suite is the check.
+
+**`CollectorContext.signal` is on the same side of the line as everything else.** It is the one field a collector is *meant* to hold live — it is a cancellation handle, and passing it to `fetch` is what it is for — but that licence ends when `collect` returns. `aborted` moves on its own, so a rule holding a signal and reading it inside `verify` is not a function of `attrs` at all, and the suite revokes it exactly as it revokes `ctx.resource`. What the suite could not do is wrap it in a `Proxy`: `AbortSignal`'s members are brand-checked against the receiver, so a proxied signal fails `addEventListener`, `AbortSignal.any` and `fetch` — the harness would have started failing honest collectors for an artefact of its own. So the view is a real signal minted by `AbortSignal.any`, and revoking shadows its members with accessors that throw the same error a revoked proxy does. The check is unchanged in strength; only the mechanism differs, for the one type that cannot be a proxy. The reasoning is written on `revocableSignal`; a future field with internal slots of its own should follow it rather than take an exemption.
 
 ## Core Vocabulary Scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,134 @@ and version sections follow the release labeling policy in
 
 ### Security
 
+- **BREAKING**: collectors now run under a deadline, a cancellation signal and a
+  concurrency bound, and **a bound that trips denies the decision**
+  ([#115](https://github.com/o3co/auth.policy-verifier/issues/115)).
+
+  Both pipelines ran their collectors under a bare `Promise.all`. Collectors are
+  the layer designed to call databases and HTTP APIs, and a `Promise.all` has no
+  deadline, no cancellation and no bound on how much work it starts — so a
+  single collector holding a dead socket held the authorization decision with
+  it, for as long as the socket took to notice. Siblings kept running after one
+  of them had already failed the request, and a dependency slowdown piled up
+  unbounded in-flight work instead of shedding it. On a PDP's hot path that is
+  both a latency failure and a DoS amplifier: one `POST /verify/batch` is up to
+  50 decisions, each fanning out across every configured collector.
+
+  **`CollectorContext` gained a required `signal: AbortSignal`** — the breaking
+  half. It aborts when that collector overruns its budget, when the pipeline
+  overruns its deadline, when a sibling has already failed the decision, or when
+  the caller went away.
+
+  *What a collector author must change:* nothing to keep compiling — a collector
+  only reads the context. What you should change is to pass the signal to
+  whatever the collector waits on, which is the only thing that makes
+  cancellation real:
+
+  ```diff
+  -const res = await fetch(this.endpoint);
+  +const res = await fetch(this.endpoint, { signal: context.signal });
+  ```
+
+  The pipeline stops waiting on a collector that ignores its signal — the bound
+  does not depend on cooperation — but that collector's outbound call goes on
+  running against a dependency that has already lost the request it belonged to.
+
+  *What breaks* is code that **builds** a `CollectorContext`: a custom
+  transport or interceptor, and every test fixture with a context literal. Add
+  the field. A transport that has no cancellation of its own passes
+  `new AbortController().signal`. Callers of `AttributePipeline.collect` /
+  `RulePipeline.collect` are unaffected: those now take a `CollectorRequest` —
+  the same shape *without* `signal`, since the per-collector signal is the
+  pipeline's to mint. A caller with an outer deadline may still set the optional
+  `signal` on the request, and the pipeline links it into its own, so aborting
+  it cancels every collector in flight.
+
+  **The bounds, and why these numbers.** All three are on by default, so a
+  library consumer who configures nothing is still bounded:
+
+  | Knob | Default | What it bounds |
+  | --- | --- | --- |
+  | `verify.collectorTimeoutMs` | `2000` | one collector. A healthy lookup against a dependency the deployment runs answers in single-digit milliseconds; 2s is far past "slow" and short of the timeouts callers put on `/verify` itself, so the verifier is the layer that notices — and it can name *which* collector, which a caller-side timeout never can. The budget starts when that collector starts, so queueing behind the concurrency cap does not spend it |
+  | `verify.collectorDeadlineMs` | `5000` | the whole fan-out, per pipeline. A per-collector budget cannot bound a *set*: once collectors queue, enough of them each finishing just inside their own budget still adds up to a request nobody is waiting for |
+  | `verify.collectorConcurrency` | `8` | collectors in flight at once, per pipeline, per decision. More than any realistic collector set, so a normal configuration still fans out in one wave and nothing about its latency changes. What it removes is the tail — dozens of collectors, or a 50-entry batch, multiplying into simultaneous outbound calls against a dependency that has just started to slow down |
+
+  Each knob routes through `resolveBound` at both config boundaries — the schema
+  for config files, `createApp` for the hand-built configs it also accepts —
+  with one spec table in `config/bounds.mts`, per AGENTS.md "Two-Boundary Config
+  Validation". The defaults themselves are `packages/core`'s and are re-exported
+  by `config/defaults.mts` rather than restated, so the config file's default and
+  the pipeline's cannot drift. `0` is refused for all three: a zero timeout
+  cancels every collector before it can answer, and a zero concurrency is a
+  fan-out that starts nothing and resolves with no attributes and no rules — a
+  fail-open dressed as a setting. The shipped `templates/standalone` config
+  writes all three out with their `VERIFY_COLLECTOR_*` env substitutions, beside
+  the `#118` limits.
+
+  **A note on the `verify` block's own default, because this nearly went wrong.**
+  The block carries a `.default(() => ({…}))`, and zod takes that object
+  *verbatim* — it never parses it back through the shape. A knob added to the
+  shape but not to that literal is therefore `undefined` for every config that
+  omits the `verify` block entirely, which is the ordinary deployment shape,
+  since an overlay config repeats only the sections it changes. Nothing throws;
+  the bound simply stops existing. #115 and #118 both added knobs here and landed
+  a day apart, so the second merge could have looked clean and silently dropped
+  the first's defaults. It is now asserted instead of reviewed: the two
+  productions of the block — present-and-empty (which runs the shape's per-key
+  defaults) and absent (which takes the literal) — must be deeply equal, so a
+  future knob added to one and not the other fails without anyone remembering to
+  extend a list. `loadConfig.test.mts` proves the same end-to-end through the
+  real HOCON loader, on a config directory with no `verify` block at all.
+
+  **A collector whose decision is already lost is never invoked.** Not started
+  and then cancelled — not started. Handing a collector an aborted signal and
+  relying on it to notice is a different thing: the documented way to use the
+  signal is to pass it to `fetch`, so a collector that does not check
+  `signal.aborted` before its first `await` has already put the request on the
+  wire. That is an outbound call for an answer nobody will read, usually against
+  the very dependency whose slowness ended the decision. The check sits at the
+  point of invocation rather than in the loop above it, so it holds however the
+  fan-out is driven, and the failure it raises is the *set's* reason — the
+  deadline, a sibling's error, the caller leaving — never a timeout attributed to
+  a collector that never ran and never overran anything.
+
+  **Fail closed: a timeout denies, and can never allow.** The pipeline throws
+  `CollectorTimeoutError` and returns nothing at all — never the results that
+  arrived in time. That is the whole design decision. Partial attributes merely
+  weaken a rule's inputs, but partial rules weaken the *policy*, and an empty
+  rule set is an **allow** wherever `rule.onEmptyRuleSet = "allow"` is set. So
+  the evaluator is never reached: `routes/verify.mts` catches the error and
+  builds the deny itself — `403`, `code: "collector_timeout"`, empty
+  `reason.groups` — which means there is no code path on which a timeout can
+  become a permit. Pinned by `createApp — a stalled collector denies (#115)`,
+  which asserts a deployment that *does* allow an empty rule set still denies a
+  stalled one.
+
+  It is a deny and not a `5xx` on purpose: a 5xx invites the enforcement layer
+  to retry the same stalled dependency, or to conclude the PDP is down and apply
+  a fallback nobody in this repo wrote. The wire message names no collector and
+  no bound — that reaches the caller, and the collector set is deployment
+  topology; the detail goes to the `collector_timeout` log line. The decision
+  still emits its `decision` audit line and increments the deny counters, so a
+  timeout is visible as what it is rather than disappearing into the 500 rate.
+  In a batch the bound is per decision: one entry timing out denies that entry
+  and leaves the rest decided.
+
+  **Rule purity is unchanged in strength.** The signal lands on the very object
+  `describeRulePurityConformance` revokes, and it is the first context field a
+  collector is *meant* to hold live — but only for the length of `collect`.
+  `aborted` moves on its own, so a rule that carried a signal into `verify`
+  would not be a function of `attrs`, and the suite revokes it exactly as it
+  revokes `ctx.resource`. What had to change is the mechanism, not the check: an
+  `AbortSignal` cannot be wrapped in a `Proxy` — its members are brand-checked
+  against the receiver, so a proxied signal throws on `addEventListener`,
+  `AbortSignal.any` and `fetch`, and the harness would have begun failing honest
+  collectors for an artefact of its own. The view is now a real signal minted by
+  `AbortSignal.any` (linked to the case's own, so cancellation still propagates),
+  and revoking shadows its members with accessors throwing the same `TypeError` a
+  revoked proxy throws. Both halves are pinned: a rule holding the signal is
+  rejected, and a collector using it in every legitimate way passes.
+
 - **BREAKING**: `/verify` and `/verify/batch` now hold the request body to
   stated limits, refuse unknown properties and whitespace, and **validate the
   body before verifying the token**

--- a/README.ja.md
+++ b/README.ja.md
@@ -271,6 +271,16 @@ verify {
   maxContextEntries = ${?VERIFY_MAX_CONTEXT_ENTRIES}
   maxContextValueLength = 1024  # `context` 内の文字列の文字数（キー名を含む）
   maxContextValueLength = ${?VERIFY_MAX_CONTEXT_VALUE_LENGTH}
+
+  # 各決定で 2 つの pipeline が走らせる collector fan-out の上限 (#115)。
+  # いずれかを超えた決定は deny になる — 部分的な結果は決して返さない。
+  # 下記「コレクターのデッドライン」を参照。
+  collectorTimeoutMs   = 2000   # コレクター 1 本あたりの予算
+  collectorTimeoutMs   = ${?VERIFY_COLLECTOR_TIMEOUT_MS}
+  collectorDeadlineMs  = 5000   # pipeline 単位の fan-out 全体
+  collectorDeadlineMs  = ${?VERIFY_COLLECTOR_DEADLINE_MS}
+  collectorConcurrency = 8      # 同時に走らせるコレクター数
+  collectorConcurrency = ${?VERIFY_COLLECTOR_CONCURRENCY}
 }
 ```
 
@@ -308,6 +318,20 @@ charset は `415 unsupported_media_type` です。上の例はレスポンスボ
 `README.md` / `README.ja.md` / `CHANGELOG.md` に現れ、かつエンドポイントが実際に返す内容へ
 parse されることを `verifyInputValidation.test.mts` が検証しています。3 か所のコピーがコードから
 も互いからも drift しないのはそのためです。
+
+### コレクターのデッドライン
+
+Attribute / Rule コレクターはデータベースや HTTP API を呼ぶ層であり、つまり停止しうる層です。fan-out は 3 つの上限で守られており、既定で有効です — 何も設定していない deployment にも適用されます:
+
+| 設定キー | 既定値 | 何を制限するか |
+| --- | --- | --- |
+| `verify.collectorTimeoutMs` | `2000` | コレクター 1 本の所要時間。予算はそのコレクターが**開始した時点**から数えるので、同時実行上限による順番待ちで消費されることはない |
+| `verify.collectorDeadlineMs` | `5000` | pipeline 単位の fan-out 全体の所要時間。個々の予算は超えていないのに合計では超えている、というケースを捕える |
+| `verify.collectorConcurrency` | `8` | 1 決定・1 pipeline あたりの同時実行数。現実的なコレクター構成より大きいので通常は何も変わらず、依存先が遅くなって処理が積み上がり始めたときだけ効く |
+
+各コレクターには `CollectorContext.signal` で `AbortSignal` が渡されます。そのコレクターの予算切れ、pipeline のデッドライン超過、兄弟コレクターの失敗による決定の中止、呼び出し側の切断のいずれでも abort します。コレクターが待つ相手にそのまま渡してください — `fetch(url, { signal: context.signal })` — そうすれば外向きの処理も実際に取り消されます。
+
+**上限を超えた決定は deny です。** `403` と `code: "collector_timeout"`、`reason.groups` は空で応答し、詳細は呼び出し側ではなく `collector_timeout` ログ行に出ます。意図的に `5xx` にはせず、「時間内に集まったぶんで判定する」こともしません — ルールが少ないことは**ポリシーが弱いこと**であり、1 つも無ければ `rule.onEmptyRuleSet = "allow"` の deployment では **allow** になるからです。そのため評価器には到達させません。バッチでは上限は決定単位なので、1 エントリの超過はそのエントリだけを deny にし、残りは通常どおり判定されます。
 
 ### リソース文字列形式 (DotNotation)
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,16 @@ verify {
   maxContextEntries = ${?VERIFY_MAX_CONTEXT_ENTRIES}
   maxContextValueLength = 1024  # characters in any `context` string, keys included
   maxContextValueLength = ${?VERIFY_MAX_CONTEXT_VALUE_LENGTH}
+
+  # Bounds on the collector fan-out both pipelines run per decision (#115).
+  # Exceeding any of them DENIES the decision — a partial answer is never
+  # returned. See "Collector deadlines" below.
+  collectorTimeoutMs   = 2000   # one collector's own budget
+  collectorTimeoutMs   = ${?VERIFY_COLLECTOR_TIMEOUT_MS}
+  collectorDeadlineMs  = 5000   # the whole fan-out, per pipeline
+  collectorDeadlineMs  = ${?VERIFY_COLLECTOR_DEADLINE_MS}
+  collectorConcurrency = 8      # collectors in flight at once
+  collectorConcurrency = ${?VERIFY_COLLECTOR_CONCURRENCY}
 }
 ```
 
@@ -314,6 +324,20 @@ That is `400` for malformed JSON, `413 payload_too_large` over `maxBodyBytes`, a
 response body verbatim; `verifyInputValidation.test.mts` asserts that this exact line appears in
 `README.md`, `README.ja.md` and `CHANGELOG.md` and parses to what the endpoint emits, so the three
 copies cannot drift from the code or from each other.
+
+### Collector deadlines
+
+Attribute and rule collectors are the layer that talks to databases and HTTP APIs, so they are the layer that can stall. Every fan-out is bounded three ways, and the bounds are on by default — a deployment that configures nothing still gets them:
+
+| Knob | Default | What it bounds |
+| --- | --- | --- |
+| `verify.collectorTimeoutMs` | `2000` | how long one collector may take. The budget starts when that collector starts, so queueing behind the concurrency cap does not spend it |
+| `verify.collectorDeadlineMs` | `5000` | how long a whole fan-out may take, per pipeline. Catches the case where nothing overran its own budget but the total still did |
+| `verify.collectorConcurrency` | `8` | how many collectors run at once, per pipeline, per decision. More than any realistic collector set, so it changes nothing until a dependency slows down and work starts piling up |
+
+Every collector is handed an `AbortSignal` on `CollectorContext.signal`; it aborts when that collector's budget runs out, when the pipeline's deadline does, when a sibling collector has already failed the decision, or when the caller went away. Pass it to whatever the collector waits on — `fetch(url, { signal: context.signal })` — so the outbound work is actually cancelled and not merely stopped being waited for.
+
+**Exceeding a bound denies.** The decision is answered `403` with `code: "collector_timeout"` and an empty `reason.groups`; the details go to the `collector_timeout` log line rather than to the caller. It is deliberately not a `5xx` and deliberately not "decide with what we collected in time": a short rule list is a *weaker policy*, and an empty one is an **allow** wherever `rule.onEmptyRuleSet = "allow"` is set — so the evaluator is never reached at all. In a batch the bound is per decision, so one entry timing out denies that entry and leaves the rest decided.
 
 ### Resource String Format (DotNotation)
 

--- a/docs/extending.ja.md
+++ b/docs/extending.ja.md
@@ -95,6 +95,8 @@ export class UserLevelAtLeast implements Rule {
 | `headers` | トランスポートが設定（現状は `x-request-id`） | トランスポート由来 |
 | `requestContext` | リクエストボディの `context` をそのまま転送 | **未検証（untrusted）** |
 
+（5 つ目のフィールド `signal` は入力ではなく、pipeline のキャンセルハンドルです。[デッドラインとキャンセル](#デッドラインとキャンセル) を参照。）
+
 有効なトークンを持つ者は `context` に何でも書けます。`requestContext.role` を `ATTR_ROLES` に昇格させる Collector は、呼び出し側に「自分の認可入力を自分で書く」権限を渡したことになります — トークンが「誰であるか」を述べ、そのすぐ後にボディが「何をしてよいか」を述べる形です。しかもそれはたった 1 行で、隣にある `payload.sub` を昇格させる行と見分けがつきません。
 
 データ自体には両者を区別する手がかりがないため、型に区別させます。`requestContext` の型は `UntrustedRequestContext` — プロパティアクセスでは中身に到達できない不透明な brand です:
@@ -117,6 +119,27 @@ unwrap した後の指針:
 
 `CollectorContext` を自前で組み立てるトランスポート（自作の interceptor やテスト）は、`markUntrustedRequestContext` で受け取った時点の record をマークします。本リポジトリの verify route はボディの `context` に対してまさにこれを行っており、brand を生成できるのはこの関数だけなので、生のボディオブジェクトが誤って Collector に届くことはありません。
 
+## デッドラインとキャンセル
+
+各コレクターには `CollectorContext.signal` で `AbortSignal` が渡され、そのコレクターが属する fan-out には 3 つの上限が掛かります: コレクター単位のタイムアウト（既定 2 秒）、fan-out 全体のデッドライン（5 秒）、同時実行数の上限（8）。運用側は `verify.collectorTimeoutMs` / `verify.collectorDeadlineMs` / `verify.collectorConcurrency` で調整します。
+
+**待つ相手には signal をそのまま渡してください。** キャンセルが名目でなく実効になるのはそれによってです:
+
+```ts
+async collect(context: CollectorContext): Promise<Attributes> {
+  const res = await fetch(this.endpoint, { signal: context.signal });
+  // …
+}
+```
+
+signal を無視するコレクターも pipeline は待つのをやめます — 上限はコレクターの協力に依存しません — が、そのコレクターが始めた外向きの呼び出しは、すでに失われた決定のために依存先へ走り続けます。同時実行上限が防ごうとしているのはまさにこの積み上がりであり、signal を尊重することがそれに加担しないための手段です。
+
+signal が abort する理由は 4 つあり、`signal.reason` がどれかを示します: このコレクターが予算を超えた、pipeline がデッドラインを超えた、兄弟コレクターがすでに決定を失敗させた、呼び出し側が去った。
+
+**上限を超えたリクエストは deny になります** — `403` と `code: "collector_timeout"`。pipeline は `CollectorTimeoutError` を送出し、何も返しません。これは意図的です: 間に合った attribute は Rule への入力を弱め、間に合った Rule は**ポリシー**を弱め、空になれば `rule.onEmptyRuleSet = "allow"` の deployment では allow と読まれてしまいます。だから部分的な答えはそもそも存在させません。言うことが本当に無いコレクターは、速やかに空の `Map` を返してください。タイムアウトはその表明手段ではありません。
+
+**Rule は signal を `verify` に持ち込んではいけません。** これはリクエストへの live なハンドルであり（`aborted` は勝手に変わります）、保持して `verify` で読むのは `ctx.resource` を保持するのと同じ違反です。[rule purity conformance suite](#rule-は-attrs-だけで判断する) はこれを同じ違反として検出します。
+
 ## カスタム AttributeCollector の書き方
 
 `AttributeCollector` は `@o3co/auth.policy-verifier.core` で定義されます:
@@ -129,7 +152,7 @@ interface AttributeCollector {
 
 - 1 つの Collector は **焦点を絞った属性キー群**を生成してください。関係のない抽出をまとめないこと。IP アドレスと User-Agent を抽出するなら Collector を 2 つに分けてください。
 - 属性キーは文字列定数を使うこと。`@o3co/auth.policy-verifier.core` の `ATTR_SCOPES`、`ATTR_PERMISSIONS`、`ATTR_ROLES`、`ATTR_USER_ID`、`ATTR_CLIENT_ID` を参照。プロジェクト固有のキーは独自の定数を定義し、**core のキーを異なるセマンティクスで再利用しないこと**。
-- `AttributePipeline` は全 Collector を並列実行し、結果をマージします: 配列値は連結、スカラ／オブジェクトは後勝ち。この挙動に合わせて設計し、Collector の実行順序には依存しないこと。
+- `AttributePipeline` は全 Collector を並列実行し、結果をマージします: 配列値は連結、スカラ／オブジェクトは後勝ち。この挙動に合わせて設計し、Collector の実行順序には依存しないこと。同時に走る本数には上限があり、各 Collector には時間制限があります — [デッドラインとキャンセル](#デッドラインとキャンセル) を参照。
 - `CollectorContext.requestContext` は意図的に型付けされていません。エンジンは汎用 `requestContext` Collector を提供しません。`requestContext` の形は consuming project のトランスポート層 / interceptor が定義するものであり、解釈はプロジェクトの責務だからです。必要なフィールドごとに焦点を絞った Collector を書き、形の検証はその Collector 内で行ってください。同時に唯一の未検証入力でもあります — 中身を読む前に [信頼境界](#信頼境界-requestcontext-は呼び出し側のもの) を参照してください。
 
 ### 実例: `ClientIpCollector`

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -95,6 +95,8 @@ Notes:
 | `headers` | set by the transport (currently `x-request-id`) | transport |
 | `requestContext` | the request body's `context`, forwarded verbatim | **untrusted** |
 
+(`signal` is the fifth field and the only one that is not input at all — it is the pipeline's cancellation handle. See [Deadlines and cancellation](#deadlines-and-cancellation).)
+
 Anyone holding a valid token can put anything in `context`. A collector that promotes `requestContext.role` into `ATTR_ROLES` has handed that caller its own authorization input: the token says who you are, and then the body says what you may do. It is one line, and it looks exactly like the line next to it that promotes `payload.sub`.
 
 Nothing about the data itself tells the two apart, so the type does. `requestContext` is an `UntrustedRequestContext` — an opaque brand whose contents are not reachable by property access:
@@ -117,6 +119,27 @@ Once unwrapped:
 
 A transport that builds a `CollectorContext` by hand — your own interceptor, or a test — marks the record on the way in with `markUntrustedRequestContext`. This repo's verify route does exactly that with the body's `context`, and it is the only thing that mints the brand, so a raw body object cannot reach a collector by mistake.
 
+## Deadlines and cancellation
+
+Every collector is handed an `AbortSignal` on `CollectorContext.signal`, and the fan-out it runs in is bounded three ways: a per-collector timeout (2s by default), an end-to-end deadline for the whole wave (5s), and a cap on how many collectors run at once (8). Operators tune all three through `verify.collectorTimeoutMs`, `verify.collectorDeadlineMs` and `verify.collectorConcurrency`.
+
+**Pass the signal to whatever you wait on.** That is what makes cancellation real rather than nominal:
+
+```ts
+async collect(context: CollectorContext): Promise<Attributes> {
+  const res = await fetch(this.endpoint, { signal: context.signal });
+  // …
+}
+```
+
+The pipeline stops waiting on a collector that ignores its signal — the bound does not depend on your cooperation — but the outbound call that collector started keeps running against a dependency that has already lost the request it belonged to. That is the pile-up the concurrency cap exists to prevent, and honouring the signal is how a collector stops contributing to it.
+
+The signal aborts for four reasons, and `signal.reason` says which: this collector overran its own budget, the pipeline overran its deadline, a sibling collector already failed the decision, or the caller went away.
+
+**Exceeding a bound denies the request** — `403` with `code: "collector_timeout"`. The pipeline throws `CollectorTimeoutError` and returns nothing at all, deliberately: attributes that arrived in time are a weaker input to a rule, and rules that arrived in time are a weaker *policy*, with the empty case reading as an allow wherever `rule.onEmptyRuleSet = "allow"` is set. So there is no partial answer to be tempted by. A collector that legitimately has nothing to say should return an empty `Map` promptly; timing out is never how you say that.
+
+**A rule must not carry the signal into `verify`.** It is a live handle on the request — `aborted` moves on its own — so holding one and reading it inside `verify` is the same violation as holding `ctx.resource`, and the [rule purity conformance suite](#a-rule-decides-from-attrs-and-only-from-attrs) catches it as one.
+
 ## Writing a custom AttributeCollector
 
 `AttributeCollector` is defined in `@o3co/auth.policy-verifier.core`:
@@ -129,7 +152,7 @@ interface AttributeCollector {
 
 - One collector should produce a **focused set of attribute keys**. Do not bundle unrelated extractions. If you are extracting IP address and user agent, write two collectors.
 - Prefer string constants for attribute keys. See `ATTR_SCOPES`, `ATTR_PERMISSIONS`, `ATTR_ROLES`, `ATTR_USER_ID`, `ATTR_CLIENT_ID` in `@o3co/auth.policy-verifier.core`. For project-specific keys, define your own constants and **do not reuse core keys with different semantics**.
-- The `AttributePipeline` runs all collectors in parallel and merges their results: array values are concatenated, scalar/object values follow last-writer-wins. Design accordingly — do not rely on collector ordering.
+- The `AttributePipeline` runs all collectors in parallel and merges their results: array values are concatenated, scalar/object values follow last-writer-wins. Design accordingly — do not rely on collector ordering. Only so many run at once, and each is on a clock — see [Deadlines and cancellation](#deadlines-and-cancellation).
 - `CollectorContext.requestContext` is intentionally unshaped. The engine does not ship a generic `requestContext` collector because its shape is defined by each consuming project's transport or interceptor. Write a focused collector per field you need to promote; validate shapes inside that collector. It is also the one untrusted input — see [The trust boundary](#the-trust-boundary-requestcontext-is-the-callers) before you read anything out of it.
 
 ### Worked example: `ClientIpCollector`

--- a/packages/builtins/src/__tests__/collectors/PayloadScopeCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/PayloadScopeCollector.test.mts
@@ -6,10 +6,18 @@ import { ATTR_SCOPES } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { PayloadScopeCollector } from "#/collectors/PayloadScopeCollector.mjs";
 
+/**
+ * `CollectorContext.signal` is required (#115): a pipeline supplies one per
+ * collector, so a hand-built context carries one too. These fixtures are not
+ * about cancellation, so it is a signal that never aborts.
+ */
+const NEVER_CANCELLED = new AbortController().signal;
+
 const makeContext = (scope?: string): CollectorContext => ({
 	payload: { scope } satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
+	signal: NEVER_CANCELLED,
 });
 
 describe("PayloadScopeCollector", () => {
@@ -25,6 +33,7 @@ describe("PayloadScopeCollector", () => {
 			payload: {} satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 			action: "read",
+			signal: NEVER_CANCELLED,
 		};
 		const attrs = await collector.collect(ctx);
 		expect(attrs.get(ATTR_SCOPES)).toEqual([]);

--- a/packages/builtins/src/__tests__/collectors/PayloadSubjectIdCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/PayloadSubjectIdCollector.test.mts
@@ -6,6 +6,13 @@ import { ATTR_CLIENT_ID, ATTR_USER_ID } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { PayloadSubjectIdCollector } from "#/collectors/PayloadSubjectIdCollector.mjs";
 
+/**
+ * `CollectorContext.signal` is required (#115): a pipeline supplies one per
+ * collector, so a hand-built context carries one too. These fixtures are not
+ * about cancellation, so it is a signal that never aborts.
+ */
+const NEVER_CANCELLED = new AbortController().signal;
+
 describe("PayloadSubjectIdCollector", () => {
 	const collector = new PayloadSubjectIdCollector();
 
@@ -14,6 +21,7 @@ describe("PayloadSubjectIdCollector", () => {
 			payload: { sub: "u1" } satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 			action: "read",
+			signal: NEVER_CANCELLED,
 		};
 		const attrs = await collector.collect(ctx);
 		expect(attrs.get(ATTR_USER_ID)).toBe("u1");
@@ -24,6 +32,7 @@ describe("PayloadSubjectIdCollector", () => {
 			payload: { azp: "c1" } satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 			action: "read",
+			signal: NEVER_CANCELLED,
 		};
 		const attrs = await collector.collect(ctx);
 		expect(attrs.get(ATTR_CLIENT_ID)).toBe("c1");
@@ -34,6 +43,7 @@ describe("PayloadSubjectIdCollector", () => {
 			payload: {} satisfies VerifierPayload,
 			resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 			action: "read",
+			signal: NEVER_CANCELLED,
 		};
 		const attrs = await collector.collect(ctx);
 		expect(attrs.size).toBe(0);

--- a/packages/builtins/src/__tests__/collectors/RequestContextAttributeCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/RequestContextAttributeCollector.test.mts
@@ -6,10 +6,18 @@ import { markUntrustedRequestContext } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { RequestContextAttributeCollector } from "#/collectors/RequestContextAttributeCollector.mjs";
 
+/**
+ * `CollectorContext.signal` is required (#115): a pipeline supplies one per
+ * collector, so a hand-built context carries one too. These fixtures are not
+ * about cancellation, so it is a signal that never aborts.
+ */
+const NEVER_CANCELLED = new AbortController().signal;
+
 const makeContext = (requestContext?: Record<string, unknown>): CollectorContext => ({
 	payload: {},
 	resource: { raw: "document:1", resourceType: "document", resourceId: "1" },
 	action: "read",
+	signal: NEVER_CANCELLED,
 	...(requestContext !== undefined
 		? { requestContext: markUntrustedRequestContext(requestContext) }
 		: {}),

--- a/packages/builtins/src/__tests__/collectors/StaticPermissionCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/StaticPermissionCollector.test.mts
@@ -6,10 +6,18 @@ import { ATTR_PERMISSIONS } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { StaticPermissionCollector } from "#/collectors/StaticPermissionCollector.mjs";
 
+/**
+ * `CollectorContext.signal` is required (#115): a pipeline supplies one per
+ * collector, so a hand-built context carries one too. These fixtures are not
+ * about cancellation, so it is a signal that never aborts.
+ */
+const NEVER_CANCELLED = new AbortController().signal;
+
 const stubContext: CollectorContext = {
 	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
+	signal: NEVER_CANCELLED,
 };
 
 describe("StaticPermissionCollector", () => {

--- a/packages/builtins/src/__tests__/collectors/StaticRoleCollector.test.mts
+++ b/packages/builtins/src/__tests__/collectors/StaticRoleCollector.test.mts
@@ -6,10 +6,18 @@ import { ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import { StaticRoleCollector } from "#/collectors/StaticRoleCollector.mjs";
 
+/**
+ * `CollectorContext.signal` is required (#115): a pipeline supplies one per
+ * collector, so a hand-built context carries one too. These fixtures are not
+ * about cancellation, so it is a signal that never aborts.
+ */
+const NEVER_CANCELLED = new AbortController().signal;
+
 const stubContext: CollectorContext = {
 	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",
+	signal: NEVER_CANCELLED,
 };
 
 describe("StaticRoleCollector", () => {

--- a/packages/builtins/src/__tests__/module.test.mts
+++ b/packages/builtins/src/__tests__/module.test.mts
@@ -96,6 +96,7 @@ describe("builtinCollectorsModule", () => {
 			payload: {},
 			resource: { raw: "test", resourceType: "test" },
 			action: "read",
+			signal: new AbortController().signal,
 		});
 
 		expect(attrs.get("permissions")).toEqual(["admin", "read"]);

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionPermissionRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionPermissionRuleCollector.test.mts
@@ -5,6 +5,13 @@ import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifi
 import { describe, expect, it } from "vitest";
 import { ResourceActionPermissionRuleCollector } from "#/rules/collectors/ResourceActionPermissionRuleCollector.mjs";
 
+/**
+ * `CollectorContext.signal` is required (#115): a pipeline supplies one per
+ * collector, so a hand-built context carries one too. These fixtures are not
+ * about cancellation, so it is a signal that never aborts.
+ */
+const NEVER_CANCELLED = new AbortController().signal;
+
 describe("ResourceActionPermissionRuleCollector", () => {
 	const collector = new ResourceActionPermissionRuleCollector();
 
@@ -13,6 +20,7 @@ describe("ResourceActionPermissionRuleCollector", () => {
 			payload: {} satisfies VerifierPayload,
 			resource: { raw: "document:12345", resourceType: "document", resourceId: "12345" },
 			action: "read",
+			signal: NEVER_CANCELLED,
 		};
 		const rules = await collector.collect(ctx);
 		expect(rules).toHaveLength(1);
@@ -27,6 +35,7 @@ describe("ResourceActionPermissionRuleCollector", () => {
 			payload: {} satisfies VerifierPayload,
 			resource: { raw: "project:1.member", resourceType: "project_member" },
 			action: "update",
+			signal: NEVER_CANCELLED,
 		};
 		const rules = await collector.collect(ctx);
 		const attrs = new Map([["permissions", ["project:1.member.perm:update"]]]);

--- a/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
+++ b/packages/builtins/src/__tests__/rules/collectors/ResourceActionScopeRuleCollector.test.mts
@@ -5,10 +5,18 @@ import type { CollectorContext, VerifierPayload } from "@o3co/auth.policy-verifi
 import { describe, expect, it } from "vitest";
 import { ResourceActionScopeRuleCollector } from "#/rules/collectors/ResourceActionScopeRuleCollector.mjs";
 
+/**
+ * `CollectorContext.signal` is required (#115): a pipeline supplies one per
+ * collector, so a hand-built context carries one too. These fixtures are not
+ * about cancellation, so it is a signal that never aborts.
+ */
+const NEVER_CANCELLED = new AbortController().signal;
+
 const makeContext = (resourceType: string, action: string, scope?: string): CollectorContext => ({
 	payload: { ...(scope !== undefined ? { scope } : {}) } satisfies VerifierPayload,
 	resource: { raw: `${resourceType}:1`, resourceType, resourceId: "1" },
 	action,
+	signal: NEVER_CANCELLED,
 });
 
 describe("ResourceActionScopeRuleCollector", () => {
@@ -28,6 +36,7 @@ describe("ResourceActionScopeRuleCollector", () => {
 			payload: { scope: "update:project_member" } satisfies VerifierPayload,
 			resource: { raw: "project:1.member:2", resourceType: "project_member", resourceId: "2" },
 			action: "update",
+			signal: NEVER_CANCELLED,
 		};
 		const rules = await collector.collect(ctx);
 		expect(rules).toHaveLength(1);
@@ -71,6 +80,7 @@ describe("ResourceActionScopeRuleCollector", () => {
 			payload: { scope: "read:document" } satisfies VerifierPayload,
 			resource: { raw: "document:1", resourceType: "document", resourceId: "1" },
 			action: "read",
+			signal: NEVER_CANCELLED,
 		};
 		const rules = await collector.collect(ctx);
 		expect(rules).toHaveLength(1);

--- a/packages/core/README.ja.md
+++ b/packages/core/README.ja.md
@@ -41,23 +41,39 @@ function evaluate(attrs: Attributes, rules: Rule[], options?: EvaluateOptions): 
 
 ```typescript
 class AttributePipeline {
-  constructor(collectors: AttributeCollector[])
-  collect(context: CollectorContext): Promise<Attributes>
+  constructor(collectors: AttributeCollector[], limits?: CollectorLimits)
+  collect(request: CollectorRequest): Promise<Attributes>
 }
 ```
 
 すべてのコレクターを並列実行し、結果をマージします。配列値は結合され、それ以外の型は後書きが優先されます。
 
+fan-out には上限があります — [コレクターの上限](#コレクターの上限) を参照。`collect` は `CollectorRequest`（`signal` を持たないリクエスト）を受け取り、各コレクター用の `signal` は pipeline が供給します。
+
 ### RulePipeline
 
 ```typescript
 class RulePipeline {
-  constructor(collectors: RuleCollector[])
-  collect(context: CollectorContext): Promise<Rule[]>
+  constructor(collectors: RuleCollector[], limits?: CollectorLimits)
+  collect(request: CollectorRequest): Promise<Rule[]>
 }
 ```
 
-すべてのコレクターを並列実行し、結果を単一の配列にフラット化します。
+すべてのコレクターを並列実行し、結果を単一の配列にフラット化します。上限は `AttributePipeline` と同じです。
+
+### コレクターの上限
+
+```typescript
+interface CollectorLimits {
+  collectorTimeoutMs?: number; // コレクター 1 本の予算;        既定 2000
+  deadlineMs?: number;         // pipeline 単位の fan-out 全体; 既定 5000
+  concurrency?: number;        // 同時実行数;                   既定 8
+}
+```
+
+コレクターはデータベースや HTTP API を呼ぶため、素の `Promise.all` で走らせる pipeline には待つのをやめる手段がありませんでした。各コレクターには `CollectorContext.signal` で専用の `AbortSignal` と専用の予算が渡され、fan-out 全体にはデッドラインが付き、同時に走るのは `concurrency` 本までです。何も渡さなければすべて既定値が適用されるため、上限なしで構築した pipeline も保護されています。正の整数でない上限はコンストラクタが `RangeError` で拒否します（黙って無視しません） — `concurrency: 0` は「何も集めずに解決する」になってしまうためです。
+
+**上限に達した場合は `CollectorTimeoutError` を送出し、部分的な解決は決してしません。** 部分的な attribute は Rule の入力を弱め、部分的な Rule はポリシー自体を弱めます — ルールが空なら `{ onEmptyRuleSet: "allow" }` の下では allow です。認可経路に「集まったぶんで答える」の安全な形は存在しません。
 
 ### Registry\<T\>
 
@@ -99,7 +115,10 @@ interface ModuleContext {
 | `Resource` | `{ raw: string; resourceType: string; resourceId?: string }` — パース済みリソース |
 | `ResourceParser` | `parse(raw: string): Resource` — 生のリソース文字列を `Resource` に変換する。パース対象の構文に合わない文字列には `ResourceParseError` を送出する |
 | `ResourceParseError` | `raw`（拒否した文字列）と `detail`（理由）を持つ `Error` サブクラス。サーバーエラーではなく**リクエスト**エラーであり、トランスポート層は 400 系で応答する。クラスとして export されるため `instanceof` で絞り込める |
-| `CollectorContext` | 各コレクターに渡される入力: `payload`、`resource`、`action`、省略可能な `headers` と `requestContext` |
+| `CollectorContext` | 各コレクターに渡される入力: `payload`、`resource`、`action`、`signal`、省略可能な `headers` と `requestContext` |
+| `CollectorRequest` | pipeline が受け取る形: コレクター単位の `signal` を除いた `CollectorContext`。`signal` は pipeline が供給する。こちらの省略可能な `signal` は呼び出し側のキャンセルで、pipeline 側の signal に連結される |
+| `CollectorLimits` | `{ collectorTimeoutMs?, deadlineMs?, concurrency? }` — pipeline が fan-out に課す上限。[コレクターの上限](#コレクターの上限) を参照 |
+| `CollectorTimeoutError` | コレクターが予算を、または fan-out がデッドラインを超えたときに送出される `Error` サブクラス。`pipeline` / `limit` / `timeoutMs` と、コレクター単位のタイムアウトでは `collector` を持つ。**劣化ではなく deny** — pipeline は何も返さない |
 | `UntrustedRequestContext` | `requestContext` の型 — 呼び出し側のデータであり、読むには明示的な `readUntrustedRequestContext(...)` が必要な形で封じられている。トランスポート境界で生成するのは `markUntrustedRequestContext(...)`。[docs/extending.ja.md — 信頼境界](../../docs/extending.ja.md#信頼境界-requestcontext-は呼び出し側のもの) を参照 |
 | `Attributes` | `Map<string, unknown>` — サブジェクト属性のバッグ。可変: コレクターがこれを組み立て、`AttributePipeline` がマージする |
 | `ReadonlyAttributes` | `ReadonlyMap<string, unknown>` — Rule が判定対象として受け取るビュー。評価器は同一の live map をすべての Rule に渡すため、書き込む Rule は以降の全グループの入力を書き換えてしまう |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,23 +35,39 @@ An **empty rule set is denied** (`code: "no_applicable_rule"`): a request no rul
 
 ```typescript
 class AttributePipeline {
-  constructor(collectors: AttributeCollector[])
-  collect(context: CollectorContext): Promise<Attributes>
+  constructor(collectors: AttributeCollector[], limits?: CollectorLimits)
+  collect(request: CollectorRequest): Promise<Attributes>
 }
 ```
 
 Runs all collectors in parallel and merges the results. Array values are concatenated; for all other types, the last writer wins.
 
+The fan-out is bounded — see [Collector limits](#collector-limits). `collect` takes a `CollectorRequest` (the request without a `signal`); the pipeline supplies each collector its own.
+
 ### RulePipeline
 
 ```typescript
 class RulePipeline {
-  constructor(collectors: RuleCollector[])
-  collect(context: CollectorContext): Promise<Rule[]>
+  constructor(collectors: RuleCollector[], limits?: CollectorLimits)
+  collect(request: CollectorRequest): Promise<Rule[]>
 }
 ```
 
-Runs all collectors in parallel and flattens their results into a single array.
+Runs all collectors in parallel and flattens their results into a single array, under the same bounds as `AttributePipeline`.
+
+### Collector limits
+
+```typescript
+interface CollectorLimits {
+  collectorTimeoutMs?: number; // one collector's budget;      default 2000
+  deadlineMs?: number;         // the whole fan-out, per pipeline; default 5000
+  concurrency?: number;        // collectors in flight at once;    default 8
+}
+```
+
+Collectors call databases and HTTP APIs, so a pipeline that ran them under a bare `Promise.all` had no way to stop waiting. Each collector is handed its own `AbortSignal` on `CollectorContext.signal` and its own budget; the wave gets a deadline; and only `concurrency` collectors run at once. Every default is applied when nothing is passed, so a pipeline constructed with no limits is still bounded. A limit that is not a positive integer is refused by the constructor (`RangeError`) rather than ignored — `concurrency: 0` would otherwise resolve with nothing collected.
+
+**A bound that trips throws `CollectorTimeoutError`; it never resolves partially.** Partial attributes weaken a rule's inputs, and partial rules weaken the policy — an empty rule set is an allow under `{ onEmptyRuleSet: "allow" }`. There is no safe "answer with what we got" on an authorization path.
 
 ### Registry\<T\>
 
@@ -93,7 +109,10 @@ A module registers collector, parser, and key resolver factories into the provid
 | `Resource` | `{ raw: string; resourceType: string; resourceId?: string }` — parsed resource |
 | `ResourceParser` | `parse(raw: string): Resource` — converts a raw resource string into a `Resource`; throws `ResourceParseError` when the string is not in the syntax it parses |
 | `ResourceParseError` | `Error` subclass carrying `raw` (the refused string) and `detail` (why). A **request** error, not a server error — the transport layer answers it 400-class. Exported as a class, so `instanceof` narrows it |
-| `CollectorContext` | Input passed to every collector: `payload`, `resource`, `action`, optional `headers` and `requestContext` |
+| `CollectorContext` | Input passed to every collector: `payload`, `resource`, `action`, `signal`, optional `headers` and `requestContext` |
+| `CollectorRequest` | What a pipeline is handed: a `CollectorContext` without the per-collector `signal`, which the pipeline supplies. Its own optional `signal` is caller-side cancellation, linked into the pipeline's |
+| `CollectorLimits` | `{ collectorTimeoutMs?, deadlineMs?, concurrency? }` — the bounds a pipeline runs its fan-out under. See [Collector limits](#collector-limits) |
+| `CollectorTimeoutError` | `Error` subclass thrown when a collector overruns its budget or a fan-out overruns its deadline. Carries `pipeline`, `limit`, `timeoutMs` and (for a per-collector timeout) `collector`. **A deny, not a degradation** — the pipeline returns nothing at all |
 | `UntrustedRequestContext` | The type of `requestContext` — the caller's own data, sealed so it takes an explicit `readUntrustedRequestContext(...)` to read. `markUntrustedRequestContext(...)` mints one at the transport boundary. See [docs/extending.md — The trust boundary](../../docs/extending.md#the-trust-boundary-requestcontext-is-the-callers) |
 | `Attributes` | `Map<string, unknown>` — subject attribute bag. Mutable: collectors build one, and `AttributePipeline` merges them |
 | `ReadonlyAttributes` | `ReadonlyMap<string, unknown>` — the view a rule is judged against. The evaluator hands the same live map to every rule, so a rule that wrote into it would change the inputs of every group after it |

--- a/packages/core/src/AttributePipeline.mts
+++ b/packages/core/src/AttributePipeline.mts
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AttributeCollector, Attributes, CollectorContext } from "./types.mjs";
+import {
+	type CollectorLimits,
+	type ResolvedCollectorLimits,
+	resolveCollectorLimits,
+	runCollectors,
+} from "./collectorLimits.mjs";
+import type { AttributeCollector, Attributes, CollectorRequest } from "./types.mjs";
 
 /**
  * Fan-out aggregator that runs every `AttributeCollector` in parallel and merges
@@ -10,14 +16,28 @@ import type { AttributeCollector, Attributes, CollectorContext } from "./types.m
  * Merge semantics: when the same key is produced by multiple collectors,
  * array-valued entries concatenate (in collector order), and non-array values
  * are overwritten by later collectors.
+ *
+ * The fan-out is bounded (#115): each collector gets its own timeout and an
+ * `AbortSignal`, the wave as a whole gets a deadline, and only so many
+ * collectors run at once. A bound that trips **fails the collect** — see
+ * {@link CollectorLimits} and `collectorLimits.mts` for why a partial map is
+ * never returned.
  */
 export class AttributePipeline {
-	constructor(private collectors: AttributeCollector[]) {}
+	private readonly limits: ResolvedCollectorLimits;
 
-	/** Runs every collector in parallel and returns the merged attribute map. */
-	async collect(context: CollectorContext): Promise<Attributes> {
-		const results = await Promise.all(this.collectors.map((c) => c.collect(context)));
-		return merge(results);
+	constructor(
+		private collectors: AttributeCollector[],
+		limits?: CollectorLimits,
+	) {
+		// Resolved once, here, so an unusable bound is a construction failure
+		// rather than a surprise on the first request that needed it.
+		this.limits = resolveCollectorLimits(limits);
+	}
+
+	/** Runs every collector under the pipeline's bounds and returns the merged map. */
+	async collect(request: CollectorRequest): Promise<Attributes> {
+		return merge(await runCollectors(this.collectors, request, this.limits, "attribute"));
 	}
 }
 

--- a/packages/core/src/RulePipeline.mts
+++ b/packages/core/src/RulePipeline.mts
@@ -1,19 +1,37 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CollectorContext, Rule, RuleCollector } from "./types.mjs";
+import {
+	type CollectorLimits,
+	type ResolvedCollectorLimits,
+	resolveCollectorLimits,
+	runCollectors,
+} from "./collectorLimits.mjs";
+import type { CollectorRequest, Rule, RuleCollector } from "./types.mjs";
 
 /**
  * Fan-out aggregator that runs every `RuleCollector` in parallel and flattens
  * their results into a single `Rule[]`. Unlike `AttributePipeline`, rules do not
  * merge — each collector's rules are simply concatenated.
+ *
+ * The fan-out is bounded exactly as the attribute one is (#115), and failing
+ * closed matters more here: a short rule list is a *weaker policy*, and an empty
+ * one is an allow wherever a deployment set `onEmptyRuleSet: "allow"`. A bound
+ * that trips fails the collect rather than returning the rules that arrived in
+ * time.
  */
 export class RulePipeline {
-	constructor(private collectors: RuleCollector[]) {}
+	private readonly limits: ResolvedCollectorLimits;
 
-	/** Runs every collector in parallel and returns the flattened rule list. */
-	async collect(context: CollectorContext): Promise<Rule[]> {
-		const results = await Promise.all(this.collectors.map((c) => c.collect(context)));
-		return results.flat();
+	constructor(
+		private collectors: RuleCollector[],
+		limits?: CollectorLimits,
+	) {
+		this.limits = resolveCollectorLimits(limits);
+	}
+
+	/** Runs every collector under the pipeline's bounds and returns the flattened rule list. */
+	async collect(request: CollectorRequest): Promise<Rule[]> {
+		return (await runCollectors(this.collectors, request, this.limits, "rule")).flat();
 	}
 }

--- a/packages/core/src/__tests__/AttributePipeline.test.mts
+++ b/packages/core/src/__tests__/AttributePipeline.test.mts
@@ -7,10 +7,13 @@ import type {
 	AttributeCollector,
 	Attributes,
 	CollectorContext,
+	CollectorRequest,
 	VerifierPayload,
 } from "../types.mjs";
 
-const stubContext: CollectorContext = {
+// A `CollectorRequest`, not a `CollectorContext`: the per-collector `signal` is
+// the pipeline's to supply, and this is the shape a transport hands it (#115).
+const stubContext: CollectorRequest = {
 	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",

--- a/packages/core/src/__tests__/RulePipeline.test.mts
+++ b/packages/core/src/__tests__/RulePipeline.test.mts
@@ -3,9 +3,16 @@
 
 import { describe, expect, it } from "vitest";
 import { RulePipeline } from "../RulePipeline.mjs";
-import type { CollectorContext, Rule, RuleCollector, VerifierPayload } from "../types.mjs";
+import type {
+	CollectorContext,
+	CollectorRequest,
+	Rule,
+	RuleCollector,
+	VerifierPayload,
+} from "../types.mjs";
 
-const stubContext: CollectorContext = {
+// A `CollectorRequest`, not a `CollectorContext` — see AttributePipeline.test.mts.
+const stubContext: CollectorRequest = {
 	payload: {} satisfies VerifierPayload,
 	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
 	action: "read",

--- a/packages/core/src/__tests__/collectorLimits.test.mts
+++ b/packages/core/src/__tests__/collectorLimits.test.mts
@@ -1,0 +1,568 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import { AttributePipeline } from "../AttributePipeline.mjs";
+import {
+	DEFAULT_COLLECT_DEADLINE_MS,
+	DEFAULT_COLLECTOR_CONCURRENCY,
+	DEFAULT_COLLECTOR_TIMEOUT_MS,
+} from "../collectorLimits.mjs";
+import { CollectorTimeoutError } from "../errors.mjs";
+import { RulePipeline } from "../RulePipeline.mjs";
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorRequest,
+	Rule,
+	RuleCollector,
+} from "../types.mjs";
+
+const request: CollectorRequest = {
+	payload: {},
+	resource: { raw: "test:1", resourceType: "test", resourceId: "1" },
+	action: "read",
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * A collector that never settles and never looks at its signal — the shape the
+ * whole issue is about. A collector that cooperates cannot prove the pipeline
+ * bounds anything, because it is the collector doing the bounding.
+ */
+const hanging = (): AttributeCollector => ({
+	collect: () => new Promise<Attributes>(() => {}),
+});
+
+/** A collector that rejects as soon as its signal aborts, recording that it did. */
+function cancellable(): { collector: AttributeCollector; aborted: () => boolean } {
+	let aborted = false;
+	return {
+		aborted: () => aborted,
+		collector: {
+			collect: (context) =>
+				new Promise<Attributes>((_, reject) => {
+					context.signal.addEventListener(
+						"abort",
+						() => {
+							aborted = true;
+							reject(context.signal.reason);
+						},
+						{ once: true },
+					);
+				}),
+		},
+	};
+}
+
+describe("AttributePipeline — collector cancellation (#115)", () => {
+	it("hands every collector an AbortSignal to pass to its own I/O", async () => {
+		const seen: AbortSignal[] = [];
+		const record = (): AttributeCollector => ({
+			collect: async (context) => {
+				seen.push(context.signal);
+				return new Map();
+			},
+		});
+
+		await new AttributePipeline([record(), record()]).collect(request);
+
+		expect(seen).toHaveLength(2);
+		for (const signal of seen) {
+			expect(signal).toBeInstanceOf(AbortSignal);
+			// Not aborted: a collector that finished was not cancelled, and a
+			// signal that aborts on success would make `signal.aborted` useless
+			// for telling "the request is over" from "you were cut off".
+			expect(signal.aborted).toBe(false);
+		}
+	});
+
+	it("gives each collector its own signal, so one timing out does not cancel the rest", async () => {
+		const seen = new Set<AbortSignal>();
+		const record = (): AttributeCollector => ({
+			collect: async (context) => {
+				seen.add(context.signal);
+				return new Map();
+			},
+		});
+
+		await new AttributePipeline([record(), record(), record()]).collect(request);
+
+		expect(seen.size).toBe(3);
+	});
+
+	it("propagates a signal the caller already aborted without running any collector", async () => {
+		let started = false;
+		const collector: AttributeCollector = {
+			collect: async () => {
+				started = true;
+				return new Map();
+			},
+		};
+		const controller = new AbortController();
+		controller.abort(new Error("client went away"));
+
+		await expect(
+			new AttributePipeline([collector]).collect({ ...request, signal: controller.signal }),
+		).rejects.toThrow("client went away");
+		expect(started).toBe(false);
+	});
+
+	it("cancels in-flight collectors when the caller aborts mid-collect", async () => {
+		const { collector, aborted } = cancellable();
+		const controller = new AbortController();
+		const collecting = new AttributePipeline([collector]).collect({
+			...request,
+			signal: controller.signal,
+		});
+
+		await sleep(5);
+		controller.abort(new Error("client went away"));
+
+		await expect(collecting).rejects.toThrow("client went away");
+		expect(aborted()).toBe(true);
+	});
+});
+
+describe("AttributePipeline — per-collector timeout (#115)", () => {
+	it("refuses a collector that overruns its own budget", async () => {
+		const pipeline = new AttributePipeline([hanging()], {
+			collectorTimeoutMs: 20,
+			deadlineMs: 1_000,
+		});
+
+		await expect(pipeline.collect(request)).rejects.toBeInstanceOf(CollectorTimeoutError);
+	});
+
+	it("aborts the stalled collector's signal so its own I/O is cancelled too", async () => {
+		const { collector, aborted } = cancellable();
+		const pipeline = new AttributePipeline([collector], { collectorTimeoutMs: 20 });
+
+		await expect(pipeline.collect(request)).rejects.toBeInstanceOf(CollectorTimeoutError);
+		expect(aborted()).toBe(true);
+	});
+
+	it("names the collector that stalled and the budget it overran", async () => {
+		class SlowStoreCollector implements AttributeCollector {
+			collect(): Promise<Attributes> {
+				return new Promise<Attributes>(() => {});
+			}
+		}
+		const pipeline = new AttributePipeline([new SlowStoreCollector()], { collectorTimeoutMs: 20 });
+
+		const error = await pipeline.collect(request).catch((cause: unknown) => cause);
+
+		expect(error).toBeInstanceOf(CollectorTimeoutError);
+		const timeout = error as CollectorTimeoutError;
+		expect(timeout.pipeline).toBe("attribute");
+		expect(timeout.limit).toBe("collector");
+		expect(timeout.timeoutMs).toBe(20);
+		expect(timeout.message).toContain("SlowStoreCollector");
+	});
+
+	it("starts a queued collector's budget when it starts, not when the fan-out did", async () => {
+		// With a concurrency of 1 the second collector waits for the first. If its
+		// timeout ran from the fan-out's start it would be dead on arrival — the
+		// bound would punish a collector for the queue rather than for its own
+		// latency.
+		let secondRan = false;
+		const slow: AttributeCollector = {
+			collect: async () => {
+				await sleep(40);
+				return new Map();
+			},
+		};
+		const quick: AttributeCollector = {
+			collect: async () => {
+				secondRan = true;
+				return new Map();
+			},
+		};
+		const pipeline = new AttributePipeline([slow, quick], {
+			collectorTimeoutMs: 60,
+			deadlineMs: 1_000,
+			concurrency: 1,
+		});
+
+		await pipeline.collect(request);
+
+		expect(secondRan).toBe(true);
+	});
+
+	it("bounds a stalled collector even when nothing is configured", async () => {
+		vi.useFakeTimers();
+		try {
+			const settled = expect(
+				new AttributePipeline([hanging()]).collect(request),
+			).rejects.toBeInstanceOf(CollectorTimeoutError);
+			await vi.advanceTimersByTimeAsync(DEFAULT_COLLECTOR_TIMEOUT_MS);
+			await settled;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("AttributePipeline — end-to-end deadline (#115)", () => {
+	it("refuses a fan-out that overruns the deadline though no collector overran its own budget", async () => {
+		const slow = (): AttributeCollector => ({
+			collect: async () => {
+				await sleep(30);
+				return new Map();
+			},
+		});
+		const pipeline = new AttributePipeline([slow(), slow(), slow(), slow()], {
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 50,
+			concurrency: 1,
+		});
+
+		const error = await pipeline.collect(request).catch((cause: unknown) => cause);
+
+		expect(error).toBeInstanceOf(CollectorTimeoutError);
+		const timeout = error as CollectorTimeoutError;
+		expect(timeout.limit).toBe("deadline");
+		expect(timeout.timeoutMs).toBe(50);
+	});
+
+	it("cancels whatever is still running when the deadline expires", async () => {
+		const { collector, aborted } = cancellable();
+		const pipeline = new AttributePipeline([collector], {
+			collectorTimeoutMs: 10_000,
+			deadlineMs: 20,
+		});
+
+		await expect(pipeline.collect(request)).rejects.toBeInstanceOf(CollectorTimeoutError);
+		expect(aborted()).toBe(true);
+	});
+
+	it("leaves no timer pending once the fan-out is over", async () => {
+		// Every bound is a `setTimeout`, and there are two per collector plus one
+		// per fan-out, on every decision. One left uncleared would hold a Node
+		// worker open for its full duration and pile up under load — a leak
+		// measured in seconds per request, which is exactly the resource problem
+		// this module exists to fix rather than to cause.
+		vi.useFakeTimers();
+		try {
+			const quick = (): AttributeCollector => ({ collect: async () => new Map() });
+			const before = vi.getTimerCount();
+
+			await new AttributePipeline([quick(), quick(), quick()]).collect(request);
+			expect(vi.getTimerCount()).toBe(before);
+
+			// And on the failing path, where the `finally` has to survive a throw.
+			const failing: AttributeCollector = {
+				collect: async () => {
+					throw new Error("attribute store is down");
+				},
+			};
+			await expect(new AttributePipeline([failing, quick()]).collect(request)).rejects.toThrow(
+				"attribute store is down",
+			);
+			expect(vi.getTimerCount()).toBe(before);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("ships a deadline no shorter than one collector's budget", () => {
+		// A deadline under the per-collector timeout would make the per-collector
+		// bound unreachable: every stall would be reported as a deadline, and the
+		// error would never name the collector responsible.
+		expect(DEFAULT_COLLECT_DEADLINE_MS).toBeGreaterThanOrEqual(DEFAULT_COLLECTOR_TIMEOUT_MS);
+	});
+});
+
+describe("AttributePipeline — concurrency bound (#115)", () => {
+	it("never has more than the configured number of collectors in flight", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		const collector = (): AttributeCollector => ({
+			collect: async () => {
+				inFlight += 1;
+				peak = Math.max(peak, inFlight);
+				await sleep(5);
+				inFlight -= 1;
+				return new Map();
+			},
+		});
+		const pipeline = new AttributePipeline(Array.from({ length: 12 }, collector), {
+			concurrency: 3,
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 5_000,
+		});
+
+		await pipeline.collect(request);
+
+		expect(peak).toBe(3);
+	});
+
+	it("still runs every collector, and merges them in collector order", async () => {
+		const collector = (value: string): AttributeCollector => ({
+			collect: async () => {
+				await sleep(2);
+				return new Map([["scopes", [value]]]);
+			},
+		});
+		const pipeline = new AttributePipeline(
+			["a", "b", "c", "d", "e"].map(collector),
+			// Below the collector count on purpose: the merge order is the
+			// collector list's, not the order they happened to finish in.
+			{ concurrency: 2, collectorTimeoutMs: 1_000, deadlineMs: 5_000 },
+		);
+
+		const attrs = await pipeline.collect(request);
+
+		expect(attrs.get("scopes")).toEqual(["a", "b", "c", "d", "e"]);
+	});
+
+	it("ships a concurrency bound that a normal collector set does not notice", () => {
+		expect(DEFAULT_COLLECTOR_CONCURRENCY).toBeGreaterThanOrEqual(4);
+	});
+});
+
+describe("AttributePipeline — fail closed (#115)", () => {
+	it("never returns the attributes it did collect when another collector stalls", async () => {
+		const fast: AttributeCollector = {
+			collect: async () => new Map([["scopes", ["read:project"]]]),
+		};
+		const pipeline = new AttributePipeline([fast, hanging()], {
+			collectorTimeoutMs: 20,
+			deadlineMs: 1_000,
+		});
+
+		// The dangerous shape is a pipeline that resolves with what it managed to
+		// gather: a missing `scopes` attribute is a *deny* for a scope rule, but a
+		// missing rule is an empty rule set — which a deployment that set
+		// `onEmptyRuleSet: "allow"` turns into a permit. Partial results must not
+		// exist for either pipeline.
+		await expect(pipeline.collect(request)).rejects.toBeInstanceOf(CollectorTimeoutError);
+	});
+
+	it("cancels the collectors still running when one of them fails", async () => {
+		const { collector: sibling, aborted } = cancellable();
+		const failing: AttributeCollector = {
+			collect: async () => {
+				await sleep(5);
+				throw new Error("attribute store is down");
+			},
+		};
+		const pipeline = new AttributePipeline([failing, sibling], {
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 5_000,
+		});
+
+		await expect(pipeline.collect(request)).rejects.toThrow("attribute store is down");
+		expect(aborted()).toBe(true);
+	});
+
+	it("does not invoke a collector whose decision the deadline already ended", async () => {
+		// The distinction that matters: not "cancelled after starting" but never
+		// started. A collector that passes its signal to `fetch` — the documented
+		// way to use it — has already put the request on the wire by the time it
+		// could notice `aborted`, and that request is amplification against the
+		// dependency whose slowness ended the decision.
+		let invoked = 0;
+		const slow: AttributeCollector = {
+			collect: async () => {
+				await sleep(60);
+				return new Map();
+			},
+		};
+		const later = (): AttributeCollector => ({
+			collect: async () => {
+				invoked += 1;
+				return new Map();
+			},
+		});
+		const pipeline = new AttributePipeline([slow, later(), later(), later()], {
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 25,
+			concurrency: 1,
+		});
+
+		await expect(pipeline.collect(request)).rejects.toBeInstanceOf(CollectorTimeoutError);
+		expect(invoked).toBe(0);
+	});
+
+	it("blames the deadline, not the collector it never ran", async () => {
+		// A skipped collector did not overrun anything — the set ended. Reporting
+		// it as that collector's own timeout would send an operator to tune a
+		// budget that was never spent.
+		const slow: AttributeCollector = {
+			collect: async () => {
+				await sleep(60);
+				return new Map();
+			},
+		};
+		class NeverRanCollector implements AttributeCollector {
+			async collect(): Promise<Attributes> {
+				return new Map();
+			}
+		}
+		const pipeline = new AttributePipeline([slow, new NeverRanCollector()], {
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 25,
+			concurrency: 1,
+		});
+
+		const error = (await pipeline
+			.collect(request)
+			.catch((cause: unknown) => cause)) as CollectorTimeoutError;
+
+		expect(error.limit).toBe("deadline");
+		expect(error.message).not.toContain("NeverRanCollector");
+	});
+
+	it("propagates a sibling's failure to the collectors it never let start", async () => {
+		// Same guarantee for the other two ways a fan-out ends: the reason is
+		// carried through unchanged rather than replaced by a timeout.
+		let invoked = 0;
+		const failing: AttributeCollector = {
+			collect: async () => {
+				await sleep(5);
+				throw new Error("attribute store is down");
+			},
+		};
+		const later = (): AttributeCollector => ({
+			collect: async () => {
+				invoked += 1;
+				return new Map();
+			},
+		});
+		const pipeline = new AttributePipeline([failing, later(), later()], {
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 5_000,
+			concurrency: 1,
+		});
+
+		await expect(pipeline.collect(request)).rejects.toThrow("attribute store is down");
+		expect(invoked).toBe(0);
+	});
+
+	it("does not start another collector once the fan-out has already failed", async () => {
+		let started = 0;
+		const failing: AttributeCollector = {
+			collect: async () => {
+				started += 1;
+				throw new Error("attribute store is down");
+			},
+		};
+		const later = (): AttributeCollector => ({
+			collect: async () => {
+				started += 1;
+				return new Map();
+			},
+		});
+		const pipeline = new AttributePipeline([failing, later(), later(), later()], {
+			concurrency: 1,
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 5_000,
+		});
+
+		await expect(pipeline.collect(request)).rejects.toThrow("attribute store is down");
+		expect(started).toBe(1);
+	});
+});
+
+describe("collector limits — refused at construction (#115)", () => {
+	it.each([
+		["a zero timeout", { collectorTimeoutMs: 0 }],
+		["a negative timeout", { collectorTimeoutMs: -1 }],
+		["a fractional timeout", { collectorTimeoutMs: 1.5 }],
+		["NaN", { collectorTimeoutMs: Number.NaN }],
+		[
+			"an infinite deadline — the unbounded case the knob exists to prevent",
+			{
+				deadlineMs: Number.POSITIVE_INFINITY,
+			},
+		],
+		["a zero deadline", { deadlineMs: 0 }],
+		["a zero concurrency — a fan-out that would run nothing at all", { concurrency: 0 }],
+		["a fractional concurrency", { concurrency: 2.5 }],
+	])("refuses %s", (_label, limits) => {
+		// Refused where it is written, not silently repaired: a concurrency of 0
+		// would otherwise resolve every request with no collector having run — an
+		// empty attribute map and an empty rule set, which is exactly the
+		// fail-open the deadline work exists to close.
+		expect(() => new AttributePipeline([], limits)).toThrow(RangeError);
+		expect(() => new RulePipeline([], limits)).toThrow(RangeError);
+	});
+
+	it("accepts the resolved shape a config boundary produces", () => {
+		expect(
+			() =>
+				new AttributePipeline([], { collectorTimeoutMs: 2_000, deadlineMs: 5_000, concurrency: 8 }),
+		).not.toThrow();
+	});
+});
+
+describe("RulePipeline — collector deadlines (#115)", () => {
+	const rule = (code: string): Rule => ({
+		ruleType: "scope",
+		code,
+		message: `Failed: ${code}`,
+		verify: () => true,
+	});
+
+	it("hands every rule collector an AbortSignal", async () => {
+		let seen: AbortSignal | undefined;
+		const collector: RuleCollector = {
+			collect: async (context) => {
+				seen = context.signal;
+				return [rule("ok")];
+			},
+		};
+
+		await new RulePipeline([collector]).collect(request);
+
+		expect(seen).toBeInstanceOf(AbortSignal);
+	});
+
+	it("refuses a rule collector that overruns its budget rather than returning fewer rules", async () => {
+		const present: RuleCollector = { collect: async () => [rule("ok")] };
+		const stalled: RuleCollector = { collect: () => new Promise<Rule[]>(() => {}) };
+		const pipeline = new RulePipeline([present, stalled], {
+			collectorTimeoutMs: 20,
+			deadlineMs: 1_000,
+		});
+
+		// The rule pipeline is where a partial result is most dangerous: fewer
+		// rules is a *weaker* policy, and no rules at all is an empty rule set.
+		await expect(pipeline.collect(request)).rejects.toBeInstanceOf(CollectorTimeoutError);
+	});
+
+	it("names the rule pipeline in the failure", async () => {
+		const pipeline = new RulePipeline([{ collect: () => new Promise<Rule[]>(() => {}) }], {
+			collectorTimeoutMs: 20,
+		});
+
+		const error = await pipeline.collect(request).catch((cause: unknown) => cause);
+
+		expect((error as CollectorTimeoutError).pipeline).toBe("rule");
+	});
+
+	it("bounds concurrency the same way the attribute pipeline does", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		const collector = (): RuleCollector => ({
+			collect: async () => {
+				inFlight += 1;
+				peak = Math.max(peak, inFlight);
+				await sleep(5);
+				inFlight -= 1;
+				return [];
+			},
+		});
+		const pipeline = new RulePipeline(Array.from({ length: 8 }, collector), {
+			concurrency: 2,
+			collectorTimeoutMs: 1_000,
+			deadlineMs: 5_000,
+		});
+
+		await pipeline.collect(request);
+
+		expect(peak).toBe(2);
+	});
+});

--- a/packages/core/src/__tests__/untrusted.test.mts
+++ b/packages/core/src/__tests__/untrusted.test.mts
@@ -52,6 +52,7 @@ describe("UntrustedRequestContext", () => {
 			resource: { raw: "project:1", resourceType: "project", resourceId: "1" },
 			action: "read",
 			requestContext: markUntrustedRequestContext({ tenant: "acme" }),
+			signal: new AbortController().signal,
 		};
 
 		expect(readUntrustedRequestContext(context.requestContext)).toEqual({ tenant: "acme" });

--- a/packages/core/src/collectorLimits.mts
+++ b/packages/core/src/collectorLimits.mts
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * What a collector fan-out is allowed to cost, and the one runner that enforces
+ * it (#115).
+ *
+ * Collectors are designed to call databases and HTTP APIs — that is the whole
+ * point of the layer — and both pipelines used to run them under a bare
+ * `Promise.all`. A `Promise.all` has no deadline, no cancellation and no bound
+ * on how much work it starts, so one collector holding a dead socket held the
+ * decision with it, on the authorization hot path, for as long as the socket
+ * took to notice. The siblings kept running after one of them had already
+ * failed the request, and a dependency slowdown piled up unbounded in-flight
+ * work rather than shedding it.
+ *
+ * Three bounds, because each catches something the others cannot:
+ *
+ * - a **per-collector timeout**, which names the collector that stalled;
+ * - an **end-to-end deadline**, which catches a fan-out where nothing overran
+ *   its own budget but the total still did — the shape a queue produces;
+ * - a **concurrency bound**, which is what stops a slow dependency from turning
+ *   one request into an unbounded number of simultaneous outbound calls.
+ *
+ * And one rule over all three: **a bound that trips fails the collect.** It
+ * never resolves with what it managed to gather. Partial attributes weaken a
+ * rule's inputs and partial rules weaken the policy itself — an empty rule set
+ * is an *allow* under `onEmptyRuleSet: "allow"` — so "return what we have" is
+ * the one implementation that turns a timeout into a permit. See the fail-closed
+ * suite in `__tests__/collectorLimits.test.mts`.
+ */
+
+import { CollectorTimeoutError } from "./errors.mjs";
+import type { CollectorContext, CollectorRequest } from "./types.mjs";
+
+/**
+ * How long one collector may take before it is cancelled and the decision
+ * fails.
+ *
+ * Two seconds: a collector on this path is doing one lookup against a
+ * dependency the deployment runs (a session store, a directory, an entitlement
+ * API), and a healthy one answers in single-digit milliseconds. Two seconds is
+ * far past "slow" and well short of the timeouts callers put on the verify call
+ * itself, so the verifier is the layer that notices — and it can say *which*
+ * collector, which a caller-side timeout never can.
+ */
+export const DEFAULT_COLLECTOR_TIMEOUT_MS = 2_000;
+
+/**
+ * How long the whole fan-out may take, per pipeline, however many collectors
+ * are configured.
+ *
+ * Five seconds — deliberately more than one collector's budget and less than
+ * the sum of several. The per-collector timeout cannot bound a *set*: with the
+ * concurrency cap in play, collectors queue, and enough of them each finishing
+ * just inside their own budget still adds up to a request nobody is waiting for
+ * any more. This is the bound on the answer the caller actually experiences.
+ */
+export const DEFAULT_COLLECT_DEADLINE_MS = 5_000;
+
+/**
+ * How many collectors may be in flight at once, per pipeline, per decision.
+ *
+ * Eight: more than the collector set of any deployment this project has seen,
+ * so a normal configuration still fans out in a single wave and nothing about
+ * its latency changes. What the cap removes is the tail — a config with dozens
+ * of collectors, or a `POST /verify/batch` of 50 entries, multiplying into
+ * simultaneous outbound calls against a dependency that has just started to
+ * slow down. That is the amplification the bound exists for; the number is a
+ * ceiling on pathology, not a tuning parameter.
+ */
+export const DEFAULT_COLLECTOR_CONCURRENCY = 8;
+
+/** Which fan-out a bound was tripped in. Carried into the failure message. */
+export type CollectorPipeline = "attribute" | "rule";
+
+/**
+ * Bounds on a pipeline's collector fan-out. Every field is optional and falls
+ * back to the shipped default, so a pipeline constructed with nothing is still
+ * bounded — a library consumer does not opt into being fail-closed.
+ *
+ * A deployment sets these through `verify.collectorTimeoutMs`,
+ * `verify.collectorDeadlineMs` and `verify.collectorConcurrency`; the server
+ * package holds those to the same bound at both of its config boundaries (see
+ * AGENTS.md, "Two-Boundary Config Validation") and hands the resolved numbers
+ * here.
+ */
+export interface CollectorLimits {
+	/** Milliseconds one collector may take. Defaults to {@link DEFAULT_COLLECTOR_TIMEOUT_MS}. */
+	collectorTimeoutMs?: number;
+	/** Milliseconds the whole fan-out may take. Defaults to {@link DEFAULT_COLLECT_DEADLINE_MS}. */
+	deadlineMs?: number;
+	/** Collectors in flight at once. Defaults to {@link DEFAULT_COLLECTOR_CONCURRENCY}. */
+	concurrency?: number;
+}
+
+/** {@link CollectorLimits} with every default filled in. */
+export interface ResolvedCollectorLimits {
+	collectorTimeoutMs: number;
+	deadlineMs: number;
+	concurrency: number;
+}
+
+/**
+ * Fills in the defaults and refuses a limit that is not a positive whole
+ * number, naming the field.
+ *
+ * Refused rather than repaired, and refused at construction rather than at the
+ * first request: `concurrency: 0` would otherwise start no collector at all and
+ * resolve with an empty result — an empty attribute map and an empty rule set,
+ * which is precisely the fail-open this module exists to close. A silently
+ * ignored bound is the failure mode #157 catalogued for the config knobs.
+ *
+ * This check is deliberately *weaker* than the config layer's `resolveBound`
+ * rather than a second opinion on the same values: every number `resolveBound`
+ * produces for these knobs is a positive integer, so anything accepted there is
+ * accepted here. The two cannot reach different verdicts on a configured value
+ * — this only catches a hand-written call that never met a config boundary.
+ */
+export function resolveCollectorLimits(limits?: CollectorLimits): ResolvedCollectorLimits {
+	return {
+		collectorTimeoutMs: positive(
+			limits?.collectorTimeoutMs,
+			DEFAULT_COLLECTOR_TIMEOUT_MS,
+			"collectorTimeoutMs",
+		),
+		deadlineMs: positive(limits?.deadlineMs, DEFAULT_COLLECT_DEADLINE_MS, "deadlineMs"),
+		concurrency: positive(limits?.concurrency, DEFAULT_COLLECTOR_CONCURRENCY, "concurrency"),
+	};
+}
+
+function positive(value: number | undefined, fallback: number, field: string): number {
+	if (value === undefined) return fallback;
+	// `Number.isInteger` is false for NaN and both infinities, which is the
+	// point: an infinite bound is the unbounded case these limits exist to
+	// prevent, spelled as a setting.
+	if (!Number.isInteger(value) || value < 1) {
+		throw new RangeError(`${field} must be a positive integer, got ${String(value)}`);
+	}
+	return value;
+}
+
+/** The half of a collector this runner uses — either kind produces some `T`. */
+interface Collecting<T> {
+	collect(context: CollectorContext): Promise<T>;
+}
+
+/**
+ * Runs every collector under the configured bounds and returns their results in
+ * collector order.
+ *
+ * @throws {CollectorTimeoutError} when a collector overruns its own budget or
+ * the fan-out overruns its deadline.
+ * @throws whatever a collector rejected with, or the caller's abort reason —
+ * both unchanged, so a store outage still surfaces as the store's own error.
+ *
+ * It never resolves partially: on any failure the results gathered so far are
+ * discarded and every sibling still running is cancelled.
+ */
+export async function runCollectors<T>(
+	collectors: readonly Collecting<T>[],
+	request: CollectorRequest,
+	limits: ResolvedCollectorLimits,
+	pipeline: CollectorPipeline,
+): Promise<T[]> {
+	if (collectors.length === 0) return [];
+
+	// The fan-out's own controller. It aborts for three reasons — the deadline,
+	// the caller's signal, or a sibling having already failed the request — and
+	// every per-collector signal hangs off it, so any one of them cancels the
+	// whole wave.
+	const fanOut = new AbortController();
+	const deadline = setTimeout(() => {
+		fanOut.abort(
+			new CollectorTimeoutError({ pipeline, limit: "deadline", timeoutMs: limits.deadlineMs }),
+		);
+	}, limits.deadlineMs);
+
+	const caller = request.signal;
+	const onCallerAbort = () => fanOut.abort(caller?.reason);
+	if (caller?.aborted) {
+		fanOut.abort(caller.reason);
+	} else {
+		caller?.addEventListener("abort", onCallerAbort, { once: true });
+	}
+
+	const results = new Array<T>(collectors.length);
+	let next = 0;
+
+	/**
+	 * Pulls collectors off the shared cursor until there are none left.
+	 *
+	 * It does not test the fan-out itself before each turn: `runOne` refuses an
+	 * abandoned decision at the point the collector would actually be invoked,
+	 * and its refusal propagates out of this loop, which sheds the rest of the
+	 * queue. One check, where the thing it protects happens.
+	 */
+	const lane = async (): Promise<void> => {
+		while (next < collectors.length) {
+			const index = next++;
+			results[index] = await runOne(collectors[index], index, request, limits, pipeline, fanOut);
+		}
+	};
+
+	try {
+		await Promise.all(
+			// One lane per permit, never more than there is work for.
+			Array.from({ length: Math.min(limits.concurrency, collectors.length) }, () => lane()),
+		);
+		return results;
+	} catch (cause) {
+		// Cancel the siblings still in flight. `Promise.all` has already handed us
+		// the first failure, and without this the rest would keep holding their
+		// sockets open for a decision that has already failed.
+		fanOut.abort(cause);
+		throw cause;
+	} finally {
+		clearTimeout(deadline);
+		// The caller's signal outlives this collect — a listener left on it is a
+		// leak per decision, not per process.
+		caller?.removeEventListener("abort", onCallerAbort);
+	}
+}
+
+/**
+ * Runs one collector under its own timeout, with a signal that aborts when
+ * either that timeout or the fan-out does.
+ *
+ * The budget starts here, when the collector starts, rather than when the
+ * fan-out did: under the concurrency cap a collector waits its turn, and
+ * charging it for the queue would refuse work that had not yet begun.
+ *
+ * A collector whose decision is already lost is **not invoked at all**. Handing
+ * one an aborted signal and relying on it to notice is not the same thing: a
+ * collector that does not check `signal.aborted` before its first `await` — and
+ * most do not, because the honest way to use a signal is to pass it to `fetch`
+ * — would have already put the request on the wire. That is an outbound call
+ * for an answer nobody will read, made against a dependency that is very often
+ * the one whose slowness abandoned the decision in the first place. Refusing to
+ * start is the whole point of a concurrency bound; starting and then cancelling
+ * only bounds how long the amplification lasts.
+ */
+async function runOne<T>(
+	collector: Collecting<T>,
+	index: number,
+	request: CollectorRequest,
+	limits: ResolvedCollectorLimits,
+	pipeline: CollectorPipeline,
+	fanOut: AbortController,
+): Promise<T> {
+	if (fanOut.signal.aborted) {
+		// The reason is the fan-out's, not a timeout of this collector's own: it
+		// never ran, so it never overran anything. The *set* ended — the deadline,
+		// a sibling's failure, or the caller leaving — and the failure keeps
+		// naming whichever it was. Rethrowing rather than resolving is what keeps
+		// the collect fail-closed: a skipped collector must not read as one that
+		// contributed nothing.
+		throw fanOut.signal.reason;
+	}
+
+	const own = new AbortController();
+	const inheritAbort = () => own.abort(fanOut.signal.reason);
+	fanOut.signal.addEventListener("abort", inheritAbort, { once: true });
+
+	const timeout = setTimeout(() => {
+		own.abort(
+			new CollectorTimeoutError({
+				pipeline,
+				limit: "collector",
+				timeoutMs: limits.collectorTimeoutMs,
+				collector: describeCollector(collector, index),
+			}),
+		);
+	}, limits.collectorTimeoutMs);
+
+	const cancelled = rejectOnAbort(own.signal);
+	try {
+		const context: CollectorContext = { ...request, signal: own.signal };
+		// Raced rather than awaited: a collector that ignores its signal — the
+		// hung-socket case this is all for — would otherwise never settle, and a
+		// bound only the cooperative respect is not a bound.
+		return await Promise.race([collector.collect(context), cancelled.promise]);
+	} finally {
+		clearTimeout(timeout);
+		cancelled.dispose();
+		fanOut.signal.removeEventListener("abort", inheritAbort);
+	}
+}
+
+/**
+ * A promise that rejects with `signal.reason` when it aborts and otherwise
+ * never settles, plus the way to unsubscribe it once the race is over.
+ *
+ * **Precondition: `signal` is not yet aborted.** Its one caller creates the
+ * controller a few lines above and refuses an already-abandoned fan-out before
+ * that, so an already-aborted signal cannot reach here. There is deliberately no
+ * defensive branch for it: a listener added to an aborted signal never fires, so
+ * such a branch would be the difference between rejecting and hanging — which
+ * makes it exactly the kind of code that must be reachable to be trusted, and
+ * this one would not be. A future caller that cannot honour the precondition
+ * should reject before calling rather than adding an untested path here.
+ */
+function rejectOnAbort(signal: AbortSignal): { promise: Promise<never>; dispose: () => void } {
+	// `reject` is captured rather than the whole body being written inside the
+	// executor, so there is no placeholder `dispose` waiting to be overwritten.
+	// The executor runs synchronously, so it is assigned before the next line.
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<never>((_, rejectPromise) => {
+		reject = rejectPromise;
+	});
+	const onAbort = () => reject(signal.reason);
+	signal.addEventListener("abort", onAbort, { once: true });
+	return { promise, dispose: () => signal.removeEventListener("abort", onAbort) };
+}
+
+/**
+ * Names a collector the way an operator would look for it: by class, since that
+ * is what the config's `collector` key resolves to, with the index as the
+ * fallback for a collector wired as an object literal.
+ */
+function describeCollector(collector: object, index: number): string {
+	const name = collector.constructor?.name;
+	return name && name !== "Object" ? `${name} (index ${index})` : `at index ${index}`;
+}

--- a/packages/core/src/errors.mts
+++ b/packages/core/src/errors.mts
@@ -27,3 +27,67 @@ export class ResourceParseError extends Error {
 		this.name = "ResourceParseError";
 	}
 }
+
+/** Which bound tripped: one collector's own budget, or the whole fan-out's. */
+export type CollectorTimeoutLimit = "collector" | "deadline";
+
+/**
+ * What tripped, where, and against which bound.
+ *
+ * A union rather than one shape with an optional `collector`, because the two
+ * limits genuinely carry different information: a per-collector timeout always
+ * knows which collector overran, and a deadline never does — it is the *set*
+ * that ran out, and no one collector is answerable for it. Stating that in the
+ * type is what lets the message be built without a "(unnamed)" fallback for a
+ * state the pipeline cannot produce.
+ */
+export type CollectorTimeoutDetail =
+	| {
+			/** The fan-out it happened in — `"attribute"` or `"rule"`. */
+			pipeline: "attribute" | "rule";
+			limit: "collector";
+			/** The bound that was exceeded, in milliseconds. */
+			timeoutMs: number;
+			/** The collector that overran. Always known for this limit. */
+			collector: string;
+	  }
+	| {
+			pipeline: "attribute" | "rule";
+			limit: "deadline";
+			timeoutMs: number;
+	  };
+
+/**
+ * Raised when a collector fan-out exceeds one of its bounds (#115) — a single
+ * collector overrunning its own budget, or the pipeline overrunning its
+ * end-to-end deadline.
+ *
+ * **This is a deny, not a degradation.** It exists as a distinct error class so
+ * a transport can answer it as a deny of its own rather than letting it fall
+ * into a generic 500, and so the collectors that were quick cannot be mistaken
+ * for the whole answer: a pipeline that timed out returns nothing at all. A
+ * partial attribute map merely weakens a rule's inputs, but a partial rule list
+ * weakens the *policy* — and an empty one is an allow wherever
+ * `onEmptyRuleSet: "allow"` is set. There is no shape of "answer with what we
+ * got" that is safe on an authorization path, which is why this is thrown
+ * instead.
+ */
+export class CollectorTimeoutError extends Error {
+	readonly pipeline: "attribute" | "rule";
+	readonly limit: CollectorTimeoutLimit;
+	readonly timeoutMs: number;
+	readonly collector?: string;
+
+	constructor(detail: CollectorTimeoutDetail) {
+		super(
+			detail.limit === "collector"
+				? `${detail.pipeline} collector ${detail.collector} did not finish within its ${detail.timeoutMs} ms budget`
+				: `the ${detail.pipeline} pipeline did not finish within its ${detail.timeoutMs} ms deadline`,
+		);
+		this.name = "CollectorTimeoutError";
+		this.pipeline = detail.pipeline;
+		this.limit = detail.limit;
+		this.timeoutMs = detail.timeoutMs;
+		this.collector = detail.limit === "collector" ? detail.collector : undefined;
+	}
+}

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -2,7 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { AttributePipeline } from "./AttributePipeline.mjs";
-export { ResourceParseError } from "./errors.mjs";
+export type {
+	CollectorLimits,
+	CollectorPipeline,
+	ResolvedCollectorLimits,
+} from "./collectorLimits.mjs";
+export {
+	DEFAULT_COLLECT_DEADLINE_MS,
+	DEFAULT_COLLECTOR_CONCURRENCY,
+	DEFAULT_COLLECTOR_TIMEOUT_MS,
+	resolveCollectorLimits,
+} from "./collectorLimits.mjs";
+export type { CollectorTimeoutDetail, CollectorTimeoutLimit } from "./errors.mjs";
+export { CollectorTimeoutError, ResourceParseError } from "./errors.mjs";
 export type { EvaluateOptions } from "./evaluate.mjs";
 export { evaluate } from "./evaluate.mjs";
 export {
@@ -30,6 +42,7 @@ export type {
 	AttributeCollector,
 	Attributes,
 	CollectorContext,
+	CollectorRequest,
 	Decision,
 	DecisionReason,
 	KeyResolver,

--- a/packages/core/src/types.mts
+++ b/packages/core/src/types.mts
@@ -44,7 +44,46 @@ export interface CollectorContext {
 	headers?: Record<string, string>;
 	/** Caller-supplied; read it with `readUntrustedRequestContext`. */
 	requestContext?: UntrustedRequestContext;
+	/**
+	 * Cancellation for this collect, and the one field that is not a fact about
+	 * the request (#115).
+	 *
+	 * It aborts when this collector overruns its budget, when the pipeline
+	 * overruns its end-to-end deadline, when a sibling collector has already
+	 * failed the decision, or when the caller went away. Pass it to whatever
+	 * this collector waits on — `fetch(url, { signal: context.signal })`, a
+	 * driver's cancellation option — so the work stops rather than being merely
+	 * stopped waiting for.
+	 *
+	 * Always present: the pipeline supplies one per collector per decision, so
+	 * there is no `?.` and no "unbounded if nobody wired it" case. Honouring it
+	 * is not what makes the deadline hold — the pipeline abandons a collector
+	 * that ignores it — but a collector that ignores it leaves its outbound call
+	 * running after the decision it belonged to is gone.
+	 *
+	 * It is a live handle on the request, so the rule contract applies to it
+	 * exactly as to the rest of the context: a **collector** may hold it for the
+	 * duration of `collect`; a **rule** must not carry it into `verify`. See
+	 * AGENTS.md, "Collector / Rule / Attribute Contract".
+	 */
+	signal: AbortSignal;
 }
+
+/**
+ * What a pipeline is handed: the request, without the per-collector `signal`
+ * the pipeline itself supplies.
+ *
+ * The two shapes are deliberately different types. A transport builds facts
+ * about a request and has no per-collector signal to give — that one belongs to
+ * the fan-out, is different for every collector, and aborts on bounds the
+ * transport knows nothing about. `signal` here is the optional *caller-side*
+ * cancellation (a client that hung up, an outer deadline); the pipeline links
+ * it into its own, so aborting it cancels every collector in flight.
+ */
+export type CollectorRequest = Omit<CollectorContext, "signal"> & {
+	/** Optional caller-side cancellation, linked into the pipeline's own. */
+	signal?: AbortSignal;
+};
 
 /**
  * Map of attribute keys to values produced by attribute collectors.

--- a/packages/server/README.ja.md
+++ b/packages/server/README.ja.md
@@ -80,9 +80,10 @@ function createVerifyRouter(config: VerifyRouterConfig): express.Router
 4. どちらの経路でもトークン自身の寿命を検証する: `exp` と `iat` は**必須**（有効期限を宣言しないトークンは失効しない）、`nbf` は存在すれば検証、`exp` は未来でなければならず、`now - iat` は `maxTokenAgeSeconds` を超えてはならない — 発行者が何年も先の `exp` を付けたトークンを拒否するのはこれ。`clockToleranceSeconds` はこれら全ての比較に効く。失敗時は 401 を返す。デコード専用経路はこれらの検査を省略せず手書きで再現するので、同一トークンに対して両モードの答えは一致する。
 5. `req.body.resource` を `resourceParser` でパースし、`req.body.action` と `req.body.context` を読み取る。
 6. `x-request-id` ヘッダーが存在する場合、`CollectorContext.headers` に含める（コレクターが上流呼び出し時に転送可能）。
-7. `attributePipeline.collect` と `rulePipeline.collect` を並列実行し、`evaluate` を呼び出す。
+7. `attributePipeline.collect` と `rulePipeline.collect` を collector の上限（`verify.collectorTimeoutMs` / `verify.collectorDeadlineMs` / `verify.collectorConcurrency`。各 collector には `CollectorContext.signal` で `AbortSignal` が渡される）のもとで並列実行し、`evaluate` を呼び出す。
 8. `200 { decision: "allow" }` または `403 { decision: "deny", code, message }` を返す。
-9. 予期しないエラーが発生した場合は `500 { decision: "deny", code: "internal_error" }` を返す。
+9. collector または fan-out が時間切れになった場合は `403 { decision: "deny", code: "collector_timeout" }` を返す (#115)。評価器には到達させない — 一部の Rule しか集まらないことはポリシーが弱いことであり、1 つも集まらなければ `rule.onEmptyRuleSet = "allow"` では allow になるため。タイムアウトは deny にしかなり得ない。詳細は呼び出し側ではなく `collector_timeout` ログ行に出る。
+10. 予期しないエラーが発生した場合は `500 { decision: "deny", code: "internal_error" }` を返す。
 
 ### AppConfigSchema / AppConfig
 
@@ -90,7 +91,7 @@ function createVerifyRouter(config: VerifyRouterConfig): express.Router
 const AppConfigSchema = z.object({
   http: z.object({
     hostname: z.string().default("127.0.0.1"),   // ループバック — 「信頼境界」を参照
-    port: z.coerce.number().default(3000),
+    port: boundedNumber(NUMERIC_BOUNDS.port, "http"),               // 1..65535、既定 3000
     pathPrefix: z.string().default(""),
     callerAuth: z.object({                        // 任意 — 「信頼境界」を参照
       header: z.string().min(1).default("x-caller-token"),
@@ -104,8 +105,8 @@ const AppConfigSchema = z.object({
       issuer: z.union([z.string(), z.array(z.string())]).optional(),   // mode = "verify" のとき必須
       audience: z.union([z.string(), z.array(z.string())]).optional(), // mode = "verify" のとき必須
       tokenType: z.string().default("at+jwt"),
-      maxTokenAgeSeconds: z.coerce.number().int().positive().default(86400),
-      clockToleranceSeconds: z.coerce.number().int().min(0).max(300).default(0),
+      maxTokenAgeSeconds: boundedNumber(NUMERIC_BOUNDS.maxTokenAgeSeconds, "oauth.jwt"),
+      clockToleranceSeconds: boundedNumber(NUMERIC_BOUNDS.clockToleranceSeconds, "oauth.jwt"),
     }),
   }),
   attribute: z.object({
@@ -118,12 +119,33 @@ const AppConfigSchema = z.object({
     parser: z.string().default("DotNotationResourceParser"),
   }),
   verify: z.object({
-    maxBatchSize: z.coerce.number().int().positive().default(50),
+    maxBatchSize: boundedNumber(NUMERIC_BOUNDS.maxBatchSize, "verify"),           // 既定 50
+    // 1 件の決定リクエストが運べる量 (#118)。
+    maxBodyBytes: boundedNumber(NUMERIC_BOUNDS.maxBodyBytes, "verify"),           // 既定 65536
+    maxResourceLength: boundedNumber(NUMERIC_BOUNDS.maxResourceLength, "verify"), // 既定 512
+    maxActionLength: boundedNumber(NUMERIC_BOUNDS.maxActionLength, "verify"),     // 既定 64
+    maxContextEntries: boundedNumber(NUMERIC_BOUNDS.maxContextEntries, "verify"), // 既定 64
+    maxContextValueLength:
+      boundedNumber(NUMERIC_BOUNDS.maxContextValueLength, "verify"),              // 既定 1024
+    // collector fan-out の上限 (#115)。超えた決定は deny になる。
+    collectorTimeoutMs: boundedNumber(NUMERIC_BOUNDS.collectorTimeoutMs, "verify"),   // 既定 2000
+    collectorDeadlineMs: boundedNumber(NUMERIC_BOUNDS.collectorDeadlineMs, "verify"), // 既定 5000
+    collectorConcurrency:
+      boundedNumber(NUMERIC_BOUNDS.collectorConcurrency, "verify"),               // 既定 8
   }),
 });
 
 type AppConfig = z.infer<typeof AppConfigSchema>;
 ```
+
+**数値ノブはすべて、両方の境界で 1 つの関数から読まれます** (#157)。`boundedNumber` は
+[`config/bounds.mts`](src/config/bounds.mts) の `resolveBound` をラップしたもので、各ノブの既定値・
+範囲・単位は `NUMERIC_BOUNDS` に一度だけ記述されます。ランタイム側のガード（`createApp`、
+`createVerifyRouter`、各 `KeyResolverFactory`）は手組み config のために `resolveBound` を直接呼ぶため、
+両境界は同じ判定を同じ文言で返します。`z.coerce.number()` ではないのは意図的です: ノブは数値か、
+HOCON の `${?VAR}` 置換が渡す文字列のいずれかで到着し、その両方を受け付けますが、`z.coerce` は
+`true` を `1`、`null` と `""` を `0` として読んでしまいます — 空で export された環境変数が「意図的な
+ゼロ」になっていたのはこれが原因でした。非整数・`NaN`・`Infinity` も同じ理由で拒否します。
 
 `attribute.collectors` と `rule.collectors` の各エントリには `collector` フィールド（登録済みファクトリ名）が必須です。追加フィールドはファクトリへの設定としてそのまま渡されます。
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -80,9 +80,10 @@ Request flow:
 4. Either way, enforce the token's own lifetime: `exp` and `iat` are **required** (a token that never states an expiry never expires), `nbf` is honoured when present, `exp` must be in the future, and `now - iat` must not exceed `maxTokenAgeSeconds` — which is what refuses a token whose issuer set `exp` years out. `clockToleranceSeconds` widens every one of those comparisons. Returns 401 on failure. The decode-only path restates these checks by hand rather than skipping them, so both modes answer the same for the same token.
 5. Parse `req.body.resource` with `resourceParser`; read `req.body.action` and `req.body.context`.
 6. Include `x-request-id` header in `CollectorContext.headers` if present (collectors can forward it to upstream calls they make).
-7. Run `attributePipeline.collect` and `rulePipeline.collect` in parallel; call `evaluate`.
+7. Run `attributePipeline.collect` and `rulePipeline.collect` in parallel, under the collector bounds (`verify.collectorTimeoutMs`, `verify.collectorDeadlineMs`, `verify.collectorConcurrency` — each collector is handed an `AbortSignal` on `CollectorContext.signal`); call `evaluate`.
 8. Return `200 { decision: "allow" }` or `403 { decision: "deny", code, message }`.
-9. Return `500 { decision: "deny", code: "internal_error" }` on unexpected errors.
+9. Return `403 { decision: "deny", code: "collector_timeout" }` when a collector or the fan-out ran out of time (#115). The evaluator is never reached — collecting *some* of the rules is a weaker policy, and none of them is an allow under `rule.onEmptyRuleSet = "allow"` — so a timeout can only ever deny. Details go to the `collector_timeout` log line, not to the caller.
+10. Return `500 { decision: "deny", code: "internal_error" }` on unexpected errors.
 
 ### AppConfigSchema / AppConfig
 
@@ -90,7 +91,7 @@ Request flow:
 const AppConfigSchema = z.object({
   http: z.object({
     hostname: z.string().default("127.0.0.1"),   // loopback — see Trust boundary
-    port: z.coerce.number().default(3000),
+    port: boundedNumber(NUMERIC_BOUNDS.port, "http"),               // 1..65535, default 3000
     pathPrefix: z.string().default(""),
     callerAuth: z.object({                        // optional — see Trust boundary
       header: z.string().min(1).default("x-caller-token"),
@@ -104,8 +105,8 @@ const AppConfigSchema = z.object({
       issuer: z.union([z.string(), z.array(z.string())]).optional(),   // required when mode is "verify"
       audience: z.union([z.string(), z.array(z.string())]).optional(), // required when mode is "verify"
       tokenType: z.string().default("at+jwt"),
-      maxTokenAgeSeconds: z.coerce.number().int().positive().default(86400),
-      clockToleranceSeconds: z.coerce.number().int().min(0).max(300).default(0),
+      maxTokenAgeSeconds: boundedNumber(NUMERIC_BOUNDS.maxTokenAgeSeconds, "oauth.jwt"),
+      clockToleranceSeconds: boundedNumber(NUMERIC_BOUNDS.clockToleranceSeconds, "oauth.jwt"),
     }),
   }),
   attribute: z.object({
@@ -118,12 +119,34 @@ const AppConfigSchema = z.object({
     parser: z.string().default("DotNotationResourceParser"),
   }),
   verify: z.object({
-    maxBatchSize: z.coerce.number().int().positive().default(50),
+    maxBatchSize: boundedNumber(NUMERIC_BOUNDS.maxBatchSize, "verify"),           // default 50
+    // What one decision request may carry (#118).
+    maxBodyBytes: boundedNumber(NUMERIC_BOUNDS.maxBodyBytes, "verify"),           // default 65536
+    maxResourceLength: boundedNumber(NUMERIC_BOUNDS.maxResourceLength, "verify"), // default 512
+    maxActionLength: boundedNumber(NUMERIC_BOUNDS.maxActionLength, "verify"),     // default 64
+    maxContextEntries: boundedNumber(NUMERIC_BOUNDS.maxContextEntries, "verify"), // default 64
+    maxContextValueLength:
+      boundedNumber(NUMERIC_BOUNDS.maxContextValueLength, "verify"),              // default 1024
+    // Bounds on the collector fan-out (#115). Exceeding any of them denies.
+    collectorTimeoutMs: boundedNumber(NUMERIC_BOUNDS.collectorTimeoutMs, "verify"),   // default 2000
+    collectorDeadlineMs: boundedNumber(NUMERIC_BOUNDS.collectorDeadlineMs, "verify"), // default 5000
+    collectorConcurrency:
+      boundedNumber(NUMERIC_BOUNDS.collectorConcurrency, "verify"),               // default 8
   }),
 });
 
 type AppConfig = z.infer<typeof AppConfigSchema>;
 ```
+
+**Every numeric knob is read by one function at both boundaries** (#157). `boundedNumber` wraps
+`resolveBound` from [`config/bounds.mts`](src/config/bounds.mts), where `NUMERIC_BOUNDS` states each
+knob's default, range and unit once; the runtime guards (`createApp`, `createVerifyRouter`, the
+`KeyResolverFactory` implementations) call `resolveBound` directly for hand-built configs, so both
+reach the same verdict in the same words. It is deliberately **not** `z.coerce.number()`: a knob
+arrives either as a number or as the string a HOCON `${?VAR}` substitution delivers, and both are
+accepted — but `z.coerce` would also read `true` as `1`, `null` and `""` as `0`, which is how a
+variable exported empty used to become a deliberate zero. Non-integers, `NaN` and `Infinity` are
+refused for the same reason.
 
 Each entry in `attribute.collectors` and `rule.collectors` requires a `collector` field (the registered factory name). Additional fields are passed through to the factory as configuration.
 

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Logger, Module } from "@o3co/auth.policy-verifier.core";
+import type { Attributes, Logger, Module, Rule } from "@o3co/auth.policy-verifier.core";
 import { SignJWT } from "jose";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
@@ -1039,4 +1039,157 @@ describe("createApp — HS256 secret rotation (#112)", () => {
 			).rejects.toThrow(message);
 		},
 	);
+});
+
+/** A module whose collectors never answer — the stalled dependency #115 is about. */
+const stallingModule: Module = {
+	name: "stalling-module",
+	async init(context) {
+		context.attributeCollectorRegistry.register("StallingCollector", () => ({
+			collect: () => new Promise<Attributes>(() => {}),
+		}));
+		context.ruleCollectorRegistry.register("StallingRuleCollector", () => ({
+			collect: () => new Promise<Rule[]>(() => {}),
+		}));
+	},
+};
+
+describe("createApp — a stalled collector denies (#115)", () => {
+	/** Bounds low enough that the stall is answered well inside the test's own timeout. */
+	const bounds = { collectorTimeoutMs: 20, collectorDeadlineMs: 50 };
+
+	const stalledApp = (config: Record<string, unknown>) =>
+		createApp({
+			pathResolver: (s: string) => s,
+			config: AppConfigSchema.parse({
+				oauth: { jwt: { secret: JWT_SECRET, mode: "verify", issuer: ISSUER, audience: AUDIENCE } },
+				resource: { parser: "SimpleParser" },
+				verify: bounds,
+				...config,
+			}),
+			modules: [testModule, stallingModule, builtinKeyResolversModule],
+		});
+
+	const ask = async (app: Awaited<ReturnType<typeof createApp>>) =>
+		request(app)
+			.post("/verify")
+			.set("Authorization", `Bearer ${await signToken({ scope: "read:project" })}`)
+			.send({ resource: "project", action: "read" });
+
+	it("answers a deny instead of holding the request open", async () => {
+		const app = await stalledApp({
+			attribute: { collectors: [{ collector: "StallingCollector" }] },
+			rule: { collectors: [{ collector: "TestScopeRuleCollector" }] },
+		});
+
+		const res = await ask(app);
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("collector_timeout");
+		// Not a 500: the caller asked whether the request is authorized, and the
+		// answer the verifier can stand behind is "no". A 5xx invites the
+		// enforcement layer to retry, or — worse — to treat the PDP as down and
+		// apply its own fallback.
+		expect(res.body.reason.groups).toEqual([]);
+	});
+
+	it("still denies where the same request with no rules at all would be allowed", async () => {
+		// This is the whole of "fail closed", in one pair of cases. A rule
+		// pipeline that answered with the rules it managed to collect would hand
+		// this deployment an EMPTY rule set — and `onEmptyRuleSet: "allow"` turns
+		// an empty rule set into a permit. A timeout must not be able to walk
+		// through that door, so the timed-out pipeline never reaches the evaluator.
+		const failOpenPolicy = { onEmptyRuleSet: "allow" as const };
+
+		const allowing = await stalledApp({
+			attribute: { collectors: [] },
+			rule: { collectors: [{ collector: "EmptyRuleCollector" }], ...failOpenPolicy },
+		});
+		const control = await ask(allowing);
+		// The control: this deployment really does allow a request that collects
+		// no rules, so the case below is not passing for some other reason.
+		expect(control.status).toBe(200);
+		expect(control.body.decision).toBe("allow");
+
+		const stalled = await stalledApp({
+			attribute: { collectors: [] },
+			rule: { collectors: [{ collector: "StallingRuleCollector" }], ...failOpenPolicy },
+		});
+		const res = await ask(stalled);
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("collector_timeout");
+	});
+});
+
+describe("createApp — collector bounds, one reader at both boundaries (#115)", () => {
+	// `createApp` constructs both pipelines, so it is the runtime guard for the
+	// bounds they run under: a library consumer reaches it with a hand-built
+	// config the schema never saw. It must refuse what `AppConfigSchema` refuses,
+	// naming the same key in the same words.
+	const buildApp = (verify: unknown) =>
+		createApp({
+			pathResolver: (s: string) => s,
+			config: { ...testConfig, verify } as unknown as typeof testConfig,
+			modules: [testModule, builtinKeyResolversModule],
+		});
+
+	/** The message one boundary refused with, or `undefined` when it accepted the value. */
+	const refusal = async (act: () => Promise<unknown>): Promise<string | undefined> => {
+		try {
+			await act();
+			return undefined;
+		} catch (cause) {
+			return (cause as Error).message;
+		}
+	};
+
+	const schemaRefusal = (verify: unknown, field: string): string | undefined => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { secret: JWT_SECRET, mode: "verify", issuer: ISSUER, audience: AUDIENCE } },
+			attribute: { collectors: [] },
+			rule: { collectors: [] },
+			verify,
+		});
+		return result.success
+			? undefined
+			: result.error.issues.find((issue) => issue.path.at(-1) === field)?.message;
+	};
+
+	it.each([
+		["collectorTimeoutMs", 0],
+		["collectorTimeoutMs", -1],
+		["collectorTimeoutMs", 1.5],
+		["collectorTimeoutMs", null],
+		["collectorTimeoutMs", ""],
+		["collectorDeadlineMs", false],
+		["collectorDeadlineMs", "abc"],
+		["collectorDeadlineMs", 0],
+		["collectorConcurrency", 0],
+		["collectorConcurrency", 2.5],
+	])("refuses verify.%s = %s at boot, in the schema's wording", async (field, value) => {
+		const verify = { [field]: value };
+		const fromApp = await refusal(() => buildApp(verify));
+
+		expect(fromApp).toBeDefined();
+		expect(schemaRefusal(verify, field)).toBe(fromApp);
+	});
+
+	it("takes the strings a hand-built env config carries", async () => {
+		expect(
+			await refusal(() =>
+				buildApp({
+					collectorTimeoutMs: "500",
+					collectorDeadlineMs: "1500",
+					collectorConcurrency: "4",
+				}),
+			),
+		).toBeUndefined();
+	});
+
+	it("defaults when the bounds are absent", async () => {
+		expect(await refusal(() => buildApp({}))).toBeUndefined();
+	});
 });

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -7,7 +7,19 @@ import {
 	JWT_MODE_MIGRATION_MESSAGE,
 	JWT_MODE_REMOVED_KEYS,
 } from "#/config/application.schema.mjs";
-import { MAX_PREVIOUS_SECRETS, MIN_SECRET_ENTROPY_BYTES } from "#/config/defaults.mjs";
+import {
+	DEFAULT_COLLECT_DEADLINE_MS,
+	DEFAULT_COLLECTOR_CONCURRENCY,
+	DEFAULT_COLLECTOR_TIMEOUT_MS,
+	DEFAULT_MAX_ACTION_LENGTH,
+	DEFAULT_MAX_BATCH_SIZE,
+	DEFAULT_MAX_BODY_BYTES,
+	DEFAULT_MAX_CONTEXT_ENTRIES,
+	DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+	DEFAULT_MAX_RESOURCE_LENGTH,
+	MAX_PREVIOUS_SECRETS,
+	MIN_SECRET_ENTROPY_BYTES,
+} from "#/config/defaults.mjs";
 import { checkHs256Rotation, parseHs256Rotation } from "#/jwt/hs256Rotation.mjs";
 import { type JwksFetchConfig, resolveJwksFetchBounds } from "#/jwt/jwks.mjs";
 import { type JwtTimeClaimConfig, resolveJwtTimeClaimBounds } from "#/jwt/tokenAuthenticator.mjs";
@@ -364,6 +376,63 @@ describe("AppConfigSchema — batch decisions (#124)", () => {
 			verify: { maxBatchSize: value },
 		});
 		expect(result.success).toBe(false);
+	});
+});
+
+describe("AppConfigSchema — collector bounds (#115)", () => {
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
+
+	const parseVerify = (verify: Record<string, unknown>) =>
+		AppConfigSchema.safeParse({ oauth: { jwt: validJwt }, ...baseBody, verify });
+
+	it("defaults to the bounds core ships", () => {
+		const result = AppConfigSchema.parse({ oauth: { jwt: validJwt }, ...baseBody });
+		expect(result.verify.collectorTimeoutMs).toBe(DEFAULT_COLLECTOR_TIMEOUT_MS);
+		expect(result.verify.collectorDeadlineMs).toBe(DEFAULT_COLLECT_DEADLINE_MS);
+		expect(result.verify.collectorConcurrency).toBe(DEFAULT_COLLECTOR_CONCURRENCY);
+	});
+
+	it("takes operator-set bounds", () => {
+		const result = parseVerify({
+			collectorTimeoutMs: 500,
+			collectorDeadlineMs: 1_500,
+			collectorConcurrency: 4,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.verify.collectorTimeoutMs).toBe(500);
+			expect(result.data.verify.collectorDeadlineMs).toBe(1_500);
+			expect(result.data.verify.collectorConcurrency).toBe(4);
+		}
+	});
+
+	it("coerces the strings a HOCON env substitution produces", () => {
+		const result = parseVerify({
+			collectorTimeoutMs: "500",
+			collectorDeadlineMs: "1500",
+			collectorConcurrency: "4",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.verify.collectorTimeoutMs).toBe(500);
+			expect(result.data.verify.collectorDeadlineMs).toBe(1_500);
+			expect(result.data.verify.collectorConcurrency).toBe(4);
+		}
+	});
+
+	it.each([
+		["a zero timeout — every collector dead on arrival", { collectorTimeoutMs: 0 }],
+		["a negative timeout", { collectorTimeoutMs: -1 }],
+		["a fractional timeout", { collectorTimeoutMs: 1.5 }],
+		["a non-numeric timeout", { collectorTimeoutMs: "abc" }],
+		["an empty timeout — `VAR=` substituted", { collectorTimeoutMs: "" }],
+		["`false`, which `Number` reads as 0", { collectorTimeoutMs: false }],
+		["a null deadline", { collectorDeadlineMs: null }],
+		["a zero deadline", { collectorDeadlineMs: 0 }],
+		["a zero concurrency — a fan-out that runs nothing", { collectorConcurrency: 0 }],
+		["a fractional concurrency", { collectorConcurrency: 1.5 }],
+	])("rejects %s", (_label, verify) => {
+		expect(parseVerify(verify).success).toBe(false);
 	});
 });
 
@@ -1091,5 +1160,76 @@ describe("AppConfigSchema — HS256 secret rotation (#112)", () => {
 			...baseBody,
 		});
 		expect(result.success).toBe(true);
+	});
+});
+
+describe("AppConfigSchema — the verify block's default names every knob", () => {
+	/*
+	 * The `verify` block has two ways of being produced, and they are two
+	 * different pieces of code:
+	 *
+	 *   - the block is PRESENT (`verify {}`) → each key's own `boundedNumber`
+	 *     runs, and `resolveBound(undefined, spec)` returns that spec's fallback;
+	 *   - the block is ABSENT → zod takes the `.default(() => ({…}))` object
+	 *     VERBATIM. It never parses it back through the shape, so a key missing
+	 *     from that literal is `undefined` rather than defaulted.
+	 *
+	 * A knob added to the shape but not to the literal therefore works in every
+	 * test that writes `verify: {…}` and silently disappears for the deployment
+	 * shape that omits the block entirely — which is the common one, since an
+	 * overlay config only repeats the sections it changes. This nearly happened
+	 * when #115 and #118 both added knobs here and landed a day apart.
+	 *
+	 * Comparing the two productions is what makes that unmissable, and it is why
+	 * this is written as an equality rather than as a list of keys: a tenth knob
+	 * added to the shape alone fails here without anyone remembering to come
+	 * back and extend an assertion.
+	 */
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
+
+	const parseWith = (verify?: Record<string, unknown>) =>
+		AppConfigSchema.parse({
+			oauth: { jwt: validJwt },
+			...baseBody,
+			...(verify === undefined ? {} : { verify }),
+		});
+
+	it("answers identically whether the block is absent or empty", () => {
+		// Verified by mutation, not by hope: deleting one line from the
+		// `.default()` literal fails this case and the one below it.
+		expect(parseWith(undefined).verify).toEqual(parseWith({}).verify);
+	});
+
+	it("carries every knob the shape declares, at its documented default", () => {
+		// Spelled out as well as compared, so the equality above cannot pass by
+		// both productions being wrong in the same way.
+		expect(parseWith(undefined).verify).toEqual({
+			maxBatchSize: DEFAULT_MAX_BATCH_SIZE,
+			maxBodyBytes: DEFAULT_MAX_BODY_BYTES,
+			maxResourceLength: DEFAULT_MAX_RESOURCE_LENGTH,
+			maxActionLength: DEFAULT_MAX_ACTION_LENGTH,
+			maxContextEntries: DEFAULT_MAX_CONTEXT_ENTRIES,
+			maxContextValueLength: DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+			collectorTimeoutMs: DEFAULT_COLLECTOR_TIMEOUT_MS,
+			collectorDeadlineMs: DEFAULT_COLLECT_DEADLINE_MS,
+			collectorConcurrency: DEFAULT_COLLECTOR_CONCURRENCY,
+		});
+	});
+
+	it("names each knob in the block whose keys came from the shape", () => {
+		// Keyed off the EMPTY-block production, whose keys come from the shape
+		// rather than from the literal — so a knob the literal omits shows up
+		// here as a missing key rather than as a present `undefined`. (Iterating
+		// the absent-block production instead would skip it silently, which is
+		// the shape of the bug and not a check for it.)
+		const fromShape = parseWith({}).verify as Record<string, unknown>;
+		const fromDefault = parseWith(undefined).verify as Record<string, unknown>;
+
+		for (const key of Object.keys(fromShape)) {
+			expect(
+				fromDefault[key],
+				`verify.${key} is missing from the block's .default() literal`,
+			).toBeTypeOf("number");
+		}
 	});
 });

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -1251,3 +1251,110 @@ describe("createVerifyRouter — maxBatchSize, one reader at both boundaries (#1
 		expect(refusal(buildRouter(undefined))).toBeUndefined();
 	});
 });
+
+describe("createVerifyRouter — a collector that runs out of time denies (#115)", () => {
+	/** Stalls only for the action named, so one batch can mix stalled and decided entries. */
+	const stallingOn = (action: string): AttributeCollector => ({
+		collect: (context: CollectorContext) =>
+			context.action === action
+				? new Promise<Attributes>(() => {})
+				: Promise.resolve(new Map<string, unknown>([["scopes", ["read:project"]]])),
+	});
+
+	const stalledApp = () => {
+		const app = express();
+		app.use(
+			createVerifyRouter({
+				jwt: {
+					validate: true,
+					key: hs256Key.key,
+					algorithms: hs256Key.algorithms,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				},
+				resourceParser: new DotNotationResourceParser(),
+				// Bounds low enough that the stall is answered well inside the
+				// test's own timeout.
+				attributePipeline: new AttributePipeline([stallingOn("stall")], {
+					collectorTimeoutMs: 20,
+					deadlineMs: 50,
+				}),
+				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+			}),
+		);
+		return app;
+	};
+
+	it("answers 403 with a collector_timeout deny", async () => {
+		const token = await signHS256Token({ scope: "read:project" });
+		const res = await request(stalledApp())
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "stall" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("collector_timeout");
+		// No group was evaluated, and the reason says so rather than inventing one.
+		expect(res.body.reason).toEqual({ groups: [] });
+		// The message reaches the caller, so it names no collector and no bound.
+		expect(res.body.message).not.toMatch(/collector|ms/i);
+	});
+
+	it.each([
+		[
+			"a malformed body, unauthenticated",
+			(app: express.Express) => request(app).post("/verify").send({ resource: "project:1" }),
+			400,
+			"invalid_request",
+		],
+		[
+			"a well-formed body with no token",
+			(app: express.Express) =>
+				request(app).post("/verify").send({ resource: "project:1", action: "stall" }),
+			401,
+			"missing_token",
+		],
+	])(
+		"answers %s before any collector runs, rather than spending the budget on it",
+		async (_label, send, status, code) => {
+			// Ordering, pinned rather than read. #118 put body validation ahead of
+			// the token, and both sit ahead of `decide` — so an unauthenticated
+			// caller cannot make the verifier hold a collector budget open. If a
+			// later change moved collection ahead of either gate, this case would
+			// come back `403 collector_timeout` (and take the full budget doing
+			// it) instead of the refusal it asserts.
+			const res = await send(stalledApp());
+
+			expect(res.status).toBe(status);
+			expect(res.body.code).toBe(code);
+			expect(res.body.code).not.toBe("collector_timeout");
+		},
+	);
+
+	it("denies only the batch entry that stalled, and decides the rest", async () => {
+		// The stall is per decision, not per request: a batch is many decisions,
+		// and one of them running out of time must not refuse the others or turn
+		// the whole batch into a 500.
+		const token = await signHS256Token({ scope: "read:project" });
+		const res = await request(stalledApp())
+			.post("/verify/batch")
+			.set("Authorization", `Bearer ${token}`)
+			.send({
+				decisions: [
+					{ resource: "project:1", action: "read" },
+					{ resource: "project:2", action: "stall" },
+					{ resource: "project:3", action: "read" },
+				],
+			});
+
+		expect(res.status).toBe(200);
+		expect(res.body.decisions.map((d: { decision: string }) => d.decision)).toEqual([
+			"allow",
+			"deny",
+			"allow",
+		]);
+		expect(res.body.decisions[1].code).toBe("collector_timeout");
+	});
+});

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -4,6 +4,7 @@
 import {
 	type AttributeCollectorFactory,
 	AttributePipeline,
+	type CollectorLimits,
 	createConsoleLogger,
 	type KeyResolverFactory,
 	type Logger,
@@ -21,6 +22,7 @@ import {
 	JWT_MODE_MIGRATION_MESSAGE,
 	JWT_MODE_REMOVED_KEYS,
 } from "./config/application.schema.mjs";
+import { NUMERIC_BOUNDS, resolveBound } from "./config/bounds.mjs";
 import { CALLER_AUTH_REQUIRED } from "./config/defaults.mjs";
 import { createCallerAuthMiddleware, resolveCallerAuth } from "./http/callerAuth.mjs";
 import {
@@ -110,6 +112,31 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 	}
 
 	// 3. Resolve attribute collectors from config — call factory with config entry
+	//
+	// The bounds both pipelines run their collectors under (#115) are resolved
+	// here because this is where the pipelines are built, which makes `createApp`
+	// their runtime guard: a hand-built config reaches it with `AppConfigSchema`
+	// never having run. Read through `resolveBound` with the same specs the
+	// schema uses, so the two boundaries cannot disagree about what a value means
+	// — see AGENTS.md, "Two-Boundary Config Validation".
+	const collectorLimits: CollectorLimits = {
+		collectorTimeoutMs: resolveBound(
+			config.verify.collectorTimeoutMs,
+			NUMERIC_BOUNDS.collectorTimeoutMs,
+			"verify",
+		),
+		deadlineMs: resolveBound(
+			config.verify.collectorDeadlineMs,
+			NUMERIC_BOUNDS.collectorDeadlineMs,
+			"verify",
+		),
+		concurrency: resolveBound(
+			config.verify.collectorConcurrency,
+			NUMERIC_BOUNDS.collectorConcurrency,
+			"verify",
+		),
+	};
+
 	const attributeCollectors = config.attribute.collectors.map((entry) => {
 		const factory = attributeCollectorRegistry.get(entry.collector);
 		return factory(entry);
@@ -256,8 +283,8 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 			logger,
 			metrics: metrics.decisions,
 			resourceParser,
-			attributePipeline: new AttributePipeline(attributeCollectors),
-			rulePipeline: new RulePipeline(ruleCollectors),
+			attributePipeline: new AttributePipeline(attributeCollectors, collectorLimits),
+			rulePipeline: new RulePipeline(ruleCollectors, collectorLimits),
 			evaluateOptions: { onEmptyRuleSet: config.rule.onEmptyRuleSet },
 			maxBatchSize: config.verify.maxBatchSize,
 			// Forwarded rather than defaulted here (#118): the router resolves each

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -7,6 +7,9 @@ import { checkJwksUri } from "../jwt/jwks.mjs";
 import { type BoundSpec, NUMERIC_BOUNDS, resolveBound } from "./bounds.mjs";
 import {
 	DEFAULT_CALLER_AUTH_HEADER,
+	DEFAULT_COLLECT_DEADLINE_MS,
+	DEFAULT_COLLECTOR_CONCURRENCY,
+	DEFAULT_COLLECTOR_TIMEOUT_MS,
 	DEFAULT_HOSTNAME,
 	DEFAULT_HTTP_PORT,
 	DEFAULT_MAX_ACTION_LENGTH,
@@ -429,9 +432,46 @@ export const AppConfigSchema = z.object({
 			maxActionLength: boundedNumber(NUMERIC_BOUNDS.maxActionLength, "verify"),
 			maxContextEntries: boundedNumber(NUMERIC_BOUNDS.maxContextEntries, "verify"),
 			maxContextValueLength: boundedNumber(NUMERIC_BOUNDS.maxContextValueLength, "verify"),
+			/**
+			 * Bounds on the collector fan-out both pipelines run for every
+			 * decision (#115). Collectors call databases and HTTP APIs, and before
+			 * these they ran under a bare `Promise.all`: one stalled collector
+			 * held the decision open for as long as its socket did.
+			 *
+			 * `collectorTimeoutMs` is what one collector may take;
+			 * `collectorDeadlineMs` is what the whole wave may take, which a
+			 * per-collector budget cannot bound once collectors queue; and
+			 * `collectorConcurrency` is how many run at once, which is what stops
+			 * a slow dependency from being handed more simultaneous work as it
+			 * slows. Read through `resolveBound` so `createApp` — which builds the
+			 * pipelines, and accepts hand-built configs this schema never saw —
+			 * refuses the same values in the same words (#157).
+			 *
+			 * Exceeding any of them **denies**: see `CollectorTimeoutError` in
+			 * core for why a partial answer is never the safe one.
+			 */
+			collectorTimeoutMs: boundedNumber(NUMERIC_BOUNDS.collectorTimeoutMs, "verify"),
+			collectorDeadlineMs: boundedNumber(NUMERIC_BOUNDS.collectorDeadlineMs, "verify"),
+			collectorConcurrency: boundedNumber(NUMERIC_BOUNDS.collectorConcurrency, "verify"),
 		})
-		// Taken verbatim, like `http` above — zod does not parse a default back
-		// through the shape, so every key has to be stated here as well.
+		/*
+		 * Taken verbatim, like `http` above — zod does not parse a default back
+		 * through the shape, so **every key of the block has to be repeated here**.
+		 *
+		 * This object is the one place in the schema where an omission is silent.
+		 * A knob added to the shape above but not to this literal is simply
+		 * `undefined` for every config that has no `verify` block at all — which
+		 * is the ordinary deployment shape, since an overlay config only repeats
+		 * the sections it changes. Nothing throws; the bound just stops existing,
+		 * and for #115's knobs that means the collector deadlines quietly stop
+		 * applying. It has already nearly happened once, when #115 and #118 both
+		 * added knobs here and landed a day apart.
+		 *
+		 * So it is asserted rather than reviewed: `AppConfigSchema — the verify
+		 * block's default names every knob` walks the shape's own key list and
+		 * fails on any key this literal does not answer for. Add the knob to both,
+		 * and that test will tell you if you forgot.
+		 */
 		.default(() => ({
 			maxBatchSize: DEFAULT_MAX_BATCH_SIZE,
 			maxBodyBytes: DEFAULT_MAX_BODY_BYTES,
@@ -439,6 +479,9 @@ export const AppConfigSchema = z.object({
 			maxActionLength: DEFAULT_MAX_ACTION_LENGTH,
 			maxContextEntries: DEFAULT_MAX_CONTEXT_ENTRIES,
 			maxContextValueLength: DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
+			collectorTimeoutMs: DEFAULT_COLLECTOR_TIMEOUT_MS,
+			collectorDeadlineMs: DEFAULT_COLLECT_DEADLINE_MS,
+			collectorConcurrency: DEFAULT_COLLECTOR_CONCURRENCY,
 		})),
 	// Defaulted (not shape-only): deployments mount an overlay config OVER the
 	// template's application.conf, so a section the overlay does not repeat is

--- a/packages/server/src/config/bounds.mts
+++ b/packages/server/src/config/bounds.mts
@@ -35,6 +35,9 @@
 
 import {
 	DEFAULT_CLOCK_TOLERANCE_SECONDS,
+	DEFAULT_COLLECT_DEADLINE_MS,
+	DEFAULT_COLLECTOR_CONCURRENCY,
+	DEFAULT_COLLECTOR_TIMEOUT_MS,
 	DEFAULT_HTTP_PORT,
 	DEFAULT_JWKS_CACHE_MAX_AGE_MS,
 	DEFAULT_JWKS_COOLDOWN_MS,
@@ -183,6 +186,45 @@ export const NUMERIC_BOUNDS = {
 		fallback: DEFAULT_MAX_CONTEXT_VALUE_LENGTH,
 		minimum: 1,
 		unit: "characters",
+	},
+	/**
+	 * How long one collector may take before it is cancelled (#115). The floor
+	 * is 1: a zero budget cancels every collector before it can answer, which is
+	 * a verifier that denies everything — the same shape as the `0` cap
+	 * `maxBatchSize` refuses.
+	 */
+	collectorTimeoutMs: {
+		field: "collectorTimeoutMs",
+		fallback: DEFAULT_COLLECTOR_TIMEOUT_MS,
+		minimum: 1,
+		unit: "milliseconds",
+	},
+	/**
+	 * How long a whole collector fan-out may take. Not bounded above and not
+	 * bounded below by `collectorTimeoutMs`: a deployment may legitimately want
+	 * a deadline tighter than one collector's budget (every stall then reported
+	 * as a deadline, which is a cruder message but a correct decision), and
+	 * cross-knob validation is not something one `BoundSpec` can express.
+	 * `Infinity` is refused like every other knob here — an unbounded deadline
+	 * is the state #115 found.
+	 */
+	collectorDeadlineMs: {
+		field: "collectorDeadlineMs",
+		fallback: DEFAULT_COLLECT_DEADLINE_MS,
+		minimum: 1,
+		unit: "milliseconds",
+	},
+	/**
+	 * How many collectors run at once, per pipeline, per decision. The floor is
+	 * 1 rather than 0 for the reason `http.port`'s is: `0` is not "no limit", it
+	 * is a fan-out that starts nothing and resolves with no attributes and no
+	 * rules — a fail-open dressed as a setting.
+	 */
+	collectorConcurrency: {
+		field: "collectorConcurrency",
+		fallback: DEFAULT_COLLECTOR_CONCURRENCY,
+		minimum: 1,
+		unit: "collectors",
 	},
 } satisfies Record<string, BoundSpec>;
 

--- a/packages/server/src/config/defaults.mts
+++ b/packages/server/src/config/defaults.mts
@@ -91,6 +91,28 @@ export const DEFAULT_MAX_CONTEXT_ENTRIES = 64;
 export const DEFAULT_MAX_CONTEXT_VALUE_LENGTH = 1_024;
 
 /*
+ * Bounds on the collector fan-out (#115), re-exported from core rather than
+ * restated here.
+ *
+ * The numbers belong to the engine: `AttributePipeline` and `RulePipeline`
+ * enforce them, and a library consumer who never loads this package still gets
+ * them. Restating them would recreate exactly the fault #157 catalogued, one
+ * package boundary further out — two readers of one bound, drifting silently,
+ * with the config file's default and the pipeline's disagreeing about what an
+ * unset knob means.
+ *
+ * This is the one import this module has. Core carries no dependencies of its
+ * own, so a config-only consumer of `AppConfigSchema` still pulls in nothing but
+ * the engine's own vocabulary — which is the property `config/bounds.mts`
+ * guards, and the reason nothing heavier may ever be reached for from here.
+ */
+export {
+	DEFAULT_COLLECT_DEADLINE_MS,
+	DEFAULT_COLLECTOR_CONCURRENCY,
+	DEFAULT_COLLECTOR_TIMEOUT_MS,
+} from "@o3co/auth.policy-verifier.core";
+
+/*
  * Bounds on the remote JWKS fetch (#109). A key resolution that misses the
  * cache happens inside a verify request, so an unbounded fetch is a stall
  * vector on the decision hot path: every caller of a deployment whose provider

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -3,6 +3,7 @@
 
 import {
 	type AttributePipeline,
+	CollectorTimeoutError,
 	consoleLogger,
 	type Decision,
 	type DecisionReason,
@@ -138,6 +139,24 @@ const errorBody = (code: string, message: string): ErrorBody => ({
 	code,
 	message,
 });
+
+/**
+ * The deny a collector fan-out that ran out of time is answered with (#115).
+ *
+ * A deny, and specifically not a 5xx. The caller asked whether this request is
+ * authorized; what the verifier can stand behind when a collector stalled is
+ * "not established", and the safe rendering of that is a refusal. A 500 invites
+ * the enforcement layer to retry the same stalled dependency, or to conclude the
+ * PDP is down and apply a fallback of its own — and a fallback nobody in this
+ * repo wrote is precisely the fail-open being closed here.
+ *
+ * The message is fixed and says nothing about which collector or which bound:
+ * that reaches the caller, and the collector set is deployment topology. The
+ * detail is in the `collector_timeout` log line instead, where an operator can
+ * act on it.
+ */
+const COLLECTOR_TIMEOUT_CODE = "collector_timeout";
+const COLLECTOR_TIMEOUT_MESSAGE = "Authorization could not be decided in time";
 
 /** One validated entry: the request as sent, plus its resource already parsed. */
 interface ValidatedDecisionRequest {
@@ -471,11 +490,32 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 		// request is many decisions, and it is the per-decision cost that a
 		// collector reaching out to a store makes worse.
 		const startedAt = performance.now();
-		const [attrs, rules] = await Promise.all([
-			config.attributePipeline.collect(context),
-			config.rulePipeline.collect(context),
-		]);
-		const decision = evaluate(attrs, rules, config.evaluateOptions);
+		let decision: Decision;
+		try {
+			const [attrs, rules] = await Promise.all([
+				config.attributePipeline.collect(context),
+				config.rulePipeline.collect(context),
+			]);
+			decision = evaluate(attrs, rules, config.evaluateOptions);
+		} catch (cause) {
+			// Anything else is a genuine fault and keeps surfacing as a 500.
+			if (!(cause instanceof CollectorTimeoutError)) throw cause;
+			// The evaluator is deliberately never reached: it is the one place a
+			// short rule list could still be read as a policy, and `onEmptyRuleSet:
+			// "allow"` would then turn a timed-out rule pipeline into a permit. A
+			// deny is built here instead, with an empty `reason` because no rule
+			// group was evaluated — which is the honest account of what happened.
+			logger.error(
+				{ err: cause, resource: entry.resource, action: entry.action, requestId },
+				COLLECTOR_TIMEOUT_CODE,
+			);
+			decision = {
+				decision: "deny",
+				code: COLLECTOR_TIMEOUT_CODE,
+				message: COLLECTOR_TIMEOUT_MESSAGE,
+				reason: { groups: [] },
+			};
+		}
 		const durationMs = performance.now() - startedAt;
 
 		// Derived once and spent twice — on the audit line below and on the

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -288,4 +288,35 @@ verify {
   maxContextEntries = ${?VERIFY_MAX_CONTEXT_ENTRIES}
   maxContextValueLength = 1024
   maxContextValueLength = ${?VERIFY_MAX_CONTEXT_VALUE_LENGTH}
+
+  # Bounds on the collector fan-out both pipelines run for every decision.
+  # Collectors are the layer that calls databases and HTTP APIs, so they are the
+  # layer that can stall; without these, one collector holding a dead socket
+  # holds the whole decision.
+  #
+  # EXCEEDING ANY OF THEM DENIES the decision — `403 collector_timeout`, with an
+  # empty `reason.groups`. It is never answered with whatever was collected in
+  # time: fewer rules is a weaker policy, and no rules at all is an ALLOW
+  # wherever `rule.onEmptyRuleSet = "allow"` is set.
+  #
+  # `collectorTimeoutMs` is one collector's own budget, counted from when that
+  # collector starts rather than from when the fan-out did, so waiting behind
+  # the concurrency cap does not spend it.
+  collectorTimeoutMs = 2000
+  collectorTimeoutMs = ${?VERIFY_COLLECTOR_TIMEOUT_MS}
+
+  # `collectorDeadlineMs` is the whole fan-out, per pipeline. The per-collector
+  # budget cannot bound a SET: once collectors queue, enough of them each
+  # finishing just inside their own budget still adds up to a request nobody is
+  # waiting for any more.
+  collectorDeadlineMs = 5000
+  collectorDeadlineMs = ${?VERIFY_COLLECTOR_DEADLINE_MS}
+
+  # `collectorConcurrency` is how many run at once, per pipeline, per decision.
+  # Higher than any realistic collector set, so an ordinary configuration still
+  # fans out in one wave; what it removes is the tail, where a wide config or a
+  # full batch multiplies into simultaneous calls against a dependency that has
+  # just started to slow down.
+  collectorConcurrency = 8
+  collectorConcurrency = ${?VERIFY_COLLECTOR_CONCURRENCY}
 }

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -11,6 +11,9 @@
  * exercises parseFile, so a HOCON parser regression is otherwise invisible
  * until the container fails to start.
  */
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadAppConfig } from "../loadConfig.js";
@@ -39,6 +42,19 @@ const envKeys = [
 	"OAUTH_JWT_MAX_TOKEN_AGE_SECONDS",
 	"OAUTH_JWT_CLOCK_TOLERANCE_SECONDS",
 	"VERIFY_MAX_BATCH_SIZE",
+	// Every VERIFY_* the cases below set has to be listed, or it leaks into the
+	// tests after it. Only `VERIFY_MAX_BATCH_SIZE` was here while the #118 cases
+	// set five more, and the leak was invisible for as long as no later case
+	// loaded the shipped config and asserted on `verify` — the first one that
+	// did got a boot failure from an env var a test three screens up had set.
+	"VERIFY_MAX_BODY_BYTES",
+	"VERIFY_MAX_RESOURCE_LENGTH",
+	"VERIFY_MAX_ACTION_LENGTH",
+	"VERIFY_MAX_CONTEXT_ENTRIES",
+	"VERIFY_MAX_CONTEXT_VALUE_LENGTH",
+	"VERIFY_COLLECTOR_TIMEOUT_MS",
+	"VERIFY_COLLECTOR_DEADLINE_MS",
+	"VERIFY_COLLECTOR_CONCURRENCY",
 ] as const;
 
 /** application.conf leaves issuer/audience unset, so every load must supply them. */
@@ -249,6 +265,9 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		process.env.VERIFY_MAX_ACTION_LENGTH = "32";
 		process.env.VERIFY_MAX_CONTEXT_ENTRIES = "16";
 		process.env.VERIFY_MAX_CONTEXT_VALUE_LENGTH = "256";
+		process.env.VERIFY_COLLECTOR_TIMEOUT_MS = "750";
+		process.env.VERIFY_COLLECTOR_DEADLINE_MS = "1500";
+		process.env.VERIFY_COLLECTOR_CONCURRENCY = "4";
 
 		const config = loadAppConfig(configDirPath, "development");
 
@@ -264,6 +283,9 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		expect(config.verify.maxActionLength).toBe(32);
 		expect(config.verify.maxContextEntries).toBe(16);
 		expect(config.verify.maxContextValueLength).toBe(256);
+		expect(config.verify.collectorTimeoutMs).toBe(750);
+		expect(config.verify.collectorDeadlineMs).toBe(1_500);
+		expect(config.verify.collectorConcurrency).toBe(4);
 	});
 
 	it.each([
@@ -279,6 +301,9 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		["VERIFY_MAX_ACTION_LENGTH", "1.5"],
 		["VERIFY_MAX_CONTEXT_ENTRIES", "abc"],
 		["VERIFY_MAX_CONTEXT_VALUE_LENGTH", "0"],
+		["VERIFY_COLLECTOR_TIMEOUT_MS", "0"],
+		["VERIFY_COLLECTOR_DEADLINE_MS", "-1"],
+		["VERIFY_COLLECTOR_CONCURRENCY", "0"],
 	])("refuses to boot on %s=%s", (key, value) => {
 		setRequiredEnv();
 		process.env[key] = value;
@@ -293,6 +318,8 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		"VERIFY_MAX_BATCH_SIZE",
 		"VERIFY_MAX_BODY_BYTES",
 		"VERIFY_MAX_CONTEXT_ENTRIES",
+		"VERIFY_COLLECTOR_TIMEOUT_MS",
+		"VERIFY_COLLECTOR_CONCURRENCY",
 	])("refuses %s exported empty rather than reading it as zero", (key) => {
 		// `VAR=` substitutes an empty string, and `Number("")` is 0 — which the
 		// knobs whose floor is 0 would otherwise accept as a deliberate setting.
@@ -303,5 +330,84 @@ describe("loadAppConfig — numeric knobs through the real 3-tier resolution (#1
 		process.env[key] = "";
 
 		expect(() => loadAppConfig(configDirPath, "development")).toThrow();
+	});
+});
+
+describe("loadAppConfig — a config with no verify block at all (#115, #118)", () => {
+	/*
+	 * The shipped `application.conf` writes out every `verify` knob, so loading
+	 * it exercises the schema's per-key defaults and never the block-level one.
+	 * The block-level default is what serves the OTHER shape, and it is the
+	 * common one: an overlay config repeats only the sections it changes, and a
+	 * deployment that has no opinion about batch sizes or collector deadlines
+	 * simply never writes a `verify` block.
+	 *
+	 * zod takes `.default(() => ({…}))` verbatim rather than parsing it back
+	 * through the shape, so a knob missing from that literal is `undefined` for
+	 * exactly this shape — silently, with nothing failing. That is why it is
+	 * proved here through the real loader (`parseFile` → `withFallback` →
+	 * `validate`) rather than inferred from the schema unit tests, which all
+	 * write a `verify` block and would go on passing.
+	 */
+	const withoutVerify = (): string => {
+		const dir = mkdtempSync(path.join(tmpdir(), "policy-verifier-config-"));
+		// The minimum a deployment must state, and not one key more. No `verify`
+		// block, and an env overlay that declares nothing — the shipped
+		// development/production files are comments only, so this is their shape.
+		// The `${"$"}{?VAR}` spelling keeps the HOCON env substitutions literal
+		// `${?VAR}` text rather than JavaScript interpolation — for the parser
+		// under test and for anyone skimming the fixture.
+		writeFileSync(
+			path.join(dir, "application.conf"),
+			`
+oauth {
+  jwt {
+    algorithm = HS256
+    secret = ${"$"}{?OAUTH_JWT_SECRET}
+    issuer = ${"$"}{?OAUTH_JWT_ISSUER}
+    audience = ${"$"}{?OAUTH_JWT_AUDIENCE}
+  }
+}
+attribute { collectors = [ { collector = PayloadScopeCollector } ] }
+rule { collectors = [ { collector = ResourceActionScopeRuleCollector } ] }
+`,
+		);
+		writeFileSync(path.join(dir, "development.conf"), "# overlay declares nothing\n");
+		return dir;
+	};
+
+	it("still applies every documented verify default", () => {
+		setRequiredEnv();
+
+		const config = loadAppConfig(withoutVerify(), "development");
+
+		// All nine, spelled out. A knob that reached the shape but not the
+		// block's `.default()` literal is `undefined` here, and `toEqual` says
+		// which one.
+		expect(config.verify).toEqual({
+			maxBatchSize: 50,
+			maxBodyBytes: 65_536,
+			maxResourceLength: 512,
+			maxActionLength: 64,
+			maxContextEntries: 64,
+			maxContextValueLength: 1_024,
+			collectorTimeoutMs: 2_000,
+			collectorDeadlineMs: 5_000,
+			collectorConcurrency: 8,
+		});
+	});
+
+	it("agrees with the shipped config, which writes the same values out", () => {
+		// The two ways a deployment can arrive at the defaults — stating them in
+		// `application.conf`, or omitting the block — must not disagree. The
+		// shipped file is the documentation operators copy from, so a drift
+		// between it and the schema's fallback is a drift between what the docs
+		// say and what an unconfigured deployment runs.
+		setRequiredEnv();
+
+		const shipped = loadAppConfig(configDirPath, "development");
+		const omitted = loadAppConfig(withoutVerify(), "development");
+
+		expect(omitted.verify).toEqual(shipped.verify);
 	});
 });

--- a/tests/integration/src/conformance/rulePurity.mts
+++ b/tests/integration/src/conformance/rulePurity.mts
@@ -4,6 +4,7 @@
 import type {
 	Attributes,
 	CollectorContext,
+	CollectorRequest,
 	ReadonlyAttributes,
 	Rule,
 } from "@o3co/auth.policy-verifier.core";
@@ -16,8 +17,16 @@ export type CollectRules = (context: CollectorContext) => Promise<Rule[]>;
 export interface RulePurityCase {
 	/** Case name, used in test titles. */
 	name: string;
-	/** The request the rules are collected from. */
-	context: CollectorContext;
+	/**
+	 * The request the rules are collected from.
+	 *
+	 * A `CollectorRequest`, so a case states only facts about the request: the
+	 * per-collector `signal` is the fan-out's to supply (#115), and here the
+	 * harness *is* the fan-out. Supplying one anyway is how a case checks what
+	 * its collector does when the request is cancelled — it is linked into the
+	 * view the collector sees.
+	 */
+	context: CollectorRequest;
 	/** Attributes to run the collected rules against. */
 	attrs: Attributes;
 }
@@ -57,7 +66,7 @@ export interface RulePurityAdapter {
  * out is registered, so revocation reaches a rule that kept `ctx.resource` just
  * as it reaches one that kept `ctx`.
  */
-function revocableContext(context: CollectorContext): {
+function revocableContext(request: CollectorRequest): {
 	proxy: CollectorContext;
 	revoke: () => void;
 } {
@@ -67,6 +76,14 @@ function revocableContext(context: CollectorContext): {
 	const wrap = <T extends object>(target: T): T => {
 		const memoized = wrapped.get(target);
 		if (memoized !== undefined) return memoized as T;
+
+		// An `AbortSignal` cannot be a `Proxy` — see `revocableSignal`.
+		if (target instanceof AbortSignal) {
+			const { view, revoke } = revocableSignal(target);
+			wrapped.set(target, view);
+			revokers.push(revoke);
+			return view as unknown as T;
+		}
 
 		const { proxy, revoke } = Proxy.revocable(target, {
 			get(t, prop, receiver) {
@@ -80,6 +97,15 @@ function revocableContext(context: CollectorContext): {
 		return proxy;
 	};
 
+	// The fan-out's job, done here because here the harness is the fan-out: a
+	// collector is always handed a `signal`, so one has to exist before the
+	// context is wrapped. A case that supplied its own is linked through
+	// `revocableSignal`; one that did not gets a signal that never aborts.
+	const context: CollectorContext = {
+		...request,
+		signal: request.signal ?? new AbortController().signal,
+	};
+
 	const proxy = wrap(context);
 	return {
 		proxy,
@@ -87,6 +113,69 @@ function revocableContext(context: CollectorContext): {
 			for (const revoke of revokers) revoke();
 		},
 	};
+}
+
+/**
+ * The `AbortSignal` case, which is the one field of the context a collector is
+ * *meant* to hold live — and the one that cannot be wrapped in a `Proxy`.
+ *
+ * Both halves of that matter, and they pull in opposite directions.
+ *
+ * **It cannot be a `Proxy`.** `AbortSignal`'s members are brand-checked against
+ * the receiver's internal slots, and a proxy is not the signal. `signal.aborted`
+ * happens to read through, but `addEventListener`, `AbortSignal.any([signal])`
+ * and `fetch(url, { signal })` all throw `Method Map.prototype.get called on
+ * incompatible receiver` — so wrapping it the way every other object is wrapped
+ * would fail every collector that uses its signal for the thing it is for. That
+ * is the harness reporting its own artifact as a violation, the mistake the
+ * memoization above already exists to avoid.
+ *
+ * **It still has to be revocable.** A signal is a live view of request state:
+ * `aborted` changes under a rule's feet, so a rule that kept one and read it
+ * inside `verify` is exactly the violation this suite catches, and exempting the
+ * field would have quietly opened a hole in the check the week it was added.
+ *
+ * So the view is a genuine `AbortSignal` — `AbortSignal.any` mints one linked to
+ * the original, which keeps every brand check and the cancellation semantics
+ * intact — and revoking shadows each of its members with an own accessor that
+ * throws the same `TypeError` a revoked proxy throws. `isRevokedProxyError` then
+ * recognises it, and the violation is reported against the rule that committed
+ * it, in the same words as every other one.
+ */
+function revocableSignal(signal: AbortSignal): { view: AbortSignal; revoke: () => void } {
+	const view = AbortSignal.any([signal]);
+	return {
+		view,
+		revoke: () => {
+			// The prototype chain's string-keyed members — `aborted`, `reason`,
+			// `throwIfAborted`, `onabort` and the three `EventTarget` methods. An own
+			// accessor shadows each; the instance's own symbol-keyed internals are
+			// left alone, since nothing reads a signal through those.
+			for (const key of signalMembers(view)) {
+				Object.defineProperty(view, key, {
+					configurable: true,
+					get() {
+						throw new TypeError("Cannot perform 'get' on a proxy that has been revoked");
+					},
+				});
+			}
+		},
+	};
+}
+
+/** Every string-keyed member an `AbortSignal` answers, from its prototype chain. */
+function signalMembers(signal: AbortSignal): string[] {
+	const keys = new Set<string>();
+	for (
+		let proto: object | null = Object.getPrototypeOf(signal) as object | null;
+		proto !== null && proto !== Object.prototype;
+		proto = Object.getPrototypeOf(proto) as object | null
+	) {
+		for (const key of Object.getOwnPropertyNames(proto)) {
+			if (key !== "constructor") keys.add(key);
+		}
+	}
+	return [...keys];
 }
 
 /** Whether an error is the one a revoked proxy throws on any access. */
@@ -122,7 +211,7 @@ function describeRule(rule: Rule, index: number): string {
  */
 export async function assertRuleIndependentOfContext(
 	collect: CollectRules,
-	context: CollectorContext,
+	context: CollectorRequest,
 	attrs: Attributes,
 ): Promise<boolean[]> {
 	const { proxy, revoke } = revocableContext(context);
@@ -197,6 +286,16 @@ export async function assertRuleIndependentOfContext(
  */
 export function describeRulePurityConformance(adapter: RulePurityAdapter): void {
 	describe(`rule purity conformance — ${adapter.name}`, () => {
+		/**
+		 * The case's request as a collector receives it, for the checks below that
+		 * do not need the revocable view. Nothing here cancels — these ask what a
+		 * rule answers, not what a collector does when the request goes away.
+		 */
+		const asContext = (testCase: RulePurityCase): CollectorContext => ({
+			...testCase.context,
+			signal: testCase.context.signal ?? new AbortController().signal,
+		});
+
 		for (const testCase of adapter.cases) {
 			describe(testCase.name, () => {
 				it("answers the same once the request it was collected from is gone", async () => {
@@ -213,7 +312,7 @@ export function describeRulePurityConformance(adapter: RulePurityAdapter): void 
 				it("answers the same for a distinct map carrying equal attributes", async () => {
 					// The map's identity must not be part of the answer, or "cacheable"
 					// and "testable in isolation" both stop being true.
-					const rules = await adapter.collect(testCase.context);
+					const rules = await adapter.collect(asContext(testCase));
 					const copy: Attributes = new Map(testCase.attrs);
 
 					expect(rules.map((rule) => rule.verify(copy))).toEqual(
@@ -224,7 +323,7 @@ export function describeRulePurityConformance(adapter: RulePurityAdapter): void 
 				it("only reads the attributes it is handed", async () => {
 					// The read-only view `Rule.verify` declares, enforced at runtime for
 					// the sake of a rule authored in JavaScript, where the type is gone.
-					const rules = await adapter.collect(testCase.context);
+					const rules = await adapter.collect(asContext(testCase));
 					const readOnly: ReadonlyAttributes = new Map(testCase.attrs);
 					const before = JSON.stringify([...readOnly]);
 

--- a/tests/integration/src/default-deny-conformance.test.mts
+++ b/tests/integration/src/default-deny-conformance.test.mts
@@ -20,6 +20,9 @@ function toCollectorContext(request: AuthorizationRequest): CollectorContext {
 		// an HTTP body's — an adapter marks it on the way in, exactly as the verify
 		// route does.
 		requestContext: request.context ? markUntrustedRequestContext(request.context) : undefined,
+		// The pipelines supply one per collector (#115); an adapter calling a
+		// collector directly supplies its own. Nothing here cancels.
+		signal: new AbortController().signal,
 	};
 }
 

--- a/tests/integration/src/rule-purity-conformance.test.mts
+++ b/tests/integration/src/rule-purity-conformance.test.mts
@@ -5,20 +5,28 @@ import {
 	ResourceActionPermissionRuleCollector,
 	ResourceActionScopeRuleCollector,
 } from "@o3co/auth.policy-verifier.builtins";
-import type { Attributes, CollectorContext, Rule } from "@o3co/auth.policy-verifier.core";
+import type {
+	Attributes,
+	CollectorContext,
+	CollectorRequest,
+	Rule,
+} from "@o3co/auth.policy-verifier.core";
 import { describe, expect, it } from "vitest";
 import {
 	assertRuleIndependentOfContext,
 	describeRulePurityConformance,
 } from "./conformance/rulePurity.mjs";
 
-const scopeContext: CollectorContext = {
+// `CollectorRequest`, not `CollectorContext`: the per-collector `signal` (#115)
+// belongs to the fan-out, and here the harness is the fan-out — it supplies a
+// revocable one of its own, for the same reason it wraps the rest.
+const scopeContext: CollectorRequest = {
 	payload: { sub: "user-1", scope: "read:project write:project" },
 	resource: { raw: "project:1", resourceType: "project", resourceId: "1" },
 	action: "read",
 };
 
-const permissionContext: CollectorContext = {
+const permissionContext: CollectorRequest = {
 	payload: { sub: "user-1" },
 	resource: { raw: "project:1", resourceType: "project", resourceId: "1" },
 	action: "read",
@@ -184,6 +192,108 @@ describe("rule purity conformance — the check itself", () => {
 		expect(sameObjectTwice).toBe(true);
 		expect(distinctFieldsStayDistinct).toBe(true);
 		expect(survivesRoundTrip).toBe(true);
+	});
+
+	/*
+	 * The `signal` #115 put on `CollectorContext` is the first field a collector
+	 * is *expected* to hold live for the length of `collect` — it is a
+	 * cancellation handle, not a fact about the request, and the whole point is
+	 * to pass it to `fetch`. That pulls the harness in two directions at once,
+	 * and the three cases below pin both halves.
+	 *
+	 * It must stay revocable: a signal is a live view of request state (`aborted`
+	 * moves under the rule's feet), so a rule that kept one and read it inside
+	 * `verify` is the exact violation this suite exists to catch — and no less so
+	 * for the field being new. And it must stay *usable*: a plain revocable Proxy
+	 * over an `AbortSignal` fails every brand check on it (`addEventListener`,
+	 * `AbortSignal.any`, `fetch`), so wrapping it the way every other object is
+	 * wrapped would make honest collectors fail this suite for a reason that
+	 * exists only inside the harness.
+	 */
+	it("rejects a rule that kept the collector's AbortSignal and read it at verify time", async () => {
+		const collect = async (ctx: CollectorContext): Promise<Rule[]> => {
+			// A live handle into the request, held past `collect` — `aborted` moves
+			// on its own, so the rule's answer is not a function of `attrs`.
+			const signal = ctx.signal;
+			return [
+				{
+					ruleType: "scope",
+					code: "invalid_scope",
+					message: "Insufficient scope",
+					verify(attributes) {
+						const scopes = attributes.get("scopes");
+						return !signal.aborted && Array.isArray(scopes) && scopes.includes("read:project");
+					},
+				},
+			];
+		};
+
+		await expect(assertRuleIndependentOfContext(collect, scopeContext, attrs)).rejects.toThrow(
+			/read its collector's context/,
+		);
+	});
+
+	it("hands the collector an AbortSignal every real use of one still works on", async () => {
+		let usable = false;
+		const collect = async (ctx: CollectorContext): Promise<Rule[]> => {
+			// Everything a collector legitimately does with it. Each of these
+			// throws on a `Proxy`-wrapped signal, because the receiver fails the
+			// brand check on `AbortSignal`'s internal slots.
+			ctx.signal.addEventListener("abort", () => {});
+			ctx.signal.throwIfAborted();
+			const linked = AbortSignal.any([ctx.signal]);
+			usable = ctx.signal instanceof AbortSignal && ctx.signal.aborted === false && !linked.aborted;
+
+			const required = `${ctx.action}:${ctx.resource.resourceType}`;
+			return [
+				{
+					ruleType: "scope",
+					code: "invalid_scope",
+					message: "Insufficient scope",
+					verify(attributes) {
+						const scopes = attributes.get("scopes");
+						return Array.isArray(scopes) && scopes.includes(required);
+					},
+				},
+			];
+		};
+
+		await assertRuleIndependentOfContext(collect, scopeContext, attrs);
+
+		expect(usable).toBe(true);
+	});
+
+	it("keeps the collector's signal linked to the one the case supplied", async () => {
+		// The harness hands out a view, not the case's own signal — so the view
+		// has to follow it, or a case that cancels mid-collect would be testing
+		// nothing.
+		const controller = new AbortController();
+		let cancelled = false;
+
+		const collect = async (ctx: CollectorContext): Promise<Rule[]> => {
+			ctx.signal.addEventListener("abort", () => {
+				cancelled = true;
+			});
+			// `AbortSignal.any` forwards the abort synchronously, so by the next
+			// line the collector's view has already fired.
+			controller.abort(new Error("caller went away"));
+			return [
+				{
+					ruleType: "scope",
+					code: "invalid_scope",
+					message: "Insufficient scope",
+					verify: () => true,
+				},
+			];
+		};
+
+		await assertRuleIndependentOfContext(
+			collect,
+			{ ...scopeContext, signal: controller.signal },
+			attrs,
+		);
+
+		expect(cancelled).toBe(true);
 	});
 
 	it("rejects a rule that mutates the attributes it is judged against", async () => {


### PR DESCRIPTION
`AttributePipeline` and `RulePipeline` ran their collectors under a bare `Promise.all`. Collectors are the layer designed to call databases and HTTP APIs, and a `Promise.all` has no deadline, no cancellation and no bound on how much work it starts — so one collector holding a dead socket held the authorization decision with it, siblings kept running after another had already failed the request, and a dependency slowdown piled up unbounded in-flight work instead of shedding it. One `POST /verify/batch` is up to 50 decisions, each fanning out across every configured collector, so this was a DoS amplifier as well as a latency failure.

## The defaults, and why

| Knob | Default | Why this number |
| --- | --- | --- |
| `verify.collectorTimeoutMs` | `2000` | A healthy lookup against a dependency the deployment runs answers in single-digit milliseconds. 2s is far past "slow" and short of the timeouts callers put on `/verify` itself, so the verifier is the layer that notices — and it can name **which** collector, which a caller-side timeout never can. The budget starts when the collector starts, not when the fan-out did, so queueing behind the concurrency cap does not spend it. |
| `verify.collectorDeadlineMs` | `5000` | A per-collector budget cannot bound a *set*. Once collectors queue, enough of them each finishing just inside their own budget still adds up to a request nobody is waiting for. Deliberately longer than one collector's budget and shorter than the sum of several. |
| `verify.collectorConcurrency` | `8` | More than the collector set of any deployment this project has seen, so a normal configuration still fans out in one wave and nothing about its latency changes. What the cap removes is the tail: dozens of collectors, or a 50-entry batch, multiplying into simultaneous outbound calls against a dependency that has just started to slow down. It is a ceiling on pathology, not a tuning parameter. |

Both triage recommendations were kept as-is; the code did not suggest better. The one number triage did not name is the concurrency cap, argued above.

All three route through `resolveBound` at **both** config boundaries — `AppConfigSchema` for config files, `createApp` for the hand-built configs it also accepts — with one spec table in `config/bounds.mts` and the path supplied by the boundary, per AGENTS.md "Two-Boundary Config Validation". `createApp` is the runtime guard because it is what constructs the pipelines. The defaults themselves live in `packages/core` and are **re-exported** by `config/defaults.mts` rather than restated, so the config file's default and the pipeline's cannot drift — the #157 failure one package boundary further out. `0` is refused for all three: a zero timeout cancels every collector before it can answer, and a zero concurrency is a fan-out that starts nothing and resolves with no attributes and no rules, which is a fail-open dressed as a setting.

## How cancellation reaches a collector

`CollectorContext` gained a required `signal: AbortSignal`. Per decision, per pipeline:

- the pipeline builds one `AbortController` for the fan-out. It aborts on the deadline, on the caller's signal, or when a sibling collector has already failed the decision;
- each collector gets its **own** controller, linked to the fan-out's and carrying its own timer, so one collector timing out does not cancel the rest;
- the collector is invoked with `{ ...request, signal: own.signal }` and raced against that signal. The race is what makes the bound real: a collector that ignores its signal — the hung-socket case this is all for — would otherwise never settle, and a bound only the cooperative respect is not a bound;
- on any failure the fan-out controller is aborted, which cancels every sibling still in flight, and the worker loop refuses to start anything new.

A collector honours it by passing it on: `fetch(url, { signal: context.signal })`. That does not make the deadline hold — the pipeline abandons a collector that ignores it — but it is what stops the outbound call still running against a dependency that has already lost the request it belonged to.

`AttributePipeline.collect` / `RulePipeline.collect` now take a `CollectorRequest`: the same shape **without** `signal`, since the per-collector signal is the pipeline's to mint. Its own optional `signal` is caller-side cancellation (a client that hung up, an outer deadline), linked into the pipeline's. `routes/verify.mts` therefore needed no change at all where it builds the context — the edit there is one import, two constants, and a `try`/`catch` around the two existing lines.

## Fail closed — the proof

The pipeline throws `CollectorTimeoutError` and returns **nothing at all**. It never resolves with the results that arrived in time, and that is the whole design decision rather than an implementation detail:

- partial *attributes* merely weaken a rule's inputs — a missing `scopes` denies a scope rule;
- partial *rules* weaken the **policy**, and an empty rule list is an **allow** wherever `rule.onEmptyRuleSet = "allow"` is set.

So there is no shape of "answer with what we got" that is safe, and the evaluator is never reached: `routes/verify.mts` catches the error and builds the deny itself — `403`, `code: "collector_timeout"`, empty `reason.groups`. There is no code path on which a timeout can become a permit.

Pinned behaviourally by `createApp — a stalled collector denies (#115)`, which is a pair:

1. a **control** — a deployment with `onEmptyRuleSet: "allow"` and a rule collector that returns `[]` really does answer `200 allow`, so the case below is not passing for some other reason;
2. the same deployment with a rule collector that stalls answers `403 collector_timeout`.

That is exactly the fail-open being closed. Core carries the same property from the other side (`AttributePipeline — fail closed`), and the router pins that in a batch the bound is per decision: one entry timing out denies that entry and leaves the rest decided, rather than 500-ing the batch.

A deny and not a `5xx`, deliberately: a 5xx invites the enforcement layer to retry the same stalled dependency, or to conclude the PDP is down and apply a fallback nobody in this repo wrote. The wire message names no collector and no bound — that reaches the caller, and the collector set is deployment topology; the detail goes to the `collector_timeout` log line. The decision still emits its `decision` audit line and increments the deny counters, so a timeout is visible as what it is instead of disappearing into the 500 rate.

## Interaction with the rule-purity conformance helper

The signal lands on the very object `describeRulePurityConformance` revokes, and the two genuinely tension — but only over the *mechanism*, not the check. Both halves are pinned by tests rather than argued.

**It has to stay revocable.** `signal` is the first context field a collector is *meant* to hold live, but that licence ends when `collect` returns. `aborted` moves on its own, so a rule that carried a signal into `verify` is not a function of `attrs` at all — the same violation as holding `ctx.resource`. Exempting the field would have quietly opened a hole in the check the week it was added. `rejects a rule that kept the collector's AbortSignal and read it at verify time` pins that it does not.

**It cannot be a `Proxy`.** `AbortSignal`'s members are brand-checked against the receiver. `signal.aborted` happens to read through a proxy, but `addEventListener`, `AbortSignal.any([signal])` and `fetch(url, { signal })` all throw `Method Map.prototype.get called on incompatible receiver` — verified before writing the fix. Wrapping it the way every other object is wrapped would have made the suite fail every collector that uses its signal for the thing it is for: the harness reporting its own artefact as a violation, which is the mistake the existing memoization already exists to avoid.

**Resolution, with no loosening.** The view handed to a collector is a genuine `AbortSignal` minted by `AbortSignal.any([caseSignal])` — every brand check passes, and it stays linked, so a case that cancels mid-collect still reaches the collector. Revoking shadows each of its prototype members with an own accessor that throws the same `TypeError` a revoked proxy throws, so `isRevokedProxyError` recognises it and the violation is reported against the offending rule in the same words as every other one. `hands the collector an AbortSignal every real use of one still works on` and `keeps the collector's signal linked to the one the case supplied` pin the other half.

`RulePurityCase.context` is now a `CollectorRequest`, so a case states facts about the request and the harness — which *is* the fan-out here — supplies the signal. Existing fixtures needed no change. The reasoning is written on `revocableSignal` and summarised in AGENTS.md, so a future field with internal slots of its own follows it rather than taking an exemption.

## Breaking change, and what an author must do

`CollectorContext.signal` is required.

- **A collector author** needs no change to keep compiling — a collector only reads the context. What they *should* change is to pass the signal on: `fetch(this.endpoint, { signal: context.signal })`.
- **Code that builds a `CollectorContext`** — a custom transport or interceptor, and every test fixture with a context literal — must supply one. A transport with no cancellation of its own passes `new AbortController().signal`.
- **Callers of `pipeline.collect(...)`** are unaffected: it now takes `CollectorRequest`, which is the same shape without `signal`.
- **Operationally**, a stalled collector that previously produced a `500 internal_error` now produces a `403 collector_timeout`. An enforcement layer that distinguishes the two should be told.

The CHANGELOG carries the full entry, including the config-key table and the fail-closed reasoning.

## Rebased onto #166 — the `verify` block's `.default()`

Rebased on `05d73fc`. The two PRs collide in five places, four of which conflict textually and were resolved by keeping both sides: `NUMERIC_BOUNDS` (fifteen specs now), `config/defaults.mts`, `createApp`'s forwarding, and the schema's `verify` shape.

The fifth is the one that could have merged cleanly and still been wrong. The block carries `.default(() => ({…}))`, **zod takes that object verbatim**, and it never parses it back through the shape — so a knob present in the shape but missing from the literal is `undefined` for every config that omits the `verify` block entirely. That is the ordinary deployment shape, since an overlay config repeats only the sections it changes. Nothing throws; the bound just stops existing. Landing second, this branch could have silently dropped #118's five defaults, or had its own three dropped by whoever lands third.

The literal now names all nine (`maxBatchSize`, #118's five, my three), and it is **asserted rather than reviewed**, in two places:

- **`AppConfigSchema — the verify block's default names every knob`** compares the block's two productions: present-and-empty (`verify: {}`, which runs each key's own `boundedNumber` → `resolveBound(undefined)` → that spec's fallback) against absent (which takes the literal). They must be deeply equal, and equal to the documented constants. Written as an equality rather than a key list on purpose: a *tenth* knob added to the shape alone fails this without anyone remembering to extend an assertion.
- **`loadAppConfig — a config with no verify block at all`** proves it end-to-end through the real 3-tier HOCON path — `parseFile(<env>.conf).withFallback(parseFile(application.conf))` → `validate(…, AppConfigSchema)` — against a config directory written with no `verify` block and a comment-only overlay. All nine arrive at their documented defaults, and a second case asserts the omitted-block result equals the shipped-config result, so the file operators copy from cannot drift from the fallback an unconfigured deployment runs.

**Verified by mutation, not by hope:** deleting one line from the `.default()` literal fails both schema cases. I ran that before keeping them.

Two things fell out of doing this properly:

- **`templates/standalone/config/application.conf` now carries the three knobs** with their `VERIFY_COLLECTOR_*` substitutions. #113 has landed, so the conflict that made me skip it is gone — and without it the env vars my README documents would have done nothing for a standalone deployment. `loadConfig.test.mts` covers them like #118's: read from the environment, refused at `0`/`-1`, and refused when exported empty.
- **`loadConfig.test.mts` was leaking env between tests.** Its `afterEach` cleans the `envKeys` list, which named only `VERIFY_MAX_BATCH_SIZE` while #118's cases set five more `VERIFY_*` variables. The leak was invisible while no later case loaded the shipped config and asserted on `verify`; my new case was the first that did, and it failed with a boot error from a variable a test three screens up had set. All eight are now listed.

## Ordering against #166, and the flake I did not paper over

#166 moved body validation ahead of authentication. The collector-timeout deny lives inside `decide`, which runs after both gates, so the precedence is `400 invalid_request` → `401` → `403 collector_timeout`. That is the right order — you should not be able to learn that a PDP's collectors are slow, or make it spend a collector budget, without a well-formed body and a valid token. **Pinned rather than read:** with a stalling collector configured, a malformed unauthenticated body still returns `400` and a well-formed body with no token still returns `401`, neither taking the budget. If a later change moved collection ahead of either gate, those cases come back `403 collector_timeout`.

One honest note: on the first post-rebase full run, `metrics.test.mts > labels by the route pattern, not the URL` failed at 5013ms. Because that is suspiciously close to my 5s deadline default I chased it rather than re-running: the test uses `bareApp()`, which builds no verify router, no pipelines and no `CollectorContext`, so no timer of mine exists in its path. It has not recurred in four subsequent full runs. It is a supertest ephemeral-port flake, not this change.

What it *did* prompt is a guard worth having, since an uncleared timer would be the one way this change could cause diffuse slowness: **`leaves no timer pending once the fan-out is over`** asserts `vi.getTimerCount()` is unchanged after a successful collect and after a failing one, so the `finally` that clears two timers per collector plus one per fan-out is checked on both paths.

## Review round 2

**Copilot: a collector was invoked with an already-aborted signal.** Correct, and fixed at the point where the work starts. `runOne` now refuses before invoking `collect`, and the redundant check in the lane loop is gone — one guard, in the place the invariant is actually about. Handing a collector an aborted signal and trusting it to notice is not equivalent: the documented way to use the signal is to pass it to `fetch`, so a collector that does not test `aborted` before its first `await` has already put the request on the wire — an outbound call for an answer nobody will read, usually against the very dependency whose slowness ended the decision.

The **outcome for that collector** is the fan-out's own reason rethrown — the deadline, a sibling's error, or the caller leaving — never a `CollectorTimeoutError` attributed to it. It never ran, so it never overran anything, and blaming it would send an operator to tune a budget that was never spent. Rethrowing rather than resolving is what keeps fail-closed intact: a skipped collector must not read as one that legitimately contributed nothing. Three tests pin it (never invoked; the deadline is blamed rather than the skipped collector; a sibling's failure propagates unchanged).

Scope note, since it affects how much to trust the guard: mutation-testing it (`if (false)`) fails exactly one case — `propagates a signal the caller already aborted without running any collector`. That is its reachable path, and it is the one the removed lane check used to serve. The mid-flight cases reach zero collectors by exception propagation instead, which the three new tests pin as behaviour.

**Copilot: the README schema example types the collector knobs as `z.number()`.** Right, and the neighbours were stale in the same class: they read `z.coerce.number()`, which conveys coercion but has been wrong about the mechanism since #157, and differs materially — `z.coerce` accepts `true` as `1` and `null`/`""` as `0`, which the real schema refuses and has tests for. So rather than swap `z.number()` for a spelling that is merely less wrong, every numeric knob in the example now reads as the code does, `boundedNumber(NUMERIC_BOUNDS.x, "path")`, with a paragraph stating what that admits (a number, or the string a HOCON `${?VAR}` substitution delivers) and what it refuses. #118's five `verify` knobs were also missing from the example and are now listed, so the block shows all nine. `README.md` and `README.ja.md` are identical in structure — checked mechanically by diffing their key lists, not by eye.

**codecov/project/core, 98.30% (-1.70%).** Found rather than guessed: `pnpm --filter core test:coverage` put `src` at exactly 98.30%, matching codecov, with two misses and both mine. Neither was untested *behaviour* — both were **dead branches**, so the fix was to delete the unreachable code rather than write tests that reach for it:

- `errors.mts:69` — `detail.collector ?? "(unnamed)"`. The fallback could never be taken, because a per-collector timeout always knows its collector. `CollectorTimeoutDetail` is now a union discriminated on `limit`: `collector` is required on the `"collector"` arm and absent on `"deadline"`, which is the truth about those two cases anyway — a deadline is the *set* running out, and no one collector is answerable for it. The impossible state is now unrepresentable and the fallback is gone.
- `collectorLimits.mts:298-299` — the `if (signal.aborted)` early return in `rejectOnAbort`, which the new abort-before-start guard made unreachable (its one caller passes a controller created three lines above). Removed, with the precondition written on the function: a listener added to an already-aborted signal never fires, so a defensive branch there would be the difference between rejecting and hanging — exactly the code that has to be reachable to be trusted, and that one would not be.
- The uncovered *function* was the `let dispose = () => {}` placeholder in the same helper, only ever called on the branch above. `rejectOnAbort` now captures `reject` from the executor instead, so there is no placeholder to overwrite.

`packages/core` is now **100% statements, 100% functions, 100% lines**; the sole remaining branch miss is `consoleLogger.mts:97`, which predates this branch (`git diff origin/develop -- packages/core/src/logging/` is empty). `coverage/` was deleted before linting, and the final validation run used no `--coverage`.

## Test results

All run after the review fixes, in the worktree, `coverage/` deleted first and no `--coverage` on this run:

- `pnpm lint` — clean, 145 files, no warnings
- `pnpm -r run build` — clean
- `pnpm run typecheck` — clean across all 6 workspaces (this is what type-checks the test files)
- `pnpm run test` — **1502 passed**, 0 failed: core 108 (11 files), builtins 474 (21), server 705 (14), integration 75 (6), templates/standalone 62 (4), create-app 78 (1)
- CI's `verify()`-reads-a-context grep gate, run locally: `OK: no verify() body reads a collector context (126 files scanned)`
- `packages/core` coverage (measured separately, then cleaned): 100% statements / 100% functions / 100% lines

New coverage: 28 cases in `packages/core/src/__tests__/collectorLimits.test.mts` (cancellation, per-collector timeout, deadline, concurrency, fail-closed, construction-time refusal, timer hygiene, both pipelines), 3 in the rule-purity conformance suite, 16 schema cases including the three-case `.default()` guard, 15 `createApp` cases (fail-closed pair plus two-boundary agreement), 4 router cases (deny, gate ordering, batch), and 5 in `loadConfig.test.mts` (no-`verify`-block defaults, shipped-config agreement, env reads and refusals).

## Judgment calls

- **`createApp` is the runtime-guard boundary**, not `createVerifyRouter`, because `createApp` is what constructs the pipelines; the router receives them already built. The two-boundary test compares `createApp`'s refusal against the schema's, in the shape `maxBatchSize` already uses.
- **The knobs live in the existing `verify` block** rather than a new top-level section, so they reuse its `boundedNumber(spec, "verify")` path and need no new defaulted block.
- **Core validates its own limits, weakly and once, at construction** (`RangeError` on a non-positive integer). It cannot disagree with `resolveBound`: every value `resolveBound` produces for these knobs is a positive integer, so anything the config layer accepts core accepts. It exists only so a hand-written `concurrency: 0` fails loudly instead of silently resolving with nothing collected.
- **`templates/standalone/config/application.conf` now carries the knobs.** It was deliberately untouched in the first revision to avoid conflicting with `fix/113`; that has landed, and leaving it out would have meant documenting `VERIFY_COLLECTOR_*` env vars that a standalone deployment could not actually use.
- **Each collector gets its own signal**, not a shared one, so one collector's timeout does not cancel siblings that are still inside their own budgets.
- **The concurrency cap is per decision**, not a process-wide semaphore. A shared one would bound the batch amplification harder, but a stalled collector holding a permit would then block unrelated requests — head-of-line blocking on the hot path, in exchange for a bound `maxBatchSize` already provides a ceiling on.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
