### PR TITLE
docs(server): define the oauth namespace in this module's vocabulary; link the stack claims contract

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -61,7 +61,7 @@ POST /verify/batch — 同じ契約で、1 往復に N 件の decision
 
 - **Collector パターン** — 属性とルールはコンポーザブルな Collector で収集。静的なポリシーファイルではない。任意の属性ソース（DB, 外部 API, JWT クレーム）向けにカスタム Collector を追加可能。
 - **boolean ではなく decision 契約** — リクエストは `(subject, resource, action, context)`、応答は各ルールグループとその結果を並べた構造化 `reason` を必ず伴う。「なぜ deny されたか」をパイプラインの再実行なしに答えられる。`POST /verify/batch` は複数リソースを 1 往復で判定する。
-- **JWT 検証アルゴリズム設定可能** — HS256（共有シークレット）、RS256/ES256/EdDSA（JWKS URI または公開鍵直接指定）。[auth.provider](https://github.com/o3co/auth.provider) の JWT 設定と対称設計。
+- **JWT 検証アルゴリズム設定可能** — HS256（共有シークレット）、RS256/ES256/EdDSA（JWKS URI または公開鍵直接指定）。設定は `oauth.jwt` 配下にあり、[auth.provider](https://github.com/o3co/auth.provider) と意図的に対称 — この namespace が verifier 上で何を意味するかは[設定](#設定)を参照。
 - **RFC 9068 §4 のトークン検証** — 署名だけでなく `iss` / `aud` / `typ` ヘッダも検証する。同じ鍵で署名された `id_token` / refresh token / logout token や、他サービス向けに発行されたトークンは拒否される。`mode = "verify"`（デフォルト）のとき `issuer` と `audience` は必須。
 - **トークン寿命の上限** — `exp` と `iat` は「あれば検証する」ではなく**必須**。さらに `maxTokenAgeSeconds` が、発行者がどれだけ先の `exp` を付けたかに関わらず「発行からどれだけ経ったトークンまで受け入れるか」の上限を課す。`exp` を持たずに発行（あるいは偽造）されたトークンは、永久に有効ではなく拒否される。`clockToleranceSeconds`（デフォルト 0、上限 300）はクロックずれの許容幅。これらはすべて `insecure-decode` モードでも同じく適用されるので、2 つのモードが同一トークンについて食い違うことはない。
 - **JWKS サポート** — `jwksUri` を auth.provider の `https://.../.well-known/jwks.json` に向ければ鍵ローテーションに自動対応。エンドポイントは TLS 必須（ローカル開発向けにループバックのみ例外）。取得はタイムアウト / クールダウン / キャッシュ期間で必ず上限が付き、プロバイダー障害が判定パスを止めない。
@@ -196,6 +196,8 @@ RuleCollector だけではポリシーになりません。ルールグループ
 | `RequestContextAttributeCollector` | リクエスト `context` の宣言済みフィールド | 運用者が決めたキー |
 
 ## 設定
+
+`oauth` namespace（env prefix `OAUTH_JWT_*`）は本モジュールの credential 層 — rule が走る前に verifier が subject を認証する方法 — である。verifier は OAuth flow を実装しない。この名前は所有の主張ではなくマッピングであり、キーは [auth.provider](https://github.com/o3co/auth.provider) の `oauth { jwt { … } }` と意図的に対称にしてある。1 つのデプロイが token 境界の両側を 1 つの語彙で扱えるようにするためだ。境界の claim レベルの半面は umbrella の [claims-contract](https://github.com/o3co/auth/blob/develop/docs/claims-contract.ja.md) に規定されており、ここにあるキーは鍵配布の半面である。
 
 HOCON 設定 + 環境変数オーバーライド:
 
@@ -362,6 +364,8 @@ scope ルールが使う認可の名前空間なので、不正な入力を推�
 発行された grant を呼び出し側に与えてしまいます。
 
 ## auth.provider との接続
+
+auth.provider が書き、この verifier が読む claim と、それぞれの側での意味 — claim レベルの契約 — は umbrella の [docs/claims-contract.ja.md](https://github.com/o3co/auth/blob/develop/docs/claims-contract.ja.md) に規定されている。本節はその鍵配布の半面を扱う。
 
 auth.provider が非対称 JWT 署名 (RS256/ES256/EdDSA) を使う場合、policy-verifier の `jwksUri` をプロバイダーの JWKS エンドポイントに向ける:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ so the enforcement layer can implement against the same table.
 
 - **Collector pattern** — Attributes and rules are gathered by composable collectors, not a static policy file. Add custom collectors for any attribute source (database, external API, JWT claims).
 - **A decision contract, not a boolean** — every request is `(subject, resource, action, context)` and every answer carries a structured `reason` naming each rule group and how it came out, so "why was this denied" is answerable without re-running the pipeline. `POST /verify/batch` decides many resources in one round trip.
-- **Configurable JWT verification** — HS256 (shared secret), RS256/ES256/EdDSA (JWKS URI or direct public key). Symmetric design with [auth.provider](https://github.com/o3co/auth.provider)'s JWT config.
+- **Configurable JWT verification** — HS256 (shared secret), RS256/ES256/EdDSA (JWKS URI or direct public key). Config lives under `oauth.jwt`, deliberately symmetric with [auth.provider](https://github.com/o3co/auth.provider)'s — see [Configuration](#configuration) for what the namespace means on a verifier.
 - **RFC 9068 §4 token validation** — `iss`, `aud` and the `typ` header are checked alongside the signature, so an `id_token`, refresh token or logout token signed with the same key, or a token minted for another service, is rejected. `issuer` and `audience` are required whenever `mode = "verify"` (the default).
 - **Bounded token lifetime** — `exp` and `iat` are **required**, not merely honoured when present, and `maxTokenAgeSeconds` caps how long after issuance a token is accepted whatever `exp` its issuer chose. A token minted or forged without an expiry is refused rather than accepted forever. `clockToleranceSeconds` (0 by default, capped at 300) is the skew allowance. Every one of these applies in `insecure-decode` mode too, so the two modes never disagree about the same token.
 - **JWKS support** — Point `jwksUri` at auth.provider's `https://.../.well-known/jwks.json` for automatic key rotation. The endpoint must be TLS-protected (loopback hosts excepted for local development), and the fetch is bounded by an operator-set timeout, cooldown and cache age so a provider outage cannot stall the decision path.
@@ -199,6 +199,8 @@ collector writing `permissions` / `roles` in the same edit.
 | `RequestContextAttributeCollector` | declared fields of the request `context` | the operator's own keys |
 
 ## Configuration
+
+The `oauth` namespace (env prefix `OAUTH_JWT_*`) is this module's credential layer: how the verifier authenticates the subject before any rule runs. The verifier implements no OAuth flow — the name is a mapping, not a claim of ownership: the keys are deliberately symmetric with [auth.provider](https://github.com/o3co/auth.provider)'s `oauth { jwt { … } }`, so one deployment addresses both sides of the token boundary with one vocabulary. The claim-level half of that boundary is specified in the umbrella's [claims-contract](https://github.com/o3co/auth/blob/develop/docs/claims-contract.md); the keys here are the key-distribution half.
 
 HOCON config with environment variable overrides:
 
@@ -368,6 +370,8 @@ a second `:` in a segment (`a:1:2` is not truncated to `a:1`), and surrounding o
 parser that guessed at malformed input could hand a caller a grant written for a different resource.
 
 ## Connecting to auth.provider
+
+The claim-level contract — which claims auth.provider writes and this verifier reads, and what each side means by them — is specified in the umbrella's [docs/claims-contract.md](https://github.com/o3co/auth/blob/develop/docs/claims-contract.md). This section covers the key-distribution half.
 
 When auth.provider uses asymmetric JWT signing (RS256/ES256/EdDSA), point the policy-verifier's `jwksUri` at the provider's JWKS endpoint:
 

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -147,6 +147,16 @@ export const AppConfigSchema = z.object({
 		// The default object is taken verbatim — zod does not parse it back through
 		// the shape — so it has to state every key that has no other source.
 		.default(() => ({ hostname: DEFAULT_HOSTNAME, port: DEFAULT_HTTP_PORT, pathPrefix: "" })),
+	/**
+	 * The credential layer: how this verifier authenticates the subject before
+	 * any rule runs. This module implements no OAuth flow, so the namespace
+	 * name is a mapping, not a claim of ownership — the keys live under
+	 * `oauth.jwt` (env: `OAUTH_JWT_*`) deliberately symmetric with
+	 * auth.provider's `oauth { jwt { … } }`, so one deployment addresses both
+	 * sides of the token boundary with one vocabulary. The claim-level half of
+	 * that boundary is specified in the umbrella's docs/claims-contract.md
+	 * (o3co/auth); the keys below are the key-distribution half.
+	 */
 	oauth: z.object({
 		// Algorithm names are free-form strings so user-registered algorithms can be selected
 		// from config without editing the schema enum. Built-in algorithms keep schema-level


### PR DESCRIPTION
Closes #171 (parent: o3co/auth#11). Item 1 of the issue (`VerifierPayload.token`) was superseded by #177, which removed the field outright — see the [status comment](https://github.com/o3co/auth.policy-verifier/issues/171#issuecomment-5455503292). This PR is the remainder: item 2 plus the pointer o3co/auth#13 planned for this repo.

## What

- **JSDoc on the schema's `oauth` key** (application.schema.mts): the namespace is the credential layer — how this verifier authenticates the subject before any rule runs. On a module that implements no OAuth flow the name is a mapping, not a claim of ownership: deliberately symmetric with auth.provider's `oauth { jwt { … } }` so one deployment addresses both sides of the token boundary with one vocabulary.
- **README Configuration section**: the same definition in prose, replacing the drive-by 'Symmetric design with auth.provider's JWT config' in the Features bullet (which now points at Configuration).
- **README 'Connecting to auth.provider'**: lead-in line linking the umbrella's [docs/claims-contract.md](https://github.com/o3co/auth/blob/develop/docs/claims-contract.md) for the claim-level half; that section keeps the key-distribution half.
- ja mirrors updated in lockstep.

## Verification

Doc-only: one comment block in the schema (no code path touched), README/README.ja prose. The README-verbatim tests pin the deny envelope and the `verify { … }` defaults block — neither section is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)