### PR TITLE
fix(core,server)!: a scalar attribute conflict denies the decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -864,6 +864,22 @@ and version sections follow the release labeling policy in
 
 ### Changed
 
+- **BREAKING**: two collectors writing **different** values to the same scalar
+  attribute key now deny the decision instead of silently last-writer-winning
+  ([#174](https://github.com/o3co/auth.policy-verifier/issues/174), from #126
+  item 2). A collector-ordering mistake used to weaken authorization with no
+  signal anywhere; an attribute map whose content depends on collector order is
+  not something to authorize from. The merge throws the new
+  `AttributeConflictError` (exported from core; message names the KEY only —
+  values are claims and may be sensitive), and `/verify` answers it exactly as
+  it answers a #115 timeout: `403` with `decision: "deny"`, `code:
+  "attribute_conflict"`, an empty `reason`, and the detail on the operator's
+  log line. Identical re-writes (same primitive value, or the same object
+  reference) are not conflicts, so trivially-redundant collectors keep working;
+  array-valued keys are unaffected and still concatenate. **Migration** for a
+  deployment that relied on deliberate override chains: give the key one owning
+  collector, or namespace the keys.
+
 - A scaffolded project keeps `"private": true`
   ([#126](https://github.com/o3co/auth.policy-verifier/issues/126) item 4).
   `create-auth-policy-verifier` used to delete the field, so the project it

--- a/packages/core/src/AttributePipeline.mts
+++ b/packages/core/src/AttributePipeline.mts
@@ -7,6 +7,7 @@ import {
 	resolveCollectorLimits,
 	runCollectors,
 } from "./collectorLimits.mjs";
+import { AttributeConflictError } from "./errors.mjs";
 import type { AttributeCollector, Attributes, CollectorRequest } from "./types.mjs";
 
 /**
@@ -43,9 +44,18 @@ export class AttributePipeline {
 
 /**
  * Merges attribute maps into a single map. Array-valued entries concatenate
- * in input order; non-array values are overwritten by later maps — and a
- * non-array value also resets any accumulation, so a later array starts fresh
- * rather than concatenating onto something that was already overwritten.
+ * in input order. A non-array value may be written once — or re-written with
+ * the **identical** value (same primitive, or same object reference); two
+ * maps writing *different* values to the same scalar key throw
+ * {@link AttributeConflictError}, which the transport answers as a deny
+ * (#174). Last-writer-wins let a collector-ordering mistake silently weaken
+ * decisions (#126 item 2); an ambiguous attribute map is not something to
+ * authorize from.
+ *
+ * A scalar write still resets any array accumulation for its key, and a later
+ * array still replaces an earlier scalar — the mixed-type semantics are
+ * unchanged (and pinned by tests); only the scalar-vs-scalar disagreement is
+ * a conflict.
  *
  * Array fragments are collected per key and concatenated once at the end
  * (#126 item 3): the previous shape re-copied the whole accumulated array for
@@ -62,6 +72,11 @@ function merge(maps: Attributes[]): Attributes {
 				if (parts === undefined) fragments.set(key, [value]);
 				else parts.push(value);
 			} else {
+				// `Object.is`, not `===`: a NaN re-written as NaN is the same
+				// value, not a disagreement.
+				if (merged.has(key) && !Object.is(merged.get(key), value)) {
+					throw new AttributeConflictError(key);
+				}
 				fragments.delete(key);
 				merged.set(key, value);
 			}

--- a/packages/core/src/__tests__/AttributePipeline.test.mts
+++ b/packages/core/src/__tests__/AttributePipeline.test.mts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import { AttributePipeline } from "../AttributePipeline.mjs";
+import { AttributeConflictError } from "../errors.mjs";
 import type {
 	AttributeCollector,
 	Attributes,
@@ -45,12 +46,47 @@ describe("AttributePipeline", () => {
 		expect(result.get("scopes")).toEqual(["read:user", "write:user"]);
 	});
 
-	it("overwrites non-array values (last wins)", async () => {
+	// #174: two collectors disagreeing on a scalar key is an integration bug,
+	// and last-writer-wins let it weaken decisions silently (#126 item 2). The
+	// merge now refuses the map; the transport answers the refusal as a deny.
+	it("rejects two collectors writing DIFFERENT values to the same scalar key", async () => {
 		const a: Attributes = new Map([["userId", "1"]]);
 		const b: Attributes = new Map([["userId", "2"]]);
 		const pipeline = new AttributePipeline([makeCollector(a), makeCollector(b)]);
+		await expect(pipeline.collect(stubContext)).rejects.toThrow(AttributeConflictError);
+	});
+
+	it("names the conflicting KEY in the error, never the values", async () => {
+		const a: Attributes = new Map([["department", "sales-secret"]]);
+		const b: Attributes = new Map([["department", "eng-secret"]]);
+		const pipeline = new AttributePipeline([makeCollector(a), makeCollector(b)]);
+		const error = await pipeline.collect(stubContext).then(
+			() => {
+				throw new Error("unreachable: collect resolved");
+			},
+			(e: unknown) => e as Error,
+		);
+		expect(error.message).toContain("department");
+		// Attribute values are claims and may be sensitive; the message travels
+		// into logs, so neither value may appear.
+		expect(error.message).not.toContain("sales-secret");
+		expect(error.message).not.toContain("eng-secret");
+	});
+
+	it("allows an identical scalar re-write — same value is not a disagreement", async () => {
+		const a: Attributes = new Map([["userId", "1"]]);
+		const b: Attributes = new Map([["userId", "1"]]);
+		const pipeline = new AttributePipeline([makeCollector(a), makeCollector(b)]);
 		const result = await pipeline.collect(stubContext);
-		expect(result.get("userId")).toBe("2");
+		expect(result.get("userId")).toBe("1");
+	});
+
+	it("still rejects a scalar disagreement even with an array write between them", async () => {
+		const a: Attributes = new Map([["userId", "1"]]);
+		const b: Attributes = new Map([["userId", ["array-interlude"]]]);
+		const c: Attributes = new Map([["userId", "2"]]);
+		const pipeline = new AttributePipeline([makeCollector(a), makeCollector(b), makeCollector(c)]);
+		await expect(pipeline.collect(stubContext)).rejects.toThrow(AttributeConflictError);
 	});
 
 	// #126 item 3 pinned the merge to one concatenation per key; these two pin

--- a/packages/core/src/errors.mts
+++ b/packages/core/src/errors.mts
@@ -91,3 +91,31 @@ export class CollectorTimeoutError extends Error {
 		this.collector = detail.limit === "collector" ? detail.collector : undefined;
 	}
 }
+
+/**
+ * Raised when two attribute maps write **different** values to the same
+ * scalar (non-array) key (#174). An identical re-write — same primitive
+ * value, or the same object reference — is not a conflict.
+ *
+ * **This is a deny, not a degradation** — the same stance as
+ * {@link CollectorTimeoutError}: an attribute map whose content depends on
+ * collector ordering is not something to authorize from, and the previous
+ * last-writer-wins silently weakened decisions when collectors disagreed
+ * (#126 item 2). Array-valued keys are unaffected; they concatenate.
+ *
+ * The message names the KEY only, never the values: attribute values are
+ * claims and may be sensitive, and this message travels into logs.
+ */
+export class AttributeConflictError extends Error {
+	readonly key: string;
+
+	constructor(key: string) {
+		super(
+			`two collectors wrote different values to the scalar attribute ${JSON.stringify(key)}; ` +
+				"a map whose content depends on collector order is refused. Give the key one " +
+				"owning collector, or namespace it (identical re-writes are allowed)",
+		);
+		this.name = "AttributeConflictError";
+		this.key = key;
+	}
+}

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -14,7 +14,7 @@ export {
 	resolveCollectorLimits,
 } from "./collectorLimits.mjs";
 export type { CollectorTimeoutDetail, CollectorTimeoutLimit } from "./errors.mjs";
-export { CollectorTimeoutError, ResourceParseError } from "./errors.mjs";
+export { AttributeConflictError, CollectorTimeoutError, ResourceParseError } from "./errors.mjs";
 export type { EvaluateOptions } from "./evaluate.mjs";
 export { evaluate } from "./evaluate.mjs";
 export {

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -1252,6 +1252,56 @@ describe("createVerifyRouter — maxBatchSize, one reader at both boundaries (#1
 	});
 });
 
+describe("createVerifyRouter — collectors disagreeing on a scalar attribute deny (#174)", () => {
+	const writesDepartment = (value: string): AttributeCollector => ({
+		collect: async () =>
+			new Map<string, unknown>([
+				["department", value],
+				["scopes", ["read:project"]],
+			]),
+	});
+
+	const conflictedApp = () => {
+		const app = express();
+		app.use(
+			createVerifyRouter({
+				jwt: {
+					validate: true,
+					key: hs256Key.key,
+					algorithms: hs256Key.algorithms,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				},
+				resourceParser: new DotNotationResourceParser(),
+				attributePipeline: new AttributePipeline([
+					writesDepartment("sales"),
+					writesDepartment("eng"),
+				]),
+				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+			}),
+		);
+		return app;
+	};
+
+	it("answers 403 with an attribute_conflict deny", async () => {
+		const token = await signHS256Token({ scope: "read:project" });
+		const res = await request(conflictedApp())
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(res.status).toBe(403);
+		expect(res.body.decision).toBe("deny");
+		expect(res.body.code).toBe("attribute_conflict");
+		// No rule group was evaluated, and the reason says so.
+		expect(res.body.reason).toEqual({ groups: [] });
+		// The caller's message names neither the key nor the values — those
+		// reach the operator's log line only.
+		expect(res.body.message).not.toMatch(/department|sales|eng/);
+	});
+});
+
 describe("createVerifyRouter — a collector that runs out of time denies (#115)", () => {
 	/** Stalls only for the action named, so one batch can mix stalled and decided entries. */
 	const stallingOn = (action: string): AttributeCollector => ({

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+	AttributeConflictError,
 	type AttributePipeline,
 	CollectorTimeoutError,
 	consoleLogger,
@@ -157,6 +158,8 @@ const errorBody = (code: string, message: string): ErrorBody => ({
  */
 const COLLECTOR_TIMEOUT_CODE = "collector_timeout";
 const COLLECTOR_TIMEOUT_MESSAGE = "Authorization could not be decided in time";
+const ATTRIBUTE_CONFLICT_CODE = "attribute_conflict";
+const ATTRIBUTE_CONFLICT_MESSAGE = "Authorization inputs conflicted";
 
 /** One validated entry: the request as sent, plus its resource already parsed. */
 interface ValidatedDecisionRequest {
@@ -498,21 +501,31 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 			]);
 			decision = evaluate(attrs, rules, config.evaluateOptions);
 		} catch (cause) {
-			// Anything else is a genuine fault and keeps surfacing as a 500.
-			if (!(cause instanceof CollectorTimeoutError)) throw cause;
+			// Two collect failures are denies of their own (#115 timeouts, #174
+			// attribute conflicts); anything else is a genuine fault and keeps
+			// surfacing as a 500.
+			const denial =
+				cause instanceof CollectorTimeoutError
+					? { code: COLLECTOR_TIMEOUT_CODE, message: COLLECTOR_TIMEOUT_MESSAGE }
+					: cause instanceof AttributeConflictError
+						? { code: ATTRIBUTE_CONFLICT_CODE, message: ATTRIBUTE_CONFLICT_MESSAGE }
+						: null;
+			if (denial === null) throw cause;
 			// The evaluator is deliberately never reached: it is the one place a
 			// short rule list could still be read as a policy, and `onEmptyRuleSet:
-			// "allow"` would then turn a timed-out rule pipeline into a permit. A
-			// deny is built here instead, with an empty `reason` because no rule
-			// group was evaluated — which is the honest account of what happened.
+			// "allow"` would then turn a timed-out (or conflicted) pipeline into a
+			// permit. A deny is built here instead, with an empty `reason` because
+			// no rule group was evaluated — which is the honest account of what
+			// happened. The conflicted attribute KEY reaches the log line via the
+			// error's message; the caller's message names neither key nor values.
 			logger.error(
 				{ err: cause, resource: entry.resource, action: entry.action, requestId },
-				COLLECTOR_TIMEOUT_CODE,
+				denial.code,
 			);
 			decision = {
 				decision: "deny",
-				code: COLLECTOR_TIMEOUT_CODE,
-				message: COLLECTOR_TIMEOUT_MESSAGE,
+				code: denial.code,
+				message: denial.message,
 				reason: { groups: [] },
 			};
 		}


### PR DESCRIPTION
## Summary

Implements the **owner decision on #174 (option A)**: two collectors writing **different** values to the same scalar attribute key throw the new `AttributeConflictError` → the collect fails → `/verify` answers a **deny**, through the same seam #115's timeouts use (`403`, `code: "attribute_conflict"`, empty `reason`, operator detail on the log line only).

- **Identical re-writes are not conflicts** (`Object.is`, so a NaN re-write is the same value); trivially-redundant collectors keep working.
- **The error names the KEY, never the values** — attribute values are claims, and the message travels into logs. Pinned by a test with sentinel values asserted absent.
- Array keys unaffected (concatenate); mixed-type semantics unchanged and still pinned by the #173 tests — a scalar disagreement is caught even with an array write between the two scalars (tested).
- BREAKING: CHANGELOG carries the migration (one owning collector per key, or namespace keys).

## Test plan

- Core: conflict rejects / key-not-values message / identical re-write passes / array-interlude still rejects.
- Server: `conflictedApp` integration — 403 `attribute_conflict` deny with empty reason and a caller message naming neither key nor values.
- Full workspace build + test + lint green.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)