### PR TITLE
test: pin the VerifierEndpoint wire contract, as fixtures another repo can read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,6 +516,50 @@ and version sections follow the release labeling policy in
 
 ### Added
 
+- **A wire-contract conformance suite, so "drop-in replaceable behind
+  `VerifierEndpoint`" is a claim this repository can fail**
+  ([#125](https://github.com/o3co/auth.policy-verifier/issues/125)). The
+  interface an enforcement layer codes against lives in
+  [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors), so
+  nothing here checked that the wire shape this service publishes is the wire
+  shape that repository implements. A field rename or a status remap would have
+  been invisible until it broke every caller at once, at runtime.
+
+  `describeWireContractConformance` joins the other suites in
+  `tests/integration/src/conformance/`, and it is the odd one out on purpose:
+  the rest are engine-agnostic and pin the seam *underneath* the endpoint, while
+  this one pins the HTTP surface *above* it — statuses, the exact key set of
+  every response body, and which refusal wins when a request is wrong in two
+  ways at once. Its adapter is a transport rather than an engine, so an OPA or
+  Cedar deployment of this same service satisfies it by answering identically
+  over HTTP, which is precisely what the swap promise means.
+
+  **The fixtures are JSON files** (`conformance/fixtures/wireContract/`), not
+  literals in the runner. The enforcement layer is a different repository and
+  need not be TypeScript; a table it can read is the only version of this
+  contract that can be shared rather than re-typed, and re-typing it is the
+  drift #125 was filed about. `requestCases.json` is every refusal — status,
+  code, and what the message must and must not name — and
+  `responseEnvelopes.json` is the key set of each response body, exhaustive in
+  both directions: a response carrying a key the contract never promised fails
+  as readily as one missing a key it did.
+
+  It pins the contract **as #118 and #115 left it**, not as it was: a malformed
+  body is `400 invalid_request` whether or not a credential was presented (it
+  was `401` before #118), an oversized body is a `413 payload_too_large` deny
+  envelope rather than Express's HTML page, whitespace in `resource` or `action`
+  is refused rather than trimmed, an unknown property is refused and named,
+  `subject` is omitted when the token carries no `sub` (#158), `satisfiedBy`
+  appears on a passing rule group only (#135), and a collector fan-out that runs
+  out of time is `403 collector_timeout` with an empty `reason.groups` (#115).
+  `POST /verify/batch` is pinned alongside it — the envelope, the preserved
+  order, `200` even when every entry denies, and the refusal that names the
+  offending index and rejects the whole batch before any entry is decided.
+
+  The deny envelope the READMEs print verbatim is now read from
+  `responseEnvelopes.json` by `verifyInputValidation.test.mts` instead of being
+  restated there, so the shape has one definition rather than a fourth copy.
+
 - **A rule-purity conformance suite, so the contract `evaluate()` spends is one
   something can fail** ([#152](https://github.com/o3co/auth.policy-verifier/issues/152)).
   `evaluate()` runs every rule group rather than stopping at the first failure
@@ -1337,6 +1381,17 @@ and version sections follow the release labeling policy in
   departure from its shared-check-function mechanism — and which had never been
   written for the one departure the section documents. Two implementations held
   in step by hand had drifted, as #157's numeric knobs had before them.
+
+- The "How It Works" diagram in `README.md` and `README.ja.md` still put JWT
+  verification first, contradicting the same file's own "Request Limits" section
+  and the behaviour #118 shipped
+  ([#125](https://github.com/o3co/auth.policy-verifier/issues/125)). The diagram
+  is the first thing a client author reads, and it described the pre-#118
+  ordering: a reader who took it at face value would have expected `401` for a
+  malformed unauthenticated request, which is exactly the answer that changed.
+  Body validation is now step 1, the remaining steps are renumbered, and the
+  order is stated under the diagram rather than left to be inferred from it.
+  Found while writing the #125 conformance suite.
 
 - A decision response carried `subject: ""` for a token whose `sub` claim is
   present but empty, while the field's own documentation said it is absent when

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,19 +23,21 @@ Authorization: Bearer <jwt>
   ┌──────────────────────────────────────────────────┐
   │                  /verify ハンドラ                  │
   │                                                   │
-  │  1. JWT 検証 (HS256 / RS256 / ES256 / EdDSA)     │
+  │  1. body 検証 (上限・文法・未知キー)               │
   │                                                   │
-  │  2. AttributeCollectors (並列)                    │
+  │  2. JWT 検証 (HS256 / RS256 / ES256 / EdDSA)     │
+  │                                                   │
+  │  3. AttributeCollectors (並列)                    │
   │     ├─ PayloadScopeCollector → JWT からスコープ   │
   │     ├─ PayloadSubjectIdCollector → サブジェクトID  │
   │     └─ (カスタム Collector...)                    │
   │                                                   │
-  │  3. RuleCollectors (並列)                         │
+  │  4. RuleCollectors (並列)                         │
   │     ├─ ResourceActionScopeRuleCollector            │
   │     │   → HasScope("read:project")                │
   │     └─ (カスタム RuleCollector...)                │
   │                                                   │
-  │  4. 評価                                          │
+  │  5. 評価                                          │
   │     ルールグループ内は OR、グループ間は AND          │
   │     全グループを評価 → 構造化 reason                │
   │                                                   │
@@ -47,6 +49,13 @@ POST /verify/batch — 同じ契約で、1 往復に N 件の decision
 {"decisions": [{"resource": "project:1", "action": "read"}, …]}
   → 200 {"decisions": [{…}, …]}   (順序は保持。全部 deny でも 200)
 ```
+
+ステップ 1 はステップ 2 の **前** に走る。不正な body は資格情報の有無にかかわらず
+`400 invalid_request` であり、body で拒否されたリクエストでは Collector は 1 つも動かない。
+その順序の理由と、匿名の呼び出し元が何を知り得るかは [リクエストの上限](#リクエストの上限) を参照。
+上図のステータス・コード・レスポンスキーを含む wire 契約全体は
+[`tests/integration/src/conformance/`](tests/integration/src/conformance/) が固定しており、
+そのフィクスチャは JSON なので enforcement 層は同じ表に対して実装できる。
 
 ## 特徴
 

--- a/README.md
+++ b/README.md
@@ -23,19 +23,21 @@ Authorization: Bearer <jwt>
   ┌──────────────────────────────────────────────────┐
   │                  /verify handler                  │
   │                                                   │
-  │  1. Verify JWT (HS256 / RS256 / ES256 / EdDSA)   │
+  │  1. Validate body (bounds, grammar, keys)         │
   │                                                   │
-  │  2. AttributeCollectors (parallel)                │
+  │  2. Verify JWT (HS256 / RS256 / ES256 / EdDSA)   │
+  │                                                   │
+  │  3. AttributeCollectors (parallel)                │
   │     ├─ PayloadScopeCollector → scopes from JWT    │
   │     ├─ PayloadSubjectIdCollector → subject ID     │
   │     └─ (custom collectors...)                     │
   │                                                   │
-  │  3. RuleCollectors (parallel)                     │
+  │  4. RuleCollectors (parallel)                     │
   │     ├─ ResourceActionScopeRuleCollector           │
   │     │   → HasScope("read:project")                │
   │     └─ (custom rule collectors...)                │
   │                                                   │
-  │  4. Evaluate                                      │
+  │  5. Evaluate                                      │
   │     OR within rule group, AND across groups        │
   │     every group runs → structured reason           │
   │                                                   │
@@ -47,6 +49,13 @@ POST /verify/batch — the same contract, N decisions per round trip
 {"decisions": [{"resource": "project:1", "action": "read"}, …]}
   → 200 {"decisions": [{…}, …]}   (order preserved; 200 even if all deny)
 ```
+
+Step 1 runs **before** step 2: a malformed body is `400 invalid_request` whether or not a credential
+was presented, and no collector runs for a request that was refused on its body. See
+[Request Limits](#request-limits) for why that order, and what an anonymous caller learns from it.
+The whole wire contract — every status, code and response key above — is pinned by
+[`tests/integration/src/conformance/`](tests/integration/src/conformance/), whose fixtures are JSON
+so the enforcement layer can implement against the same table.
 
 ## Features
 

--- a/packages/server/src/__tests__/verifyInputValidation.test.mts
+++ b/packages/server/src/__tests__/verifyInputValidation.test.mts
@@ -4,7 +4,7 @@
 /*
  * Request validation on the decision endpoints (#118).
  *
- * Three things are pinned here, and #125 will pin them again from the outside:
+ * Three things are pinned here:
  *
  * 1. Every input a caller controls is bounded by a stated limit — body bytes,
  *    `resource` and `action` length, and the shape of `context` — and each
@@ -12,6 +12,15 @@
  * 2. The body is validated BEFORE the token is verified, so a malformed
  *    unauthenticated request is answered 400 rather than 401.
  * 3. A body-parser failure answers the deny envelope, not Express's HTML page.
+ *
+ * Points 2 and 3 are wire-visible, and #125 now pins them from outside this
+ * package too, in `tests/integration/src/conformance/wireContract.mts`. The two
+ * suites are not copies of one another: this one holds the limits to their
+ * *configured numbers* and to the two-boundary agreement, which is
+ * package-internal; the conformance suite holds the *answers* to the shape an
+ * enforcement layer implements against. Where they would otherwise have stated
+ * the same literal — the deny envelope the READMEs print — this file reads the
+ * conformance fixture rather than keeping a second copy of it.
  */
 
 import { readFileSync } from "node:fs";
@@ -42,13 +51,32 @@ import {
 import { HS256KeyResolverFactory } from "#/jwt/index.mjs";
 import { createVerifyRouter, type VerifyRouterConfig } from "#/routes/verify.mjs";
 
+/** Repo root, four levels up from `packages/server/src/__tests__`. */
+const repoRoot = new URL("../../../../", import.meta.url);
+
 /**
  * The deny envelope exactly as `README.md`, `README.ja.md` and `CHANGELOG.md`
- * print it for a body the parser refuses. One literal, checked against the
- * route's own answer and against all three files — see the last describe.
+ * print it for a body the parser refuses, checked against the route's own
+ * answer and against all three files — see the last describe.
+ *
+ * **Read from the #125 conformance fixture, not restated here.** That file is
+ * the contract an enforcement layer implements against, and a literal here
+ * would have been a fourth copy of a shape whose three existing copies are the
+ * reason this describe exists. It is read as bytes rather than imported because
+ * the fixture is a data file another repository consumes by path — see
+ * `tests/integration/src/conformance/wireContract.mts`.
  */
-const DOCUMENTED_DENY_ENVELOPE =
-	'{"decision": "deny", "code": "invalid_request", "message": "Request body is not valid JSON"}';
+const DOCUMENTED_DENY_ENVELOPE = (
+	JSON.parse(
+		readFileSync(
+			new URL(
+				"tests/integration/src/conformance/fixtures/wireContract/responseEnvelopes.json",
+				repoRoot,
+			),
+			"utf8",
+		),
+	) as { error: { documentedExample: string } }
+).error.documentedExample;
 
 /** 64 hex characters — 32 decoded bytes, the entropy floor #114 enforces. */
 const JWT_SECRET = "11".repeat(32);
@@ -530,13 +558,11 @@ describe("the documented deny envelope is the one the endpoint emits (#118, #125
 	 * literal, asserted to be valid JSON, to equal what the route actually
 	 * answers, and to appear verbatim in every file that documents it.
 	 *
-	 * #125 will pin the same contract from outside the repo. Both should be
-	 * describing this object.
+	 * #125 pins the same contract from outside the repo, and `DOCUMENTED_DENY_
+	 * ENVELOPE` above is now read from its fixture: there is one object, and
+	 * both suites describe it.
 	 */
 	const documentedIn = ["README.md", "README.ja.md", "CHANGELOG.md"] as const;
-
-	/** Repo root, four levels up from `packages/server/src/__tests__`. */
-	const repoRoot = new URL("../../../../", import.meta.url);
 
 	it("is valid JSON", () => {
 		expect(() => JSON.parse(DOCUMENTED_DENY_ENVELOPE)).not.toThrow();

--- a/tests/integration/src/conformance/fixtures/wireContract/requestCases.json
+++ b/tests/integration/src/conformance/fixtures/wireContract/requestCases.json
@@ -1,0 +1,393 @@
+{
+	"about": [
+		"Every request the decision endpoints refuse, and the status and code each one is",
+		"refused with. One row per wire-visible behaviour, as data rather than as test code,",
+		"so an enforcement layer implementing against this endpoint can read the same table.",
+		"`credential` names what the sender puts in the Authorization header; the adapter",
+		"mints it. `payload.kind` is `json` (sent as application/json), `text` (sent",
+		"verbatim under `contentType`), `overBodyLimit` or `overBatchSize` (the adapter",
+		"builds one past the limit its own deployment is configured with — the contract is",
+		"that a limit exists and how it answers, not what the number is).",
+		"The whole table is pinned as it stands AFTER #118 reordered body validation ahead",
+		"of authentication. Three rows below answered 401 before that change and answer 400",
+		"now, and three more answered with Express's HTML error page and now answer this",
+		"envelope. All six carry \"issue\": \"#118\", so a reader who finds an older client",
+		"disagreeing with this table knows which side moved and when."
+	],
+	"cases": [
+		{
+			"id": "verify/body-is-an-array",
+			"pins": "the body must be an object; a JSON array is not one",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": [] },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/resource-missing",
+			"pins": "resource is required",
+			"issue": "#18",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "action": "read" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/action-missing",
+			"pins": "action is required",
+			"issue": "#18",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": "project:1" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/resource-empty",
+			"pins": "an empty resource is not a resource",
+			"issue": "#18",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": "", "action": "read" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/action-empty",
+			"pins": "an empty action is not an action",
+			"issue": "#18",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": "project:1", "action": "" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/resource-not-a-string",
+			"pins": "resource is a string, and a number is not coerced into one",
+			"issue": "#18",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": 42, "action": "read" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/resource-with-inner-whitespace",
+			"pins": "whitespace inside resource is refused, not trimmed away",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": "project: 1", "action": "read" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/resource-with-surrounding-whitespace",
+			"pins": "a padded resource is refused rather than trimmed into a different one",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": " project:1 ", "action": "read" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/action-with-whitespace",
+			"pins": "whitespace in action is refused too — RFC 6749 §3.3 makes space the scope delimiter",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": "project:1", "action": "read all" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/resource-the-parser-refuses",
+			"pins": "a resource string the configured parser refuses is the caller's syntax error, not a 500",
+			"issue": "#117",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "resource": "a..b", "action": "read" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/unknown-property-subject",
+			"pins": "a body-supplied subject is refused and named, never quietly dropped",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": { "resource": "project:1", "action": "read", "subject": "admin" }
+			},
+			"expect": { "status": 400, "code": "invalid_request" },
+			"messageMentions": ["subject"]
+		},
+		{
+			"id": "verify/unknown-property-misspelled",
+			"pins": "a misspelled property is named rather than ignored",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": { "resource": "project:1", "action": "read", "contxt": { "tenant_id": "acme" } }
+			},
+			"expect": { "status": 400, "code": "invalid_request" },
+			"messageMentions": ["contxt"]
+		},
+		{
+			"id": "verify/context-is-an-array",
+			"pins": "context is an object; an array is a shape no collector expects",
+			"issue": "#124",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": { "resource": "project:1", "action": "read", "context": [] }
+			},
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/context-is-null",
+			"pins": "an explicit null context is refused rather than read as an absent one",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": { "resource": "project:1", "action": "read", "context": null }
+			},
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/malformed-json",
+			"pins": "a body the parser cannot read answers the deny envelope, never Express's HTML page",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "none",
+			"contentType": "application/json",
+			"payload": { "kind": "text", "text": "{\"resource\": \"project:1\", \"leaked-key\": " },
+			"expect": { "status": 400, "code": "invalid_request" },
+			"matchesDocumentedExample": true,
+			"mustNotEcho": ["leaked-key"]
+		},
+		{
+			"id": "verify/body-over-the-size-limit",
+			"pins": "a body over maxBodyBytes is a payload_too_large deny, not an Express 413 page",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"contentType": "application/json",
+			"payload": { "kind": "overBodyLimit" },
+			"expect": { "status": 413, "code": "payload_too_large" }
+		},
+		{
+			"id": "verify/unreadable-charset",
+			"pins": "a charset the parser cannot decode is 415, as the deny envelope",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"contentType": "application/json; charset=iso-8859-1",
+			"payload": { "kind": "text", "text": "{\"resource\":\"project:1\",\"action\":\"read\"}" },
+			"expect": { "status": 415, "code": "unsupported_media_type" }
+		},
+		{
+			"id": "verify/body-sent-as-text-plain",
+			"pins": "a content type express.json skips never becomes an object, and is refused as malformed",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "valid",
+			"contentType": "text/plain",
+			"payload": { "kind": "text", "text": "resource=project:1&action=read" },
+			"expect": { "status": 400, "code": "invalid_request" },
+			"mustNotEcho": ["resource=project:1"]
+		},
+		{
+			"id": "verify/malformed-body-no-token",
+			"pins": "the body is checked before the token: 400, where this answered 401 missing_token before #118",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "none",
+			"payload": { "kind": "json", "value": { "resource": "project:1" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/malformed-body-unverifiable-token",
+			"pins": "same ordering with a token present that would not verify: 400, not 401 invalid_token",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "unverifiable",
+			"payload": { "kind": "json", "value": { "resource": "   ", "action": "read" } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "verify/well-formed-body-no-token",
+			"pins": "a usable body with no credential still falls through to 401 missing_token",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "none",
+			"payload": { "kind": "json", "value": { "resource": "project:1", "action": "read" } },
+			"expect": { "status": 401, "code": "missing_token" }
+		},
+		{
+			"id": "verify/well-formed-body-unverifiable-token",
+			"pins": "a usable body with a token that does not verify is 401 invalid_token",
+			"issue": "#118",
+			"endpoint": "/verify",
+			"credential": "unverifiable",
+			"payload": { "kind": "json", "value": { "resource": "project:1", "action": "read" } },
+			"expect": { "status": 401, "code": "invalid_token" }
+		},
+		{
+			"id": "verify/unsupported-authorization-scheme",
+			"pins": "only the Bearer scheme is accepted, and the refusal has its own code",
+			"issue": "#17",
+			"endpoint": "/verify",
+			"credential": "unsupportedScheme",
+			"payload": { "kind": "json", "value": { "resource": "project:1", "action": "read" } },
+			"expect": { "status": 401, "code": "unsupported_scheme" }
+		},
+		{
+			"id": "batch/malformed-body-no-token",
+			"pins": "the batch endpoint checks its body before the token exactly as /verify does",
+			"issue": "#118",
+			"endpoint": "/verify/batch",
+			"credential": "none",
+			"payload": { "kind": "json", "value": { "decisions": [] } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "batch/well-formed-body-no-token",
+			"pins": "a usable batch with no credential still falls through to 401 missing_token",
+			"issue": "#118",
+			"endpoint": "/verify/batch",
+			"credential": "none",
+			"payload": {
+				"kind": "json",
+				"value": { "decisions": [{ "resource": "project:1", "action": "read" }] }
+			},
+			"expect": { "status": 401, "code": "missing_token" }
+		},
+		{
+			"id": "batch/body-is-an-array",
+			"pins": "the batch envelope is an object, not the array of entries itself",
+			"issue": "#124",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": [{ "resource": "project:1", "action": "read" }] },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "batch/decisions-absent",
+			"pins": "decisions is required",
+			"issue": "#124",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": {} },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "batch/decisions-not-an-array",
+			"pins": "decisions is an array",
+			"issue": "#124",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "decisions": {} } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "batch/decisions-empty",
+			"pins": "an empty batch is a malformed request rather than an empty answer",
+			"issue": "#124",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": { "kind": "json", "value": { "decisions": [] } },
+			"expect": { "status": 400, "code": "invalid_request" }
+		},
+		{
+			"id": "batch/unknown-envelope-property",
+			"pins": "nothing rides beside decisions, and the refusal names what did",
+			"issue": "#118",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": {
+					"decisions": [{ "resource": "project:1", "action": "read" }],
+					"parallel": true
+				}
+			},
+			"expect": { "status": 400, "code": "invalid_request" },
+			"messageMentions": ["parallel"]
+		},
+		{
+			"id": "batch/entry-is-not-an-object",
+			"pins": "a batch names the offending index rather than the offending value",
+			"issue": "#124",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": { "decisions": [{ "resource": "project:1", "action": "read" }, "project:2"] }
+			},
+			"expect": { "status": 400, "code": "invalid_request" },
+			"messageMentions": ["decisions[1]"]
+		},
+		{
+			"id": "batch/entry-missing-action",
+			"pins": "one unusable entry refuses the whole batch, and the index says which",
+			"issue": "#124",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": {
+					"decisions": [{ "resource": "project:1", "action": "read" }, { "resource": "project:2" }]
+				}
+			},
+			"expect": { "status": 400, "code": "invalid_request" },
+			"messageMentions": ["decisions[1]"]
+		},
+		{
+			"id": "batch/entry-unknown-property",
+			"pins": "an entry's unknown property is refused, named, and located by index",
+			"issue": "#118",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": {
+					"decisions": [
+						{ "resource": "project:1", "action": "read" },
+						{ "resource": "project:2", "action": "read", "subject": "admin" }
+					]
+				}
+			},
+			"expect": { "status": 400, "code": "invalid_request" },
+			"messageMentions": ["decisions[1]", "subject"]
+		},
+		{
+			"id": "batch/entry-resource-the-parser-refuses",
+			"pins": "the resource grammar applies per entry, and the index says which entry broke it",
+			"issue": "#117",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": {
+				"kind": "json",
+				"value": {
+					"decisions": [
+						{ "resource": "project:1", "action": "read" },
+						{ "resource": "a..b", "action": "read" }
+					]
+				}
+			},
+			"expect": { "status": 400, "code": "invalid_request" },
+			"messageMentions": ["decisions[1]"]
+		},
+		{
+			"id": "batch/over-the-entry-cap",
+			"pins": "a batch past maxBatchSize is refused whole, before any entry is decided",
+			"issue": "#157",
+			"endpoint": "/verify/batch",
+			"credential": "valid",
+			"payload": { "kind": "overBatchSize" },
+			"expect": { "status": 400, "code": "invalid_request" }
+		}
+	]
+}

--- a/tests/integration/src/conformance/fixtures/wireContract/responseEnvelopes.json
+++ b/tests/integration/src/conformance/fixtures/wireContract/responseEnvelopes.json
@@ -1,0 +1,53 @@
+{
+	"about": [
+		"The response envelopes POST /verify and POST /verify/batch answer with, as data.",
+		"Consumed by tests/integration/src/conformance/wireContract.mts and by",
+		"packages/server/src/__tests__/verifyInputValidation.test.mts, which reads",
+		"`error.documentedExample` rather than keeping a second copy of it. An enforcement",
+		"layer implementing against this endpoint (o3co/protobuf.interceptors) can read the",
+		"same file: it is JSON at a stable path, not a TypeScript literal.",
+		"Key lists are EXHAUSTIVE. A response carrying a key not named here is drift, and",
+		"the suite fails on the extra key as readily as on a missing one — an enforcement",
+		"layer that switched on a field this contract never promised is exactly the coupling",
+		"#125 exists to prevent."
+	],
+	"error": {
+		"keys": ["decision", "code", "message"],
+		"decision": "deny",
+		"documentedExample": "{\"decision\": \"deny\", \"code\": \"invalid_request\", \"message\": \"Request body is not valid JSON\"}"
+	},
+	"decision": {
+		"required": ["resource", "action", "decision", "reason"],
+		"optional": ["subject"],
+		"denyAlsoCarries": ["code", "message"],
+		"allowNeverCarries": ["code", "message"]
+	},
+	"batch": {
+		"keys": ["decisions"]
+	},
+	"ruleGroup": {
+		"required": ["ruleType", "passed", "evaluated"],
+		"onlyOnAPassingGroup": ["satisfiedBy"]
+	},
+	"ruleOutcome": {
+		"keys": ["code", "message", "passed"]
+	},
+	"status": {
+		"allow": 200,
+		"deny": 403,
+		"batchDecided": 200,
+		"invalidRequest": 400,
+		"unauthenticated": 401,
+		"payloadTooLarge": 413,
+		"unsupportedMediaType": 415
+	},
+	"codes": {
+		"invalidRequest": "invalid_request",
+		"missingToken": "missing_token",
+		"invalidToken": "invalid_token",
+		"unsupportedScheme": "unsupported_scheme",
+		"payloadTooLarge": "payload_too_large",
+		"unsupportedMediaType": "unsupported_media_type",
+		"collectorTimeout": "collector_timeout"
+	}
+}

--- a/tests/integration/src/conformance/wireContract.mts
+++ b/tests/integration/src/conformance/wireContract.mts
@@ -1,0 +1,471 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * The layer this suite pins, and why it is the odd one out.
+ *
+ * The other suites in this directory are deliberately ENGINE-agnostic: they take
+ * an adapter that decides a request somehow, and say nothing about how the
+ * request arrived. `decisionContract.mts` would be satisfied by an in-process
+ * OPA, a Cedar adapter, or a function call — that is the point, because the
+ * thing it pins is the migration seam *underneath* the endpoint.
+ *
+ * This one pins the seam ABOVE it: the HTTP surface itself. Status codes, the
+ * exact key set of each response body, which refusal wins when a request is
+ * wrong in two ways at once. `VerifierEndpoint` — the interface an enforcement
+ * layer codes against — lives in o3co/protobuf.interceptors, so nothing in this
+ * repository was checking that the wire shape it publishes is the wire shape
+ * that repository implements (#125). An engine swap is invisible to a caller;
+ * a field rename here breaks every caller at once, silently, at runtime.
+ *
+ * So the adapter here is a TRANSPORT, not an engine: it puts bytes on the wire
+ * and reports the raw answer. An adapter for the OPA or Cedar deployment of
+ * this same service satisfies this suite by answering identically over HTTP,
+ * which is exactly the "drop-in replaceable behind `VerifierEndpoint`" claim
+ * the README makes.
+ *
+ * **The fixtures are JSON files, not literals in this module** — see
+ * `fixtures/wireContract/`. The enforcement layer is a different repository
+ * (and need not be TypeScript); a table it can read is the only version of this
+ * contract that can be shared rather than re-typed, and re-typing is the drift
+ * #125 was filed about. This module is the runner; the contract is the data.
+ *
+ * **The table is the post-#118 contract.** #118 moved body validation ahead of
+ * authentication and gave the body parser's own failures the deny envelope,
+ * which changed six answers on the wire: three that were 401 and are now 400,
+ * and three that were Express's HTML error page and are now this envelope. Those
+ * rows carry `"issue": "#118"` and say so in their `pins`, so a reader who finds
+ * this suite disagreeing with an older client knows which side moved and when.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/** Which decision endpoint a case is sent to. */
+export type WireEndpoint = "/verify" | "/verify/batch";
+
+/**
+ * What the sender puts in the `Authorization` header. The adapter mints each
+ * one, because what makes a token verifiable is the deployment's own key
+ * material — the contract is what the endpoint does with each kind, not how it
+ * is signed.
+ */
+export type WireCredential =
+	/** A token this deployment verifies, carrying `fixtures.subject` as its `sub`. */
+	| "valid"
+	/** The same, but with no `sub` claim at all — the #158 case. */
+	| "validWithoutSubject"
+	/** No `Authorization` header. */
+	| "none"
+	/** A bearer token that will not verify. */
+	| "unverifiable"
+	/** A well-formed header naming a scheme that is not Bearer. */
+	| "unsupportedScheme";
+
+/**
+ * What is sent as the body. `overBodyLimit` and `overBatchSize` are built by
+ * the adapter rather than carried here: both are operator knobs, and the
+ * contract is that the limit exists and how exceeding it is answered, not what
+ * number this deployment set it to.
+ */
+export type WirePayload =
+	| { kind: "json"; value: unknown }
+	| { kind: "text"; text: string }
+	| { kind: "overBodyLimit" }
+	| { kind: "overBatchSize" };
+
+/** One request, as the transport must send it. */
+export interface WireExchange {
+	endpoint: WireEndpoint;
+	credential: WireCredential;
+	/** Explicit `Content-Type`; omitted means `application/json`. */
+	contentType?: string;
+	payload: WirePayload;
+}
+
+/** One row of `fixtures/wireContract/requestCases.json`. */
+export interface WireRequestCase extends WireExchange {
+	/** Stable identifier, so another repository can reference one row. */
+	id: string;
+	/** What this row exists to pin, in one sentence. */
+	pins: string;
+	/** The issue that decided it. */
+	issue: string;
+	expect: { status: number; code: string };
+	/** Substrings the refusal must name — a field, or a batch index. */
+	messageMentions?: string[];
+	/** Substrings of the request that must not come back in the answer. */
+	mustNotEcho?: string[];
+	/** Whether this row's answer is the envelope the READMEs print verbatim. */
+	matchesDocumentedExample?: boolean;
+}
+
+/** The raw HTTP answer, before any interpretation. */
+export interface WireResponse {
+	status: number;
+	/** The `Content-Type` header as received; `undefined` when there is none. */
+	contentType: string | undefined;
+	/** The parsed body. */
+	body: unknown;
+	/** The body as bytes-as-text, for the assertions about what is *not* in it. */
+	text: string;
+}
+
+/** A decision request body, as `POST /verify` takes it. */
+export interface WireDecisionRequest {
+	resource: string;
+	action: string;
+	context?: Record<string, unknown>;
+}
+
+/**
+ * The requests this deployment's own policy answers a particular way. The suite
+ * pins the wire shape and the relationships between its parts, never a
+ * particular policy — so each of these is the deployment's to supply.
+ */
+export interface WireFixtures {
+	/** The `sub` the `valid` credential carries. */
+	subject: string;
+	/** A request this policy allows. */
+	allowed: WireDecisionRequest;
+	/** A request this policy denies. */
+	denied: WireDecisionRequest;
+	/**
+	 * Optional: a request that denies with at least one rule group still
+	 * passing, so `satisfiedBy`'s "on a passing group only" half is checked
+	 * against a response that carries both kinds of group at once (#135).
+	 */
+	partiallySatisfied?: WireDecisionRequest;
+	/**
+	 * Optional: a request whose collector fan-out runs out of time, for the
+	 * `collector_timeout` deny (#115). A deployment with no stallable collector
+	 * omits it and the two cases that need it do not run.
+	 */
+	stalling?: WireDecisionRequest;
+}
+
+/** Hooks a decision endpoint must provide to be checked against the wire contract. */
+export interface WireContractAdapter {
+	/** Deployment name, used in test titles. */
+	name: string;
+	/** Sends one exchange and reports the raw answer. Never throws on a 4xx. */
+	send(exchange: WireExchange): Promise<WireResponse>;
+	fixtures: WireFixtures;
+}
+
+/** The shape of `fixtures/wireContract/responseEnvelopes.json`. */
+interface ResponseEnvelopes {
+	error: { keys: string[]; decision: string; documentedExample: string };
+	decision: {
+		required: string[];
+		optional: string[];
+		denyAlsoCarries: string[];
+		allowNeverCarries: string[];
+	};
+	batch: { keys: string[] };
+	ruleGroup: { required: string[]; onlyOnAPassingGroup: string[] };
+	ruleOutcome: { keys: string[] };
+	status: Record<string, number>;
+	codes: Record<string, string>;
+}
+
+/**
+ * Reads one fixture file.
+ *
+ * `readFileSync` rather than an `import ... with { type: "json" }`: these files
+ * are a data table another repository consumes by path, and reading them as
+ * data is what keeps that true. It also spares `tests/integration` a
+ * `resolveJsonModule` setting whose only purpose would be to type a file the
+ * interfaces above already describe.
+ */
+export function readWireContractFixture<T>(name: string): T {
+	return JSON.parse(
+		readFileSync(new URL(`./fixtures/wireContract/${name}`, import.meta.url), "utf8"),
+	) as T;
+}
+
+/** The response envelopes, as data. Exported so a driver can assert against the same table. */
+export const RESPONSE_ENVELOPES =
+	readWireContractFixture<ResponseEnvelopes>("responseEnvelopes.json");
+
+/** The refusal table, as data. */
+export const REQUEST_CASES = readWireContractFixture<{ cases: WireRequestCase[] }>(
+	"requestCases.json",
+).cases;
+
+/** Every key of `body`, sorted, for an exact-key-set comparison. */
+const keysOf = (body: unknown): string[] => Object.keys(body as Record<string, unknown>).sort();
+
+/** The batch envelope around a list of decision requests. */
+const batchOf = (requests: WireDecisionRequest[]) => ({ decisions: requests });
+
+/**
+ * Conformance suite pinning the `VerifierEndpoint` wire contract
+ * (o3co/auth.policy-verifier#125).
+ *
+ * See the header of this file for which layer this pins and why it is not
+ * engine-agnostic like its neighbours.
+ */
+export function describeWireContractConformance(adapter: WireContractAdapter): void {
+	const {
+		error,
+		decision: decisionEnvelope,
+		batch,
+		ruleGroup,
+		ruleOutcome,
+		status,
+		codes,
+	} = RESPONSE_ENVELOPES;
+
+	/** Sends a decision body with the given credential, defaulting to a usable one. */
+	const post = (
+		endpoint: WireEndpoint,
+		value: unknown,
+		credential: WireCredential = "valid",
+	): Promise<WireResponse> =>
+		adapter.send({ endpoint, credential, payload: { kind: "json", value } });
+
+	/**
+	 * Asserts one decision body carries exactly the contract's keys, and that its
+	 * `reason` is built the way the contract says.
+	 */
+	const expectDecisionEnvelope = (body: unknown): Record<string, unknown> => {
+		const decision = body as Record<string, unknown>;
+		const permitted = new Set([
+			...decisionEnvelope.required,
+			...decisionEnvelope.optional,
+			...(decision.decision === "deny" ? decisionEnvelope.denyAlsoCarries : []),
+		]);
+
+		for (const key of decisionEnvelope.required) expect(Object.keys(decision)).toContain(key);
+		// Exhaustive in both directions: a key the contract never promised is drift
+		// as surely as a missing one, because a client that starts reading it has
+		// coupled itself to something no version of this contract guarantees.
+		expect(Object.keys(decision).filter((key) => !permitted.has(key))).toEqual([]);
+		if (decision.decision === "deny") {
+			for (const key of decisionEnvelope.denyAlsoCarries) {
+				expect(Object.keys(decision)).toContain(key);
+			}
+		} else {
+			for (const key of decisionEnvelope.allowNeverCarries) {
+				expect(Object.keys(decision)).not.toContain(key);
+			}
+		}
+
+		const groups = (decision.reason as { groups: Record<string, unknown>[] }).groups;
+		expect(Array.isArray(groups)).toBe(true);
+		for (const group of groups) {
+			const permittedGroupKeys = new Set([...ruleGroup.required, ...ruleGroup.onlyOnAPassingGroup]);
+			for (const key of ruleGroup.required) expect(Object.keys(group)).toContain(key);
+			expect(Object.keys(group).filter((key) => !permittedGroupKeys.has(key))).toEqual([]);
+			for (const outcome of group.evaluated as Record<string, unknown>[]) {
+				expect(keysOf(outcome)).toEqual([...ruleOutcome.keys].sort());
+			}
+		}
+		return decision;
+	};
+
+	describe(`wire contract conformance — ${adapter.name}`, () => {
+		describe("every refusal is the deny envelope, and nothing else", () => {
+			for (const wireCase of REQUEST_CASES) {
+				it(`${wireCase.id} → ${wireCase.expect.status} ${wireCase.expect.code} (${wireCase.pins})`, async () => {
+					const res = await adapter.send(wireCase);
+
+					expect(res.status).toBe(wireCase.expect.status);
+					// The whole point of the envelope: a client that parses only
+					// decision JSON is never handed Express's HTML error page.
+					expect(res.contentType).toMatch(/^application\/json/);
+
+					const body = res.body as Record<string, unknown>;
+					expect(keysOf(body)).toEqual([...error.keys].sort());
+					expect(body.decision).toBe(error.decision);
+					expect(body.code).toBe(wireCase.expect.code);
+					expect(typeof body.message).toBe("string");
+					expect(body.message).not.toBe("");
+
+					for (const mention of wireCase.messageMentions ?? []) {
+						expect(body.message).toContain(mention);
+					}
+					for (const secret of wireCase.mustNotEcho ?? []) {
+						expect(res.text).not.toContain(secret);
+					}
+					if (wireCase.matchesDocumentedExample) {
+						expect(body).toEqual(JSON.parse(error.documentedExample));
+					}
+				});
+			}
+		});
+
+		describe("a decision", () => {
+			it("answers 200 and the allow envelope for a request the policy allows", async () => {
+				const res = await post("/verify", adapter.fixtures.allowed);
+
+				expect(res.status).toBe(status.allow);
+				const body = expectDecisionEnvelope(res.body);
+				expect(body.decision).toBe("allow");
+				expect(body.resource).toBe(adapter.fixtures.allowed.resource);
+				expect(body.action).toBe(adapter.fixtures.allowed.action);
+			});
+
+			it("answers 403 and the deny envelope for a request the policy denies", async () => {
+				// 403 rather than 200-with-a-deny: the status is the answer, so an
+				// enforcement layer that only ever reads it still fails closed.
+				const res = await post("/verify", adapter.fixtures.denied);
+
+				expect(res.status).toBe(status.deny);
+				const body = expectDecisionEnvelope(res.body);
+				expect(body.decision).toBe("deny");
+				expect(body.resource).toBe(adapter.fixtures.denied.resource);
+				expect(body.action).toBe(adapter.fixtures.denied.action);
+			});
+
+			it("names the token's subject, and never one the body could have carried", async () => {
+				const res = await post("/verify", adapter.fixtures.allowed);
+				expect((res.body as Record<string, unknown>).subject).toBe(adapter.fixtures.subject);
+			});
+
+			it("omits subject entirely when the token carries no sub (#158)", async () => {
+				// Omitted, not `null` and not `""`: a subject that does not exist must
+				// not be reported as one every subject-less token shares.
+				const res = await post("/verify", adapter.fixtures.allowed, "validWithoutSubject");
+
+				expect([status.allow, status.deny]).toContain(res.status);
+				expect(Object.keys(res.body as Record<string, unknown>)).not.toContain("subject");
+				expectDecisionEnvelope(res.body);
+			});
+
+			it("takes its deny code from the first failing group's first rule", async () => {
+				const res = await post("/verify", adapter.fixtures.denied);
+				const body = res.body as Record<string, unknown>;
+				const groups = (body.reason as { groups: { passed: boolean; evaluated: unknown[] }[] })
+					.groups;
+				const firstFailing = groups.find((group) => !group.passed);
+
+				expect(firstFailing).toBeDefined();
+				const representative = firstFailing?.evaluated[0] as Record<string, unknown>;
+				expect(body.code).toBe(representative.code);
+				expect(body.message).toBe(representative.message);
+			});
+
+			it("names what decided each passing group, and nothing on a failing one (#135)", async () => {
+				const request = adapter.fixtures.partiallySatisfied ?? adapter.fixtures.denied;
+				const res = await post("/verify", request);
+				const groups = (
+					res.body as {
+						reason: {
+							groups: {
+								passed: boolean;
+								evaluated: Record<string, unknown>[];
+								satisfiedBy?: Record<string, unknown>;
+							}[];
+						};
+					}
+				).reason.groups;
+
+				expect(groups.length).toBeGreaterThan(0);
+				for (const group of groups) {
+					expect(group.evaluated.length).toBeGreaterThan(0);
+					if (group.passed) {
+						expect(group.satisfiedBy).toEqual(group.evaluated.at(-1));
+						expect(group.satisfiedBy?.passed).toBe(true);
+					} else {
+						expect(group.satisfiedBy).toBeUndefined();
+						expect(group.evaluated.every((outcome) => outcome.passed === false)).toBe(true);
+					}
+				}
+			});
+		});
+
+		describe("a batch", () => {
+			it("answers 200 with one decision per entry, in request order", async () => {
+				const requests = [
+					adapter.fixtures.allowed,
+					adapter.fixtures.denied,
+					adapter.fixtures.allowed,
+				];
+				const res = await post("/verify/batch", batchOf(requests));
+
+				expect(res.status).toBe(status.batchDecided);
+				const body = res.body as { decisions: Record<string, unknown>[] };
+				expect(keysOf(body)).toEqual([...batch.keys].sort());
+				expect(body.decisions).toHaveLength(requests.length);
+				expect(body.decisions.map((d) => [d.resource, d.action])).toEqual(
+					requests.map((r) => [r.resource, r.action]),
+				);
+				// Each entry is the same envelope a single decision answers with —
+				// which is what makes the batch a round-trip optimization rather than
+				// a second response format to implement against.
+				for (const entry of body.decisions) expectDecisionEnvelope(entry);
+			});
+
+			it("answers 200 even when every entry denies — the status reports that it decided", async () => {
+				const res = await post(
+					"/verify/batch",
+					batchOf([adapter.fixtures.denied, adapter.fixtures.denied]),
+				);
+
+				expect(res.status).toBe(status.batchDecided);
+				const body = res.body as { decisions: Record<string, unknown>[] };
+				expect(body.decisions.map((entry) => entry.decision)).toEqual(["deny", "deny"]);
+			});
+
+			it.runIf(adapter.fixtures.stalling)(
+				"refuses a batch on one bad entry before deciding any of the others",
+				async () => {
+					// The observable form of "validated whole, then decided": the first
+					// entry would take the collector budget and answer 403
+					// collector_timeout, so a 400 naming index 1 is only possible if no
+					// entry was decided at all.
+					const stalling = adapter.fixtures.stalling;
+					if (!stalling) return;
+					const res = await post(
+						"/verify/batch",
+						batchOf([stalling, { resource: "  ", action: "read" }]),
+					);
+
+					expect(res.status).toBe(status.invalidRequest);
+					const body = res.body as Record<string, unknown>;
+					expect(body.code).toBe(codes.invalidRequest);
+					expect(body.message).toContain("decisions[1]");
+				},
+			);
+		});
+
+		describe("a collector fan-out that runs out of time (#115)", () => {
+			it.runIf(adapter.fixtures.stalling)("denies with 403 and an empty reason", async () => {
+				const stalling = adapter.fixtures.stalling;
+				if (!stalling) return;
+				const res = await post("/verify", stalling);
+
+				// A deny and specifically not a 5xx: what the verifier can stand
+				// behind is "not established", and the safe rendering of that is a
+				// refusal an enforcement layer will not retry or fall back around.
+				expect(res.status).toBe(status.deny);
+				const body = expectDecisionEnvelope(res.body);
+				expect(body.decision).toBe("deny");
+				expect(body.code).toBe(codes.collectorTimeout);
+				// No group ran, and the reason says so rather than inventing one.
+				expect(body.reason).toEqual({ groups: [] });
+				// The message reaches the caller, so it names no collector and no bound.
+				expect(body.message).not.toMatch(/collector|ms\b/i);
+			});
+
+			it.runIf(adapter.fixtures.stalling)(
+				"denies only the entry that stalled, and decides the rest",
+				async () => {
+					const stalling = adapter.fixtures.stalling;
+					if (!stalling) return;
+					const res = await post(
+						"/verify/batch",
+						batchOf([adapter.fixtures.allowed, stalling, adapter.fixtures.allowed]),
+					);
+
+					expect(res.status).toBe(status.batchDecided);
+					const body = res.body as { decisions: Record<string, unknown>[] };
+					expect(body.decisions.map((entry) => entry.decision)).toEqual(["allow", "deny", "allow"]);
+					expect(body.decisions[1].code).toBe(codes.collectorTimeout);
+				},
+			);
+		});
+	});
+}

--- a/tests/integration/src/wire-contract-conformance.test.mts
+++ b/tests/integration/src/wire-contract-conformance.test.mts
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * The reference deployment the wire contract is checked against: this
+ * repository's own `createVerifyRouter`, over real HTTP.
+ *
+ * Everything the suite needs that is deployment-specific is here — the key
+ * material, the policy that makes one request an allow and another a deny, and
+ * the collector that can be made to stall. The contract itself is in
+ * `conformance/fixtures/wireContract/*.json`, which is what another repository
+ * implementing `VerifierEndpoint` reads.
+ */
+
+import {
+	DotNotationResourceParser,
+	PayloadScopeCollector,
+	RequestContextAttributeCollector,
+	ResourceActionScopeRuleCollector,
+} from "@o3co/auth.policy-verifier.builtins";
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorContext,
+	Rule,
+	RuleCollector,
+} from "@o3co/auth.policy-verifier.core";
+import { AttributePipeline, RulePipeline } from "@o3co/auth.policy-verifier.core";
+import { createVerifyRouter } from "@o3co/auth.policy-verifier.server";
+import express from "express";
+import { SignJWT } from "jose";
+import type { Test } from "supertest";
+import request from "supertest";
+import {
+	describeWireContractConformance,
+	type WireContractAdapter,
+	type WireCredential,
+	type WireExchange,
+	type WirePayload,
+	type WireResponse,
+} from "./conformance/wireContract.mjs";
+
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "https://api.test";
+const SUBJECT = "user-1";
+const secret = new TextEncoder().encode("wire-contract-conformance-secret");
+
+/** The action the stalling collector below never answers for. */
+const STALLING_ACTION = "stall";
+
+/**
+ * Small enough that a case can exceed them cheaply, and stated here rather than
+ * defaulted so the 413 and the batch-cap cases do not depend on this package's
+ * default ever staying what it is. The contract is that a limit exists and how
+ * it answers, not what number a deployment chose.
+ */
+const MAX_BODY_BYTES = 4096;
+const MAX_BATCH_SIZE = 8;
+
+/**
+ * Answers instantly for every action but one, and never for that one — so a
+ * single deployment serves both the ordinary cases and the `collector_timeout`
+ * deny (#115) without a second app.
+ */
+const stallableCollector: AttributeCollector = {
+	collect: (collectorContext: CollectorContext) =>
+		collectorContext.action === STALLING_ACTION
+			? new Promise<Attributes>(() => {})
+			: Promise.resolve(new Map<string, unknown>()),
+};
+
+/**
+ * A second rule group, driven by a request-context attribute, so a deny can
+ * carry a passing group beside a failing one — which is what the `satisfiedBy`
+ * case (#135) needs to see in one response.
+ */
+const tenantRuleCollector: RuleCollector = {
+	async collect() {
+		const rule: Rule = {
+			ruleType: "tenant",
+			code: "wrong_tenant",
+			message: "Request is not for the acme tenant",
+			verify: (attrs: Attributes) => attrs.get("tenantId") === "acme",
+		};
+		return [rule];
+	},
+};
+
+const app = express();
+app.use(
+	createVerifyRouter({
+		jwt: {
+			validate: true,
+			key: secret,
+			algorithms: ["HS256"],
+			issuer: ISSUER,
+			audience: AUDIENCE,
+			tokenType: "at+jwt",
+		},
+		resourceParser: new DotNotationResourceParser(),
+		attributePipeline: new AttributePipeline(
+			[
+				new PayloadScopeCollector(),
+				new RequestContextAttributeCollector({
+					attributes: [{ from: "tenant_id", to: "tenantId" }],
+				}),
+				stallableCollector,
+			],
+			// Bounds low enough that the stall is answered well inside vitest's own
+			// timeout, and high enough that the in-memory collectors beside it are
+			// never the thing that trips them.
+			{ collectorTimeoutMs: 50, deadlineMs: 150 },
+		),
+		rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector(), tenantRuleCollector]),
+		maxBodyBytes: MAX_BODY_BYTES,
+		maxBatchSize: MAX_BATCH_SIZE,
+	}),
+);
+
+/** A token this deployment verifies, with or without a `sub` claim. */
+async function mintToken(subject: string | undefined): Promise<string> {
+	const jwt = new SignJWT({ scope: "read:project" })
+		.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+		.setIssuedAt()
+		// Required since #110; the time claims are not what this suite is about,
+		// so the token simply carries valid ones.
+		.setExpirationTime("1h")
+		.setIssuer(ISSUER)
+		.setAudience(AUDIENCE);
+	return (subject === undefined ? jwt : jwt.setSubject(subject)).sign(secret);
+}
+
+/** The `Authorization` header each credential kind puts on the wire. */
+async function authorization(credential: WireCredential): Promise<string | undefined> {
+	switch (credential) {
+		case "valid":
+			return `Bearer ${await mintToken(SUBJECT)}`;
+		case "validWithoutSubject":
+			return `Bearer ${await mintToken(undefined)}`;
+		case "unverifiable":
+			return "Bearer not.a.token";
+		case "unsupportedScheme":
+			return "Basic dXNlcjpwYXNzd29yZA==";
+		case "none":
+			return undefined;
+	}
+}
+
+const allowed = { resource: "project:1", action: "read", context: { tenant_id: "acme" } };
+
+/** The body text each payload kind puts on the wire, already serialized. */
+function serialize(payload: WirePayload): string {
+	switch (payload.kind) {
+		case "json":
+			return JSON.stringify(payload.value);
+		case "text":
+			return payload.text;
+		case "overBodyLimit":
+			// One character past the limit is enough, and the padding rides in
+			// `context` so the body is otherwise a request this policy would decide.
+			return JSON.stringify({ ...allowed, context: { blob: "x".repeat(MAX_BODY_BYTES) } });
+		case "overBatchSize":
+			return JSON.stringify({
+				decisions: Array.from({ length: MAX_BATCH_SIZE + 1 }, () => allowed),
+			});
+	}
+}
+
+const adapter: WireContractAdapter = {
+	name: "@o3co/auth.policy-verifier.server createVerifyRouter over HTTP",
+
+	async send(exchange: WireExchange): Promise<WireResponse> {
+		let pending: Test = request(app).post(exchange.endpoint);
+		const header = await authorization(exchange.credential);
+		if (header !== undefined) pending = pending.set("Authorization", header);
+
+		// Always explicit: superagent's default for a string body is
+		// form-urlencoded, and a case that means to send JSON must not depend on
+		// which overload of `send` it happened to reach.
+		const res = await pending
+			.set("Content-Type", exchange.contentType ?? "application/json")
+			.send(serialize(exchange.payload));
+
+		return {
+			status: res.status,
+			contentType: res.headers["content-type"] as string | undefined,
+			body: res.body,
+			text: res.text,
+		};
+	},
+
+	fixtures: {
+		subject: SUBJECT,
+		allowed,
+		// `delete:project` is a scope no token here carries, so the scope group
+		// fails while the tenant group passes.
+		denied: { resource: "project:1", action: "delete", context: { tenant_id: "acme" } },
+		// The mirror image: the scope group passes and the tenant group does not,
+		// so one response carries a `satisfiedBy` and an absence of one.
+		partiallySatisfied: { resource: "project:1", action: "read", context: { tenant_id: "other" } },
+		stalling: { resource: "project:1", action: STALLING_ACTION, context: { tenant_id: "acme" } },
+	},
+};
+
+describeWireContractConformance(adapter);


### PR DESCRIPTION
Closes #125.

The "drop-in replaceable behind `VerifierEndpoint`" claim was not something this repository could fail. The interface lives in [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors), and nothing here checked that the wire shape this service publishes is the wire shape that repository implements. An engine swap is invisible to a caller; a field rename or a status remap breaks every caller at once, silently, at runtime.

Scheduled after #118 (PR #166) on purpose, so what is pinned is the **after** column of that PR's table, and after #115 (PR #167).

## What is pinned

`describeWireContractConformance` in `tests/integration/src/conformance/wireContract.mts`, driven by `tests/integration/src/wire-contract-conformance.test.mts`. 46 cases, all passing.

**35 refusals**, each pinned to a status, a code, an exhaustive response key set, and what the message must and must not name:

| | |
| --- | --- |
| body validation | missing / empty / non-string `resource` and `action`; whitespace **refused, not trimmed** in both; unknown properties refused and **named** (`subject`, a misspelled `contxt`); `context` that is an array or `null`; a `resource` the parser refuses |
| body-parser failures | malformed JSON → `400 invalid_request`; over `maxBodyBytes` → `413 payload_too_large`; unreadable charset → `415 unsupported_media_type`; `text/plain` → `400` — all as the **deny envelope**, never Express's HTML page |
| ordering (#118) | malformed body with no token → `400`; malformed body with an unverifiable token → `400`; well-formed body with no token → `401 missing_token`; well-formed body with a bad token → `401 invalid_token`; non-Bearer scheme → `401 unsupported_scheme` |
| `/verify/batch` | envelope shape, `decisions` absent / not an array / empty, an unknown property beside `decisions`, an entry that is not an object, an entry missing `action`, an entry with an unknown property, an entry whose `resource` the parser refuses — each **naming the offending index** — and a batch past `maxBatchSize` |

**11 shape and status cases**, driven by the adapter's own policy fixtures:

- `200` + the allow envelope, `403` + the deny envelope, and the deny `code`/`message` taken from the first failing group's first rule.
- `subject` is the token's, and is **omitted entirely** — not `null`, not `""` — when the token carries no `sub` (#158).
- `reason.groups[]` carries `evaluated`, and `satisfiedBy` **only on a passing group**, equal to `evaluated.at(-1)` (#135). Checked against one response carrying a passing group and a failing group at once.
- `/verify/batch`: `200` with one decision per entry in request order, each entry the same envelope a single decision answers with; `200` even when every entry denies; and a batch refused whole on one bad entry — sent with a *stalling* entry beside the malformed one, so a `400` naming `decisions[1]` is only possible if nothing was decided first.
- A stalled collector fan-out is `403 collector_timeout` with `reason.groups: []` and a message naming no collector and no bound (#115).

Every refusal row additionally asserts `Content-Type: application/json`, `decision: "deny"`, and exactly the three envelope keys — so a `400` that grew a `reason`, or a `413` that fell back to HTML, fails here.

## The fixture layout, and why JSON

```
tests/integration/src/conformance/
  wireContract.mts                       ← the runner
  fixtures/wireContract/
    requestCases.json                    ← the 35 refusals
    responseEnvelopes.json               ← the key set of every response body
```

The issue's stated intent was fixtures the interceptor repo can consume later. That repo is a different repository and need not be TypeScript, so a table it can read is the only version of this contract that can be **shared** rather than re-typed — and re-typing it is exactly the drift #125 was filed about. The runner is code; the contract is data.

`responseEnvelopes.json` key lists are **exhaustive in both directions**: a response carrying a key the contract never promised fails as readily as one missing a key it did, because a client that starts reading an unpromised field has coupled itself to nothing.

Two payload kinds (`overBodyLimit`, `overBatchSize`) are built by the adapter rather than carried in the table: both are operator knobs, and the contract is that a limit exists and how exceeding it is answered, not what number a deployment chose. The reference deployment sets its own (4 KiB, 8 entries) rather than leaning on this package's defaults.

Files are read with `readFileSync` rather than imported as modules — they are a data table another repository consumes **by path**, and reading them as data is what keeps that true.

## Single source, not a third copy

`verifyInputValidation.test.mts` defined `DOCUMENTED_DENY_ENVELOPE` as a literal and asserted it appears verbatim in `README.md`, `README.ja.md` and `CHANGELOG.md`. It now reads that string from `responseEnvelopes.json`, so the shape has one definition and the two suites are provably describing the same object. Its header comment was updated to say what each suite owns: this one holds the limits to their configured numbers and to the two-boundary agreement (package-internal); the conformance suite holds the answers to the shape an enforcement layer implements against.

## What the pinning exposed

**Both READMEs' "How It Works" diagram still described the pre-#118 ordering.** Step 1 of the `/verify` handler was "Verify JWT", with body validation absent entirely — while the *same file's* "Request Limits" section says the body is validated first, and while #118 shipped exactly that. The diagram is the first thing a client author reads, and a reader taking it at face value would have expected `401` for a malformed unauthenticated request: the single answer that changed. Fixed in both files — body validation is step 1, the rest renumbered, and the order stated under the diagram rather than left to be inferred. Recorded under `### Fixed` in the CHANGELOG.

Two smaller observations, **not changed here** — both are behaviour, and changing either is a wire-contract decision that belongs in its own issue rather than in a PR whose job is to write the contract down:

1. **`401 unsupported_scheme` echoes the caller's scheme unbounded.** `tokenAuthenticator.mts` answers `` `Unsupported authorization scheme: ${scheme}` ``, where `scheme` is whatever precedes the first space in the header — up to Node's header limit. #118 spent real effort bounding echoed caller data (unknown property names are capped at three, truncated to 32 characters, and quoted through `JSON.stringify`); this message predates that and was not swept in. The suite pins the status and the code, deliberately not the echo.
2. **The auth codes are undocumented outside the source.** `missing_token`, `invalid_token` and `unsupported_scheme` are what an enforcement layer must switch on, and no `.md` in the repo names `unsupported_scheme` at all. They are now in `responseEnvelopes.json`, which is at least a machine-readable home for them, but the READMEs still describe 401 only as "authentication failures".

Also noted: `DEFAULT_MAX_BODY_BYTES` and the four other #118 limit defaults are not exported from `packages/server`'s index while `DEFAULT_MAX_BATCH_SIZE` is. Not a contract issue — the conformance driver sets its own limits anyway — but a consumer building a hand-made config reaches for one family and finds half of it.

## Judgment calls

- **TDD on a suite that pins existing behaviour.** Everything here is green by construction, so the honest RED was to make the suite *bite*: the three ordering rows were written with #118's **before** column first and run — exactly those three failed (`expected 400 to be 401`, and the batch row likewise) while the other 43 passed — then corrected to the after column. That is what shows the rows are load-bearing rather than tautological.
- **Shape assertions stayed in code; the table went to JSON.** Relationships (`satisfiedBy === evaluated.at(-1)`, the deny code coming from the first failing group) are logic, and encoding them as data would have produced a fixture format nobody outside this repo could read. The request→answer table is genuinely tabular, and that is the half another repository needs.
- **Per-field limit cases were left out of the table.** `maxContextEntries` / `maxContextValueLength` at the boundary are already pinned thoroughly in `verifyInputValidation.test.mts` against configured numbers, which is a package-internal concern. The wire-visible half — that exceeding a limit is a `400`, and that the outer `maxBodyBytes` envelope is a `413` — is here.
- **One deployment, not two.** The stalling collector keys on a single action, so the same app serves the ordinary cases and the `collector_timeout` deny; bounds are `collectorTimeoutMs: 50` / `deadlineMs: 150`, high enough that the in-memory collectors beside it are never what trips them. The whole suite runs in ~170 ms.
- **Batch entry-vs-single equivalence is not re-asserted.** `decisionContract.mts` already pins that a batch entry decides identically to that request alone. This suite pins the batch *envelope* and points at the other suite rather than adding a second copy.
- **CHANGELOG: yes, an entry.** Precedent is the #152 rule-purity conformance suite, which is equally tests-only and carries a full `### Added` entry. The README correction is a separate `### Fixed` entry.

## Verification

Full run on this branch, no `--coverage`:

```
pnpm lint                 Checked 149 files. No fixes applied.
pnpm -r run build         all packages Done
pnpm run typecheck        all 6 projects Done
pnpm run test             create-app 78 | core 108 | builtins 474 | server 705 | standalone 62 | integration 121
                          = 1548 passed, 0 failed
```

The CI rule-purity grep gate was also run locally against the staged tree: `OK: no verify() body reads a collector context (128 files scanned)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
