### PR TITLE
fix(core,server)!: collectors get claims, not the credential — exposure is a stated config decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -864,6 +864,23 @@ and version sections follow the release labeling policy in
 
 ### Changed
 
+- **BREAKING**: collectors no longer receive the raw credential unless the
+  deployment states it —
+  `VerifierPayload.token` is removed
+  ([#175](https://github.com/o3co/auth.policy-verifier/issues/175), from #126
+  item 1). Every collector received the raw, replayable bearer token via
+  `CollectorContext.payload`; a collector that logged its context leaked a live
+  credential. Collectors now get verified claims only. The one legitimate use —
+  a project-side collector calling a downstream API *as the subject* (token
+  forwarding/exchange) — opts in with `verify.credentialToCollectors =
+  "expose"` (`VERIFY_CREDENTIAL_TO_COLLECTORS`; an enum, not a boolean, so the
+  string an env substitution delivers needs no coercion path), which surfaces
+  the credential as **`CollectorContext.credential`** — a stated, greppable
+  config decision. **Migration:** a collector reading `payload.token` sets the
+  config key and reads `context.credential` instead. The authenticator's
+  `AuthenticationResult` now carries `credential` beside `payload`; the route,
+  not the authenticator, owns the exposure decision.
+
 - **BREAKING**: two collectors writing **different** values to the same scalar
   attribute key now deny the decision instead of silently last-writer-winning
   ([#174](https://github.com/o3co/auth.policy-verifier/issues/174), from #126

--- a/packages/core/src/types.mts
+++ b/packages/core/src/types.mts
@@ -45,6 +45,17 @@ export interface CollectorContext {
 	/** Caller-supplied; read it with `readUntrustedRequestContext`. */
 	requestContext?: UntrustedRequestContext;
 	/**
+	 * The raw, replayable credential the request arrived under — present ONLY
+	 * when the composition opted in (`verify.credentialToCollectors =
+	 * "expose"`, #175). Absent by default: collectors get verified claims, not
+	 * the credential, because a collector that logs its context would otherwise
+	 * leak a live token. The one legitimate use is a project-side collector
+	 * calling a downstream API *as the subject* (token forwarding/exchange);
+	 * that deployment states the exposure in config, where it is greppable.
+	 * NEVER log this field.
+	 */
+	credential?: string;
+	/**
 	 * Cancellation for this collect, and the one field that is not a fact about
 	 * the request (#115).
 	 *
@@ -205,7 +216,6 @@ export interface VerifierPayload {
 	aud?: string | string[];
 	exp?: number;
 	iat?: number;
-	token?: string;
 	/**
 	 * The `Authorization` scheme the token arrived under, as the caller wrote it
 	 * — `"Bearer"` (RFC 6750), whose casing is not normalized because it is

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -1213,6 +1213,7 @@ describe("AppConfigSchema — the verify block's default names every knob", () =
 			collectorTimeoutMs: DEFAULT_COLLECTOR_TIMEOUT_MS,
 			collectorDeadlineMs: DEFAULT_COLLECT_DEADLINE_MS,
 			collectorConcurrency: DEFAULT_COLLECTOR_CONCURRENCY,
+			credentialToCollectors: "never",
 		});
 	});
 
@@ -1222,6 +1223,11 @@ describe("AppConfigSchema — the verify block's default names every knob", () =
 		// here as a missing key rather than as a present `undefined`. (Iterating
 		// the absent-block production instead would skip it silently, which is
 		// the shape of the bug and not a check for it.)
+		//
+		// `toBeDefined`, not `toBeTypeOf("number")`: the guard's job is catching
+		// a knob the literal omits, and since #175 the block carries a
+		// non-numeric knob (`credentialToCollectors`). The value-level agreement
+		// is the equality test above.
 		const fromShape = parseWith({}).verify as Record<string, unknown>;
 		const fromDefault = parseWith(undefined).verify as Record<string, unknown>;
 
@@ -1229,7 +1235,7 @@ describe("AppConfigSchema — the verify block's default names every knob", () =
 			expect(
 				fromDefault[key],
 				`verify.${key} is missing from the block's .default() literal`,
-			).toBeTypeOf("number");
+			).toBeDefined();
 		}
 	});
 });

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -1252,6 +1252,68 @@ describe("createVerifyRouter — maxBatchSize, one reader at both boundaries (#1
 	});
 });
 
+describe("createVerifyRouter — the credential reaches collectors only by stated opt-in (#175)", () => {
+	const seen: Array<{ credential: string | undefined; payloadToken: unknown }> = [];
+	const capturing = (): AttributeCollector => ({
+		collect: async (context: CollectorContext) => {
+			seen.push({
+				credential: context.credential,
+				payloadToken: (context.payload as Record<string, unknown>).token,
+			});
+			return new Map<string, unknown>([["scopes", ["read:project"]]]);
+		},
+	});
+
+	const appWith = (credentialToCollectors?: "never" | "expose") => {
+		const app = express();
+		app.use(
+			createVerifyRouter({
+				jwt: {
+					validate: true,
+					key: hs256Key.key,
+					algorithms: hs256Key.algorithms,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				},
+				resourceParser: new DotNotationResourceParser(),
+				attributePipeline: new AttributePipeline([capturing()]),
+				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+				...(credentialToCollectors ? { credentialToCollectors } : {}),
+			}),
+		);
+		return app;
+	};
+
+	it("default: the collector sees neither context.credential nor a payload token", async () => {
+		seen.length = 0;
+		const token = await signHS256Token({ scope: "read:project" });
+		await request(appWith())
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.credential).toBeUndefined();
+		// #175 removed VerifierPayload.token — the claims object carries no
+		// replayable credential for a context-logging collector to leak.
+		expect(seen[0]?.payloadToken).toBeUndefined();
+	});
+
+	it('"expose": context.credential is the raw bearer token, and the payload still carries none', async () => {
+		seen.length = 0;
+		const token = await signHS256Token({ scope: "read:project" });
+		await request(appWith("expose"))
+			.post("/verify")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ resource: "project:1", action: "read" });
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.credential).toBe(token);
+		expect(seen[0]?.payloadToken).toBeUndefined();
+	});
+});
+
 describe("createVerifyRouter — collectors disagreeing on a scalar attribute deny (#174)", () => {
 	const writesDepartment = (value: string): AttributeCollector => ({
 		collect: async () =>

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -295,6 +295,7 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 			maxActionLength: config.verify.maxActionLength,
 			maxContextEntries: config.verify.maxContextEntries,
 			maxContextValueLength: config.verify.maxContextValueLength,
+			credentialToCollectors: config.verify.credentialToCollectors,
 		}),
 	);
 

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -453,6 +453,17 @@ export const AppConfigSchema = z.object({
 			collectorTimeoutMs: boundedNumber(NUMERIC_BOUNDS.collectorTimeoutMs, "verify"),
 			collectorDeadlineMs: boundedNumber(NUMERIC_BOUNDS.collectorDeadlineMs, "verify"),
 			collectorConcurrency: boundedNumber(NUMERIC_BOUNDS.collectorConcurrency, "verify"),
+			/**
+			 * Whether collectors receive the raw credential as
+			 * `CollectorContext.credential` (#175). `"never"` (default): verified
+			 * claims only — the credential is replayable and a collector that
+			 * logs its context would leak a live token. `"expose"`: for a
+			 * project-side collector that calls a downstream API as the subject
+			 * (token forwarding/exchange); the exposure is a stated, greppable
+			 * config decision. An enum, not a boolean: `${?ENV}` hands this
+			 * schema a string, and an enum takes it without a coercion path.
+			 */
+			credentialToCollectors: z.enum(["never", "expose"]).default("never"),
 		})
 		/*
 		 * Taken verbatim, like `http` above — zod does not parse a default back
@@ -482,6 +493,7 @@ export const AppConfigSchema = z.object({
 			collectorTimeoutMs: DEFAULT_COLLECTOR_TIMEOUT_MS,
 			collectorDeadlineMs: DEFAULT_COLLECT_DEADLINE_MS,
 			collectorConcurrency: DEFAULT_COLLECTOR_CONCURRENCY,
+			credentialToCollectors: "never" as const,
 		})),
 	// Defaulted (not shape-only): deployments mount an overlay config OVER the
 	// template's application.conf, so a section the overlay does not repeat is

--- a/packages/server/src/jwt/tokenAuthenticator.mts
+++ b/packages/server/src/jwt/tokenAuthenticator.mts
@@ -409,7 +409,7 @@ export function assertTimeClaims(payload: JWTPayload, bounds: JwtTimeClaimBounds
  * module's.
  */
 export type AuthenticationResult =
-	| { ok: true; payload: VerifierPayload }
+	| { ok: true; payload: VerifierPayload; credential: string }
 	| { ok: false; code: "missing_token" | "unsupported_scheme" | "invalid_token"; message: string };
 
 /** Authenticates one `Authorization` header value into a verified payload. */
@@ -508,7 +508,13 @@ export function createTokenAuthenticator(
 			// `authScheme`, not `tokenType` (#158): `jwt.tokenType` a few lines up
 			// is the accepted `typ` header, an entirely different thing, and the
 			// two shared a name in the one module that mentions both.
-			return { ok: true, payload: { ...decoded, token, authScheme: scheme } };
+			//
+			// #175: the raw credential rides the RESULT, not the payload. The
+			// payload reaches every collector; the credential reaches a collector
+			// only when the route was composed with `credentialToCollectors:
+			// "expose"` — that gate is the route's, so this module hands the
+			// credential back separately and attaches nothing to the claims.
+			return { ok: true, payload: { ...decoded, authScheme: scheme }, credential: token };
 		},
 	};
 }

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -87,6 +87,20 @@ export interface VerifyRouterConfig {
 	 * logged but not counted; `createApp` wires the Prometheus implementation.
 	 */
 	metrics?: DecisionMetrics;
+	/**
+	 * Whether the raw credential reaches collectors as
+	 * `CollectorContext.credential` (#175). Defaults to `"never"`: collectors
+	 * get verified claims only, because the credential is replayable and a
+	 * collector that logs its context would leak a live token. `"expose"` is
+	 * for the deployment whose project-side collector calls a downstream API
+	 * *as the subject* (token forwarding/exchange) — a decision that belongs
+	 * in config, where it is greppable, not in ambient behavior.
+	 *
+	 * An enum rather than a boolean on purpose: `${?ENV}` substitution hands
+	 * schemas strings, and a string survives an enum unharmed where a bare
+	 * boolean invites the coercion-path drift o3co/auth.provider#288 documents.
+	 */
+	credentialToCollectors?: "never" | "expose";
 }
 
 /**
@@ -466,13 +480,16 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	// Constructing the authenticator runs assertVerifyRouterJwtConfig, so an
 	// invalid hand-built jwt config still fails here, at router construction.
 	const authenticator = createTokenAuthenticator(config.jwt, logger);
+	// #175: resolved once — the per-request cost is a spread, not a branch tree.
+	const exposeCredential = config.credentialToCollectors === "expose";
 
 	/** Runs the pipelines and the evaluator for one already-validated entry. */
 	async function decide(
 		req: express.Request,
-		payload: VerifierPayload,
+		auth: { payload: VerifierPayload; credential: string },
 		{ request: entry, resource }: ValidatedDecisionRequest,
 	): Promise<DecisionResponse> {
+		const payload = auth.payload;
 		const requestId = req.get("x-request-id");
 		const headers = requestId ? { "x-request-id": requestId } : undefined;
 		// `payload` survived signature verification and `headers` were read off the
@@ -486,6 +503,10 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 			action: entry.action,
 			headers,
 			requestContext: entry.context ? markUntrustedRequestContext(entry.context) : undefined,
+			// #175: absent unless the composition said "expose" — see the
+			// config field's doc. Spread-conditional so the default context
+			// carries no `credential` key at all, not an undefined one.
+			...(exposeCredential ? { credential: auth.credential } : {}),
 		};
 
 		// Timed from here so the measurement is the decision itself — the two
@@ -586,7 +607,7 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				return;
 			}
 
-			const decision = await decide(req, auth.payload, parsed.entry);
+			const decision = await decide(req, auth, parsed.entry);
 			res.status(decision.decision === "deny" ? 403 : 200).json(decision);
 		} catch (cause) {
 			logger.error({ err: cause, endpoint: "/verify" }, "verify_internal_error");
@@ -656,7 +677,7 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				return;
 			}
 
-			const decisions = await Promise.all(entries.map((entry) => decide(req, auth.payload, entry)));
+			const decisions = await Promise.all(entries.map((entry) => decide(req, auth, entry)));
 			res.status(200).json({ decisions });
 		} catch (cause) {
 			logger.error({ err: cause, endpoint: "/verify/batch" }, "verify_internal_error");

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -47,6 +47,7 @@ Individual values can also be overridden with environment variables.
 | `OAUTH_JWT_MODE` | `verify` | `verify` fully verifies tokens; the explicit `insecure-decode` (test-only) decodes without signature verification — `exp`/`nbf` are still enforced |
 | `RULE_ON_EMPTY_RULE_SET` | `deny` | Decision when no rule is collected (`deny` \| `allow`) |
 | `VERIFY_MAX_BATCH_SIZE` | `50` | Cap on `POST /verify/batch` entries |
+| `VERIFY_CREDENTIAL_TO_COLLECTORS` | `never` | `expose` hands collectors the raw credential as `context.credential` — only for a collector that calls a downstream API as the subject. The default keeps collectors on verified claims; the credential is replayable and a logged context would leak it |
 | `LOG_LEVEL` | `info` | Minimum level emitted: `trace`\|`debug`\|`info`\|`warn`\|`error`\|`fatal`\|`silent`. Also the switch for the decision log — see [Observability](#observability) |
 
 ## HS256 secret strength

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -319,4 +319,13 @@ verify {
   # just started to slow down.
   collectorConcurrency = 8
   collectorConcurrency = ${?VERIFY_COLLECTOR_CONCURRENCY}
+
+  # Whether collectors receive the raw credential as `context.credential`
+  # (#175). "never" (the default): collectors get verified claims only — the
+  # credential is replayable, and a collector that logs its context would leak
+  # a live token. Set "expose" ONLY when a project-side collector calls a
+  # downstream API as the subject (token forwarding / exchange); this line is
+  # then the greppable record of that decision. Never log the field.
+  credentialToCollectors = "never"
+  credentialToCollectors = ${?VERIFY_CREDENTIAL_TO_COLLECTORS}
 }

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -381,7 +381,7 @@ rule { collectors = [ { collector = ResourceActionScopeRuleCollector } ] }
 
 		const config = loadAppConfig(withoutVerify(), "development");
 
-		// All nine, spelled out. A knob that reached the shape but not the
+		// All ten, spelled out. A knob that reached the shape but not the
 		// block's `.default()` literal is `undefined` here, and `toEqual` says
 		// which one.
 		expect(config.verify).toEqual({
@@ -394,6 +394,7 @@ rule { collectors = [ { collector = ResourceActionScopeRuleCollector } ] }
 			collectorTimeoutMs: 2_000,
 			collectorDeadlineMs: 5_000,
 			collectorConcurrency: 8,
+			credentialToCollectors: "never",
 		});
 	});
 


### PR DESCRIPTION
## Summary

Implements the **owner decision on #175 (option A)**, from #126 item 1.

- **`VerifierPayload.token` is removed** — every collector received the raw, replayable bearer token, and a collector that logged its context leaked a live credential. Collectors now get verified claims only.
- The one legitimate use (a project-side collector calling a downstream API *as the subject* — token forwarding/exchange) **opts in**: `verify.credentialToCollectors = "expose"` / `VERIFY_CREDENTIAL_TO_COLLECTORS`, surfacing the credential as **`CollectorContext.credential`** with a NEVER-log doc. An **enum, not a boolean**, deliberately: `${?ENV}` hands the schema a string, and an enum takes it without the coercion-path drift o3co/auth.provider#288 documents.
- The authenticator hands `credential` back **beside** the payload (`AuthenticationResult`), so the route — the composition surface — owns the exposure decision; nothing rides the claims object.
- Config plumbing all the way out: schema (+ its every-knob `.default()` literal), `createApp` forwarding, template `application.conf` + README env table. The every-knob guard test generalizes from "is a number" to "is present" now that the block carries its first non-numeric knob (its value-level agreement stays pinned by the equality test).
- BREAKING: CHANGELOG carries the migration (set the key, read `context.credential`).

## Test plan

- New: default → collector sees neither `context.credential` nor any payload token; `"expose"` → `context.credential` is the raw bearer and the payload still carries none.
- Updated: schema every-knob guard (both halves), template documented-defaults test.
- Full workspace build + test + lint green.

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)