### PR TITLE
fix(builtins)!: HasPermission matches exactly and case-sensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -864,6 +864,31 @@ and version sections follow the release labeling policy in
 
 ### Changed
 
+- **BREAKING**: `HasPermission` matches exactly and case-sensitively
+  ([#155](https://github.com/o3co/auth.policy-verifier/issues/155)).
+
+  #116 made `HasScope` compare scope values exactly (RFC 6749 §3.3 makes them
+  opaque), and #117 carried the same principle into
+  `DotNotationResourceParser`: compare what was written, never a normalized
+  guess at what was meant. The permission vocabulary was never visited —
+  `HasPermission` lowercased both sides — so the exact divergence #117 closed
+  had re-entered through the permission door: the parser preserves case, making
+  `Project:1` and `project:1` two namespaces to a scope rule, while
+  `ResourceActionPermissionRuleCollector` builds `{raw}.perm:{action}` from
+  those same resources and `HasPermission` collapsed them into one.
+
+  Wildcards in a **granted** permission are kept, deliberately: a `*` is match
+  structure the policy author wrote into the grant, not a rewrite of both sides
+  behind their back. The literal halves around it now also compare exactly and
+  case-sensitively, and multiple wildcards still never match.
+
+  **Migration:** a deployment relying on case-mixed permission grants (a role
+  granting `Posts.*` against permissions built from a `posts:…` resource) now
+  sees denials where it saw grants. The change only ever narrows — nothing
+  that was denied before is granted now. Align the case of granted permissions
+  with what the resource parser actually emits; `ATTR_PERMISSIONS` /
+  `Role.permissions` values are compared verbatim.
+
 - **BREAKING**: `VerifierPayload.tokenType` is renamed to `authScheme`
   ([#158](https://github.com/o3co/auth.policy-verifier/issues/158)).
 

--- a/packages/builtins/README.md
+++ b/packages/builtins/README.md
@@ -50,11 +50,13 @@ new HasPermission(permission: string)
 
 - `ruleType`: `"permission"`, `code`: `"no_permission"`
 - Checks `ATTR_PERMISSIONS` (direct) and `ATTR_ROLES[].permissions` (via roles).
-- Wildcard matching (case-insensitive):
+- Matching is **exact and case-sensitive** — the same discipline `HasScope` applies to scopes and `DotNotationResourceParser` applies to resources: compare what was written, never a normalized guess at what was meant. The parser preserves case, so `Project:1.perm:read` and `project:1.perm:read` are different permissions, exactly as `Project:1` and `project:1` are different resources to a scope rule.
+- Wildcards in a **granted** permission are honoured — written match structure, not normalization; the literal halves around the `*` still compare exactly:
   - `"*"` matches any permission.
   - `"foo*"` matches any permission with prefix `foo`.
   - `"*bar"` matches any permission with suffix `bar`.
   - `"foo*bar"` matches any permission starting with `foo` and ending with `bar`.
+  - More than one `*` in a granted permission never matches (rejecting beats silently over-granting).
 
 ### HasScope
 

--- a/packages/builtins/src/__tests__/rules/HasPermission.test.mts
+++ b/packages/builtins/src/__tests__/rules/HasPermission.test.mts
@@ -36,10 +36,29 @@ describe("HasPermission", () => {
 		expect(rule.verify(attrs)).toBe(true);
 	});
 
-	it("is case insensitive", () => {
+	// #155: matching is exact and case-sensitive, the discipline #116 (HasScope)
+	// and #117 (DotNotationResourceParser) argued for every identifier
+	// vocabulary. The parser preserves case, so `Project:1` and `project:1` are
+	// two resources — a permission rule collapsing them was the exact
+	// "one resource on one side, two on the other" split #117 closed.
+	it("does not match across case: required Project:1 vs granted project:1", () => {
 		const rule = new HasPermission("Project:1.Perm:Read");
 		const attrs: Attributes = new Map([["permissions", ["project:1.perm:read"]]]);
-		expect(rule.verify(attrs)).toBe(true);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("does not match across case in the other direction either", () => {
+		const rule = new HasPermission("project:1.perm:read");
+		const attrs: Attributes = new Map([["permissions", ["Project:1.perm:READ"]]]);
+		expect(rule.verify(attrs)).toBe(false);
+	});
+
+	it("compares the literal halves around a wildcard case-sensitively", () => {
+		const rule = new HasPermission("project:1.perm:read");
+		// The wildcard is written structure and still honoured; the cased
+		// prefix is not the prefix the requirement carries.
+		const attrs: Attributes = new Map([["permissions", ["Project:*"]]]);
+		expect(rule.verify(attrs)).toBe(false);
 	});
 
 	it("checks permissions from roles", () => {

--- a/packages/builtins/src/rules/HasPermission.mts
+++ b/packages/builtins/src/rules/HasPermission.mts
@@ -9,10 +9,27 @@ import { ATTR_PERMISSIONS, ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
  * directly via `ATTR_PERMISSIONS` or transitively through a role in
  * `ATTR_ROLES`.
  *
- * Matching is case-insensitive. A granted permission of `"*"` wildcards
- * everything. A granted permission may contain a single `*` used as prefix,
- * suffix, or middle separator (e.g. `"posts.*"`, `"*.read"`, `"posts.*.read"`);
- * multiple wildcards are explicitly rejected because the two-part split would
+ * ## Matching
+ *
+ * Comparison is **exact and case-sensitive**, the same philosophy `HasScope`
+ * applies to scope values and `DotNotationResourceParser` applies to resource
+ * identifiers (#116, #117): compare what was written, never a normalized guess
+ * at what was meant. This rule matched case-insensitively until #155, which
+ * put permissions on the wrong side of the line those two argued —
+ * `ResourceActionPermissionRuleCollector` builds `{resource.raw}.perm:{action}`
+ * from the case-preserving parser, so `Project:1` and `project:1` were two
+ * namespaces to a scope rule and one to a permission rule. One vocabulary, one
+ * matching discipline.
+ *
+ * ## Wildcards
+ *
+ * A granted permission of `"*"` matches everything, and a granted permission
+ * may contain a single `*` as prefix, suffix, or middle separator (e.g.
+ * `"posts.*"`, `"*.read"`, `"posts.*.read"`). This is not an exception to the
+ * no-normalization rule: a wildcard is match structure the policy author
+ * **wrote into the grant**, not a rewrite of both sides behind their back. The
+ * literal halves around the `*` still compare exactly and case-sensitively.
+ * Multiple wildcards are rejected outright because the two-part split would
  * silently drop segments and over-grant.
  */
 export class HasPermission implements Rule {
@@ -35,9 +52,6 @@ export class HasPermission implements Rule {
 	}
 
 	private match(permission: string, required: string): boolean {
-		permission = permission.toLowerCase();
-		required = required.toLowerCase();
-
 		if (permission === "*") return true;
 		if (permission === required) return true;
 


### PR DESCRIPTION
## Summary

**#155** asked for a decision between two defensible positions; this takes **align with `HasScope`** — exact, case-sensitive matching — because the case-insensitivity was not a designed RBAC feature but an unvisited leftover, and it contradicted the layer directly beneath it: `ResourceActionPermissionRuleCollector` builds `{resource.raw}.perm:{action}` from the **case-preserving** parser, so `Project:1` and `project:1` were two namespaces to a scope rule and one to a permission rule — precisely the "one resource on one side, two on the other" split #117's argument closed.

- `HasPermission.match` drops the double `toLowerCase()`; the doc comment now argues the philosophy the way `HasScope`'s and the parser's do, and names #155.
- **Wildcards stay, deliberately**: a `*` in a *granted* permission is match structure the policy author wrote into the grant — declared, greppable, single — not a silent rewrite of both sides. The literal halves around it now also compare exactly. Multiple wildcards still never match.
- `packages/builtins/README.md` documents the discipline; CHANGELOG carries the BREAKING entry with the migration note.

**Direction of the change**: strictly narrowing. Nothing that was denied before is granted now; a deployment relying on case-mixed grants sees loud denials, not silent over-grants. The umbrella repo's E2E fixtures use no permissions at all, so no cross-repo test needs to move first.

## Test plan

- The "is case insensitive" test is replaced by three: no cross-case match in either direction, and case-sensitive comparison of the literal halves around a wildcard.
- Full workspace build + test + lint green.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)