### PR TITLE
fix(core,create-app): pick up #126 quick items 3 and 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -864,6 +864,13 @@ and version sections follow the release labeling policy in
 
 ### Changed
 
+- A scaffolded project keeps `"private": true`
+  ([#126](https://github.com/o3co/auth.policy-verifier/issues/126) item 4).
+  `create-auth-policy-verifier` used to delete the field, so the project it
+  generated — an authorization service carrying policy code and config — was
+  publishable by default, and an accidental `npm publish` succeeded. Publishing
+  a scaffolded service is the rare intent; state it by removing the field.
+
 - **BREAKING**: `HasPermission` matches exactly and case-sensitively
   ([#155](https://github.com/o3co/auth.policy-verifier/issues/155)).
 

--- a/create-app/src/__tests__/index.test.mts
+++ b/create-app/src/__tests__/index.test.mts
@@ -73,12 +73,12 @@ describe("scaffold", () => {
 		}
 	});
 
-	it("removes private field from package.json", () => {
+	it('keeps "private": true so a scaffolded service is not publishable by accident (#126 item 4)', () => {
 		const targetDir = join(tempDir, "verifier");
 		scaffold(targetDir, "verifier");
 
 		const pkg = JSON.parse(readFileSync(join(targetDir, "package.json"), "utf-8"));
-		expect(pkg.private).toBeUndefined();
+		expect(pkg.private).toBe(true);
 	});
 
 	it("writes scoped project name verbatim into package.json", () => {

--- a/create-app/src/index.mts
+++ b/create-app/src/index.mts
@@ -82,7 +82,11 @@ export const scaffold = (targetDir: string, projectName: string): void => {
 	const pkgPath = resolve(targetDir, "package.json");
 	const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
 	pkg.name = projectName;
-	delete pkg.private;
+	// `"private": true` is deliberately KEPT (#126 item 4). The scaffold is an
+	// authorization service — policy code and config — and deleting the field
+	// made an accidental `npm publish` succeed by default. Publishing a
+	// scaffolded service is the rare intent; the operator who has it states it
+	// by removing the field.
 
 	// Replace all workspace:* references with per-package published versions
 	const versions = getPackageVersions();

--- a/packages/core/src/AttributePipeline.mts
+++ b/packages/core/src/AttributePipeline.mts
@@ -43,19 +43,32 @@ export class AttributePipeline {
 
 /**
  * Merges attribute maps into a single map. Array-valued entries concatenate
- * in input order; non-array values are overwritten by later maps.
+ * in input order; non-array values are overwritten by later maps — and a
+ * non-array value also resets any accumulation, so a later array starts fresh
+ * rather than concatenating onto something that was already overwritten.
+ *
+ * Array fragments are collected per key and concatenated once at the end
+ * (#126 item 3): the previous shape re-copied the whole accumulated array for
+ * every contributing map (`[...existing, ...value]`), which is quadratic in
+ * collector count for a repeatedly-contributed key like roles or permissions.
  */
 function merge(maps: Attributes[]): Attributes {
 	const merged: Attributes = new Map();
+	const fragments = new Map<string, unknown[][]>();
 	for (const map of maps) {
 		for (const [key, value] of map) {
-			const existing = merged.get(key);
-			if (Array.isArray(existing) && Array.isArray(value)) {
-				merged.set(key, [...existing, ...value]);
+			if (Array.isArray(value)) {
+				const parts = fragments.get(key);
+				if (parts === undefined) fragments.set(key, [value]);
+				else parts.push(value);
 			} else {
+				fragments.delete(key);
 				merged.set(key, value);
 			}
 		}
+	}
+	for (const [key, parts] of fragments) {
+		merged.set(key, parts.flat());
 	}
 	return merged;
 }

--- a/packages/core/src/__tests__/AttributePipeline.test.mts
+++ b/packages/core/src/__tests__/AttributePipeline.test.mts
@@ -53,6 +53,27 @@ describe("AttributePipeline", () => {
 		expect(result.get("userId")).toBe("2");
 	});
 
+	// #126 item 3 pinned the merge to one concatenation per key; these two pin
+	// the mixed-type semantics the old per-map shape had, so the rewrite could
+	// not drift them: a scalar overwrite RESETS accumulation (a later array
+	// starts fresh), and an array replaces an earlier scalar outright.
+	it("a scalar write resets array accumulation for that key", async () => {
+		const a: Attributes = new Map([["scopes", ["read:user"]]]);
+		const b: Attributes = new Map([["scopes", "corrupted"]]);
+		const c: Attributes = new Map([["scopes", ["write:user"]]]);
+		const pipeline = new AttributePipeline([makeCollector(a), makeCollector(b), makeCollector(c)]);
+		const result = await pipeline.collect(stubContext);
+		expect(result.get("scopes")).toEqual(["write:user"]);
+	});
+
+	it("a later array replaces an earlier scalar", async () => {
+		const a: Attributes = new Map([["scopes", "corrupted"]]);
+		const b: Attributes = new Map([["scopes", ["read:user"]]]);
+		const pipeline = new AttributePipeline([makeCollector(a), makeCollector(b)]);
+		const result = await pipeline.collect(stubContext);
+		expect(result.get("scopes")).toEqual(["read:user"]);
+	});
+
 	it("merges different keys from multiple collectors", async () => {
 		const a: Attributes = new Map([["userId", "1"]]);
 		const b: Attributes = new Map([["scopes", ["read:user"]]]);


### PR DESCRIPTION
## Summary

Two mechanical items from the #126 tracking list (per its "split out if picked up" note, the design-flavored items stay behind — see the status comment on #126):

- **Item 3** — `AttributePipeline.merge` collects array fragments per key and concatenates once at the end, instead of `[...existing, ...value]` per contributing map (quadratic in collector count for a repeatedly-contributed key like roles/permissions). Mixed-type semantics are unchanged and now **pinned by tests**: a scalar overwrite resets accumulation (a later array starts fresh), and a later array replaces an earlier scalar outright.
- **Item 4** — the scaffold keeps `"private": true`. `create-auth-policy-verifier` deleted the field, so the project it generates — an authorization service carrying policy code and config — was publishable by default and an accidental `npm publish` succeeded. Publishing a scaffolded service is the rare intent; the operator who has it states it by removing the field. CHANGELOG entry included.

## Test plan

- New AttributePipeline tests pin the two mixed-type edges of the merge rewrite; existing concat/overwrite/different-keys tests unchanged and green.
- create-app test flipped: `pkg.private` is now asserted `true`.
- Full workspace build + test + lint green.

Refs #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)