### PR TITLE
feat(cedar): co-resident Cedar policy evaluation as an optional plugin package (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       # never run in CI at all.
       - run: pnpm run test
 
-      # Re-runs the three published packages under instrumentation to produce
+      # Re-runs the published packages under instrumentation to produce
       # the reports uploaded below.
       - run: pnpm run test:coverage
 
@@ -151,6 +151,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/builtins/coverage/coverage-final.json
           flags: builtins
+          disable_search: true
+          fail_ci_if_error: false
+
+      - name: Upload coverage to Codecov (cedar)
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/cedar/coverage/coverage-final.json
+          flags: cedar
           disable_search: true
           fail_ci_if_error: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and version sections follow the release labeling policy in
 [`docs/release-policy.md`](docs/release-policy.md).
 
+## [Unreleased]
+
+### Added
+
+- **`@o3co/auth.policy-verifier.cedar`** — co-resident [Cedar](https://www.cedarpolicy.com/)
+  policy evaluation as an optional plugin package
+  ([#185](https://github.com/o3co/auth.policy-verifier/issues/185),
+  [#186](https://github.com/o3co/auth.policy-verifier/issues/186)).
+
+  `CedarPolicyRuleCollector` compiles a `.cedar` policy set at boot (official
+  `@cedar-policy/cedar-wasm`, evaluated in-process) and surfaces the whole
+  set's verdict as one rule in one group, ANDed with the TypeScript groups —
+  Cedar's forbid-overrides-permit semantics hold inside the group, core's
+  default-deny composition across groups. Entities are synthesized per request
+  from the attribute map (attributes, group membership via parents, entity
+  references), so Cedar's language works against collector-gathered facts with
+  no entity store to build or sync. `RequestFactsCollector` promotes
+  `action` / `resourceType` / `resourceId` into attributes for the rule to
+  decide over.
+
+  Evaluation errors always deny and log, regardless of the
+  `onNoDeterminingPolicy` knob: Cedar reports a policy that reads a missing
+  attribute only in its diagnostics, and an erroring `forbid` stops
+  forbidding — the errors check runs before the decision is trusted, so a
+  typo'd attribute mapping fails closed instead of open.
+
+  Core, builtins and the server are unchanged; nothing loads unless the
+  module is imported.
+
 ## [0.5.0] - 2026-09-03
 
 ### Security

--- a/packages/cedar/LICENSE
+++ b/packages/cedar/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 1o1 Co. Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cedar/README.md
+++ b/packages/cedar/README.md
@@ -1,0 +1,97 @@
+# @o3co/auth.policy-verifier.cedar
+
+Co-resident [Cedar](https://www.cedarpolicy.com/) policy evaluation for
+[auth.policy-verifier](https://github.com/o3co/auth.policy-verifier), as an
+optional plugin package.
+
+The whole Cedar policy set is evaluated in-process (official
+`@cedar-policy/cedar-wasm`, ~15µs per decision, no network) and enters the
+engine's AND-evaluation as **one rule in one group**. TypeScript rule groups
+keep working beside it: TS collectors gather the facts, Cedar policies write
+judgment over them — **no entity store to build or sync**.
+
+This decouples policy language from PDP topology. Native logic stays
+TypeScript — no DSL is ever required — and a deployment that adopts Cedar here
+is not binding itself to this verifier: the same `.cedar` files load unchanged
+into an embedded evaluator or a Cedar agent later. Design: [#185](https://github.com/o3co/auth.policy-verifier/issues/185).
+
+## Usage
+
+```ts
+import { builtinCollectorsModule } from "@o3co/auth.policy-verifier.builtins";
+import { cedarPolicyModule } from "@o3co/auth.policy-verifier.cedar";
+import { builtinKeyResolversModule, createApp } from "@o3co/auth.policy-verifier.server";
+
+const app = await createApp({
+	pathResolver: import.meta.resolve,
+	config,
+	modules: [builtinCollectorsModule, builtinKeyResolversModule, cedarPolicyModule],
+});
+```
+
+```hocon
+attribute {
+  collectors = [
+    { collector = "PayloadSubjectIdCollector" }
+    # Promotes action / resourceType / resourceId into attributes — the rule
+    # pipeline never sees the request, so the Cedar request is built from these.
+    { collector = "RequestFactsCollector" }
+  ]
+}
+rule {
+  collectors = [
+    { collector = "CedarPolicyRuleCollector"
+      # *.cedar files, sorted and concatenated — byte-identical to what a
+      # Cedar agent would load. XOR an inline `policies = "..."` string.
+      policyDir = "config/policies"
+
+      # "abstain" (default): no determining policy leaves the decision to the
+      # other rule groups — the migration posture. Flip to "deny" when the
+      # policy set is authoritative.
+      onNoDeterminingPolicy = "abstain"
+
+      principal {
+        # type = "User"          # default
+        # idAttribute = "userId" # default (ATTR_USER_ID)
+        attributes { dept = "department" }   # principal.dept == "eng"
+        parents { Group = "groups" }         # principal in Group::"admins"
+      }
+      resource {
+        attributes {
+          # entity-reference form: resource.owner == principal
+          owner = { attribute = "resourceOwner", entityType = "User" }
+        }
+      }
+      context { mfa = "mfaVerified" }        # context.mfa
+    }
+  ]
+}
+```
+
+Request-context fields reach Cedar the same way everything else does — as
+attributes. Promote them with the builtins' `RequestContextAttributeCollector`
+(the declared-allowlist trust boundary, #123) and map them here; nothing
+undeclared can reach a policy.
+
+## Semantics
+
+- **Layered PDP.** Cedar's own semantics (forbid overrides permit) hold inside
+  the group; the group ANDs with every TypeScript group. During migration both
+  are active and compose only toward strictness.
+- **Evaluation errors always deny, and log.** Cedar reports a policy that
+  reads a missing attribute as `deny` with the cause only in diagnostics — and
+  an erroring `forbid` stops forbidding, so the top-level decision can read
+  `allow` exactly when it is least trustworthy. The rule checks
+  `diagnostics.errors` first: any error is a deny regardless of
+  `onNoDeterminingPolicy`, and is logged unless `logEvaluationErrors = false`.
+- **Entity synthesis is one hop.** Principal and resource entities are
+  synthesized per request from the attribute map — attributes, group
+  membership, entity references. Multi-hop dereference and hierarchy walks
+  need an entity store; needing them is the signal to move to a full Cedar
+  deployment, which the same `.cedar` files already fit.
+
+## Version pinning
+
+`@cedar-policy/cedar-wasm` is pinned exactly: Cedar minor releases can carry
+policy-language changes, so upgrades should be deliberate and re-validated,
+not fall out of a range resolution.

--- a/packages/cedar/package.json
+++ b/packages/cedar/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "@o3co/auth.policy-verifier.cedar",
+	"version": "0.0.0",
+	"license": "Apache-2.0",
+	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"main": "./dist/index.mjs",
+	"types": "./dist/index.d.mts",
+	"exports": {
+		".": {
+			"import": "./dist/index.mjs",
+			"types": "./dist/index.d.mts"
+		}
+	},
+	"files": [
+		"dist",
+		"LICENSE",
+		"README.md"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/o3co/auth.policy-verifier.git",
+		"directory": "packages/cedar"
+	},
+	"scripts": {
+		"prebuild": "rimraf dist",
+		"build": "tsc",
+		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"@cedar-policy/cedar-wasm": "4.12.0",
+		"@o3co/auth.policy-verifier.core": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^26.2.0",
+		"@vitest/coverage-v8": "^4.1.10",
+		"vitest": "^4.1.10"
+	}
+}

--- a/packages/cedar/src/CedarPolicyRuleCollector.mts
+++ b/packages/cedar/src/CedarPolicyRuleCollector.mts
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { preparsePolicySet, statefulIsAuthorized } from "@cedar-policy/cedar-wasm/nodejs";
+import type {
+	CollectorContext,
+	Logger,
+	Rule,
+	RuleCollector,
+} from "@o3co/auth.policy-verifier.core";
+import { createConsoleLogger } from "@o3co/auth.policy-verifier.core";
+import {
+	buildCedarRequest,
+	type CedarRequest,
+	type ResolvedMapping,
+	resolveMapping,
+} from "./mapping.mjs";
+import { loadPolicySource } from "./policySource.mjs";
+
+/** What the rule answers when no policy determined the request (see below). */
+export type NoDeterminingPolicy = "abstain" | "deny";
+
+const NO_DETERMINING_POLICIES: readonly NoDeterminingPolicy[] = ["abstain", "deny"];
+
+/** Config entry accepted by `CedarPolicyRuleCollector`. */
+export interface CedarPolicyRuleCollectorConfig {
+	/** Directory of `*.cedar` files (sorted, concatenated). XOR `policies`. */
+	policyDir?: string;
+	/** Inline Cedar policy text. XOR `policyDir`. */
+	policies?: string;
+	/** Rule group the Cedar decision joins AND-evaluation as. Default `"cedar"`. */
+	ruleType?: string;
+	/**
+	 * What the rule answers when Cedar reports no determining policy — no
+	 * `permit` matched and no `forbid` matched.
+	 *
+	 * `"abstain"` (default) passes the group, leaving the decision to the other
+	 * rule groups: the migration posture, where the policy set covers part of
+	 * the surface and the TypeScript rules still hold the rest. `"deny"` makes
+	 * the policy set authoritative — Cedar's own implicit-deny — for the moment
+	 * it covers everything.
+	 */
+	onNoDeterminingPolicy?: NoDeterminingPolicy;
+	/**
+	 * Whether the rule logs Cedar evaluation errors (default `true`).
+	 *
+	 * The error branch is load-bearing: Cedar answers a policy that reads a
+	 * missing attribute with `decision: "deny"` and the cause only in
+	 * `diagnostics.errors` — without this log, a typo'd attribute mapping is
+	 * indistinguishable from a policy deny. The healthy path never logs.
+	 */
+	logEvaluationErrors?: boolean;
+	/** Entity/context mapping — see `resolveMapping` for the shape. */
+	principal?: unknown;
+	action?: unknown;
+	resource?: unknown;
+	context?: unknown;
+}
+
+/** Constructor options beyond the config entry (programmatic composition only). */
+export interface CedarPolicyRuleCollectorOptions {
+	/** Receives evaluation-error logs. Defaults to the console-backed logger. */
+	logger?: Logger;
+}
+
+/** Distinguishes concurrently-constructed collectors' preparsed sets. */
+let policySetCounter = 0;
+
+/**
+ * Evaluates a Cedar policy set, co-resident, as one core `Rule`.
+ *
+ * ## Why one rule, not a translation
+ *
+ * Core's evaluator is OR within a group and AND across groups, with no global
+ * override; Cedar's forbid-overrides-permit is inexpressible in that algebra.
+ * So the policy set is never translated into core rules — the real Cedar
+ * evaluator runs, and its whole verdict enters AND-evaluation as a single
+ * group. Layered PDP: Cedar semantics inside the group, core semantics across
+ * groups, composing only toward strictness.
+ *
+ * ## Why evaluation happens in `verify`
+ *
+ * The attribute and rule pipelines run concurrently, so `collect` never sees
+ * the merged attributes — and the point of the design is that Cedar policies
+ * decide over what the attribute collectors gathered. `verify(attrs)` is where
+ * that map exists. Cedar evaluation is a deterministic, synchronous function
+ * of `(preparsed policy set, request)` with the request built from `attrs`
+ * alone, so the rule satisfies the purity contract exactly: the policy set id
+ * and mapping are fixed at boot, nothing of `CollectorContext` is retained,
+ * and equal attributes give equal answers. The rule object is built once, in
+ * the constructor — the hoisted form `metrics.test.mts` documents as the
+ * strongest compliance shape.
+ *
+ * The one deliberate softening: on the *error* branch the rule emits a log
+ * line (config `logEvaluationErrors`, default on). The decision itself remains
+ * a pure function of `attrs`; see the config doc for why silence there would
+ * cost more than the letter of "no side effects" buys.
+ *
+ * ## Answer interpretation
+ *
+ * | Cedar answered | with | the rule answers |
+ * | --- | --- | --- |
+ * | `allow` | no errors | pass |
+ * | `deny` | determining `forbid` | fail |
+ * | `deny` | no determining policy | `onNoDeterminingPolicy` |
+ * | anything | evaluation errors | **fail, and log** |
+ *
+ * The last row is unconditional — an evaluation error is never an abstention.
+ * Cedar treats a policy that errors as not satisfied, so a `forbid` that
+ * errors stops forbidding and the top-level decision can read `allow`; the
+ * errors check runs first precisely so that a broken input fails closed.
+ */
+export class CedarPolicyRuleCollector implements RuleCollector {
+	private readonly rule: Rule;
+
+	constructor(config: CedarPolicyRuleCollectorConfig, options?: CedarPolicyRuleCollectorOptions) {
+		const raw = (config ?? {}) as Record<string, unknown>;
+
+		const ruleType = raw.ruleType === undefined ? "cedar" : raw.ruleType;
+		if (typeof ruleType !== "string" || ruleType.length === 0) {
+			throw new Error(
+				`CedarPolicyRuleCollector: ruleType must be a non-empty string, got ${JSON.stringify(raw.ruleType)}`,
+			);
+		}
+
+		const onNoDeterminingPolicy = (raw.onNoDeterminingPolicy ?? "abstain") as NoDeterminingPolicy;
+		if (!NO_DETERMINING_POLICIES.includes(onNoDeterminingPolicy)) {
+			throw new Error(
+				`CedarPolicyRuleCollector: onNoDeterminingPolicy must be one of ${NO_DETERMINING_POLICIES.join(", ")}, got ${JSON.stringify(raw.onNoDeterminingPolicy)}`,
+			);
+		}
+
+		const rawLog = raw.logEvaluationErrors;
+		if (rawLog !== undefined && typeof rawLog !== "boolean") {
+			throw new Error(
+				`CedarPolicyRuleCollector: logEvaluationErrors must be a boolean, got ${JSON.stringify(rawLog)}`,
+			);
+		}
+		const logEvaluationErrors = rawLog ?? true;
+
+		const mapping: ResolvedMapping = resolveMapping(raw);
+		const source = loadPolicySource(raw);
+
+		// Boot-time compile. `preparsePolicySet` stores the compiled set in wasm
+		// memory under this id; the per-request call references it without
+		// re-parsing. The id is per-instance so two collectors never share a slot.
+		const policySetId = `auth.policy-verifier.cedar:${policySetCounter++}`;
+		const parsed = preparsePolicySet(policySetId, { staticPolicies: source.text });
+		if (parsed.type === "failure") {
+			const details = parsed.errors.map((error) => error.message).join("; ");
+			throw new Error(
+				`CedarPolicyRuleCollector: policy set from ${source.description} failed to compile: ${details}`,
+			);
+		}
+
+		const logger = logEvaluationErrors
+			? (options?.logger ?? createConsoleLogger({ collector: "CedarPolicyRuleCollector" }))
+			: undefined;
+
+		this.rule = buildRule({ ruleType, onNoDeterminingPolicy, policySetId, mapping, logger });
+	}
+
+	async collect(_context: CollectorContext): Promise<Rule[]> {
+		// Nothing is read from the context: everything the rule needs was fixed
+		// at boot, and everything request-shaped reaches it through `attrs`.
+		return [this.rule];
+	}
+}
+
+function buildRule(bound: {
+	ruleType: string;
+	onNoDeterminingPolicy: NoDeterminingPolicy;
+	policySetId: string;
+	mapping: ResolvedMapping;
+	logger: Logger | undefined;
+}): Rule {
+	const { ruleType, onNoDeterminingPolicy, policySetId, mapping, logger } = bound;
+	return {
+		ruleType,
+		code: "cedar_deny",
+		message: "Denied by Cedar policy",
+		verify(attrs) {
+			let request: CedarRequest;
+			try {
+				request = buildCedarRequest(mapping, attrs);
+			} catch (cause) {
+				logger?.error(
+					{ policySetId, reason: cause instanceof Error ? cause.message : String(cause) },
+					"cedar request could not be built from attributes — denying",
+				);
+				return false;
+			}
+
+			const answer = statefulIsAuthorized({ ...request, preparsedPolicySetId: policySetId });
+			if (answer.type !== "success") {
+				logger?.error(
+					{ policySetId, errors: answer.errors.map((error) => error.message) },
+					"cedar authorization call failed — denying",
+				);
+				return false;
+			}
+
+			const { decision, diagnostics } = answer.response;
+			if (diagnostics.errors.length > 0) {
+				// Checked before the decision on purpose: an erroring `forbid` stops
+				// forbidding, so `decision` can read "allow" exactly when it is least
+				// trustworthy. Never an abstention.
+				logger?.error(
+					{
+						policySetId,
+						decision,
+						errors: diagnostics.errors.map((error) => `${error.policyId}: ${error.error.message}`),
+					},
+					"cedar policy evaluation raised errors — denying",
+				);
+				return false;
+			}
+
+			if (decision === "allow") return true;
+			if (diagnostics.reason.length === 0) return onNoDeterminingPolicy === "abstain";
+			return false;
+		},
+	};
+}

--- a/packages/cedar/src/RequestFactsCollector.mts
+++ b/packages/cedar/src/RequestFactsCollector.mts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+	AttributeCollector,
+	Attributes,
+	CollectorContext,
+} from "@o3co/auth.policy-verifier.core";
+import {
+	ATTR_REQUEST_ACTION,
+	ATTR_REQUEST_RESOURCE_ID,
+	ATTR_REQUEST_RESOURCE_RAW,
+	ATTR_REQUEST_RESOURCE_TYPE,
+} from "./keys.mjs";
+
+/**
+ * Promotes the parsed request — `action` and the `Resource` fields — into
+ * attributes, so that a rule can decide over them without touching
+ * `CollectorContext`.
+ *
+ * `CedarPolicyRuleCollector` needs this: its rule builds the Cedar
+ * `(principal, action, resource, context)` request from the merged attribute
+ * map inside `verify`, and `verify` runs where the request no longer exists.
+ * Only primitives are copied — string values out of the context, never a
+ * reference into it — which is the legal side of the line the rule-purity
+ * conformance suite draws.
+ *
+ * `requestResourceId` is written only when the resource parser produced one;
+ * an absent id stays absent rather than becoming `""`, so downstream mapping
+ * can tell "no id" from "empty id".
+ */
+export class RequestFactsCollector implements AttributeCollector {
+	async collect(context: CollectorContext): Promise<Attributes> {
+		const attributes: Attributes = new Map<string, unknown>([
+			[ATTR_REQUEST_ACTION, context.action],
+			[ATTR_REQUEST_RESOURCE_TYPE, context.resource.resourceType],
+			[ATTR_REQUEST_RESOURCE_RAW, context.resource.raw],
+		]);
+		if (context.resource.resourceId !== undefined) {
+			attributes.set(ATTR_REQUEST_RESOURCE_ID, context.resource.resourceId);
+		}
+		return attributes;
+	}
+}

--- a/packages/cedar/src/__tests__/CedarPolicyRuleCollector.test.mts
+++ b/packages/cedar/src/__tests__/CedarPolicyRuleCollector.test.mts
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Attributes, CollectorContext, Logger } from "@o3co/auth.policy-verifier.core";
+import { evaluate } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	CedarPolicyRuleCollector,
+	type NoDeterminingPolicy,
+} from "../CedarPolicyRuleCollector.mjs";
+
+/** A context the collector must never read — everything reaches the rule via attrs. */
+const context: CollectorContext = {
+	subject: { sub: "user-1" },
+	resource: { raw: "document:42", resourceType: "document", resourceId: "42" },
+	action: "read",
+	signal: new AbortController().signal,
+};
+
+const REQUEST_FACTS: ReadonlyArray<[string, unknown]> = [
+	["userId", "alice"],
+	["requestAction", "read"],
+	["requestResourceType", "Document"],
+	["requestResourceId", "42"],
+];
+
+function attrsWith(entries: ReadonlyArray<[string, unknown]> = []): Attributes {
+	return new Map<string, unknown>([...REQUEST_FACTS, ...entries]);
+}
+
+function fakeLogger(): { logger: Logger; error: ReturnType<typeof vi.fn> } {
+	const error = vi.fn();
+	const logger = {
+		trace: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error,
+		fatal: vi.fn(),
+		child: (): Logger => logger,
+	} as Logger;
+	return { logger, error };
+}
+
+async function collectRule(config: Record<string, unknown>, logger?: Logger) {
+	const collector = new CedarPolicyRuleCollector(config, logger ? { logger } : undefined);
+	const rules = await collector.collect(context);
+	expect(rules).toHaveLength(1);
+	return rules[0];
+}
+
+describe("CedarPolicyRuleCollector — config validation", () => {
+	it("requires one of policyDir / policies", () => {
+		expect(() => new CedarPolicyRuleCollector({})).toThrow(/one of policyDir or policies/);
+	});
+
+	it("refuses both policyDir and policies", () => {
+		expect(
+			() =>
+				new CedarPolicyRuleCollector({
+					policyDir: "x",
+					policies: "permit(principal, action, resource);",
+				}),
+		).toThrow(/mutually exclusive/);
+	});
+
+	it("refuses a policy set that does not parse, at construction", () => {
+		expect(() => new CedarPolicyRuleCollector({ policies: "permit(when;" })).toThrow(
+			/failed to parse/,
+		);
+	});
+
+	it("refuses an unknown onNoDeterminingPolicy", () => {
+		expect(
+			() =>
+				new CedarPolicyRuleCollector({
+					policies: "permit(principal, action, resource);",
+					onNoDeterminingPolicy: "allow" as unknown as NoDeterminingPolicy,
+				}),
+		).toThrow(/onNoDeterminingPolicy must be one of abstain, deny/);
+	});
+
+	it("refuses a non-boolean logEvaluationErrors", () => {
+		expect(
+			() =>
+				new CedarPolicyRuleCollector({
+					policies: "permit(principal, action, resource);",
+					logEvaluationErrors: "yes" as unknown as boolean,
+				}),
+		).toThrow(/logEvaluationErrors must be a boolean/);
+	});
+
+	it("refuses a malformed entity attribute mapping", () => {
+		expect(
+			() =>
+				new CedarPolicyRuleCollector({
+					policies: "permit(principal, action, resource);",
+					principal: { attributes: { dept: 7 } },
+				}),
+		).toThrow(/principal\.attributes\.dept/);
+	});
+});
+
+describe("CedarPolicyRuleCollector — rule metadata", () => {
+	it("returns one rule in the configured group with the fixed code", async () => {
+		const rule = await collectRule({
+			policies: "permit(principal, action, resource);",
+			ruleType: "authz-cedar",
+		});
+		expect(rule.ruleType).toBe("authz-cedar");
+		expect(rule.code).toBe("cedar_deny");
+		expect(rule.message).toBe("Denied by Cedar policy");
+	});
+});
+
+describe("CedarPolicyRuleCollector — answer interpretation", () => {
+	const DEPT_POLICY = `permit(principal, action == Action::"read", resource) when { principal.dept == "eng" };`;
+
+	it("passes on a determining permit", async () => {
+		const rule = await collectRule({
+			policies: DEPT_POLICY,
+			principal: { attributes: { dept: "department" } },
+		});
+		expect(rule.verify(attrsWith([["department", "eng"]]))).toBe(true);
+	});
+
+	it("fails on a determining forbid, even beside a permit", async () => {
+		const rule = await collectRule({
+			policies: `
+				permit(principal, action, resource);
+				forbid(principal, action, resource) when { context.suspended == true };
+			`,
+			context: { suspended: "suspended" },
+		});
+		expect(rule.verify(attrsWith([["suspended", true]]))).toBe(false);
+		expect(rule.verify(attrsWith([["suspended", false]]))).toBe(true);
+	});
+
+	it("abstains by default when no policy determines the request", async () => {
+		// The permit's condition is simply false — no error, no determining
+		// policy — so under the default abstain the group passes and the other
+		// rule groups own the decision.
+		const rule = await collectRule({
+			policies: DEPT_POLICY,
+			principal: { attributes: { dept: "department" } },
+		});
+		expect(rule.verify(attrsWith([["department", "sales"]]))).toBe(true);
+	});
+
+	it("no-determining-policy honours the knob", async () => {
+		// An empty policy set never determines anything.
+		const abstain = await collectRule({ policies: "" });
+		expect(abstain.verify(attrsWith())).toBe(true);
+
+		const deny = await collectRule({ policies: "", onNoDeterminingPolicy: "deny" });
+		expect(deny.verify(attrsWith())).toBe(false);
+	});
+
+	it("denies and logs on evaluation errors even under abstain — the fail-open trap", async () => {
+		const { logger, error } = fakeLogger();
+		// The policy reads principal.dept but no mapping supplies it: Cedar
+		// answers deny with an empty reason and the cause only in errors[].
+		const rule = await collectRule({ policies: DEPT_POLICY }, logger);
+		expect(rule.verify(attrsWith())).toBe(false);
+		expect(error).toHaveBeenCalledOnce();
+		expect(JSON.stringify(error.mock.calls[0])).toMatch(/does not have the attribute/);
+	});
+
+	it("denies when an erroring forbid would otherwise let the top-level allow stand", async () => {
+		const { logger, error } = fakeLogger();
+		const rule = await collectRule(
+			{
+				policies: `
+					permit(principal, action, resource);
+					forbid(principal, action, resource) when { principal.banned == true };
+				`,
+			},
+			logger,
+		);
+		// `banned` is unmapped: the forbid errors and stops forbidding, Cedar's
+		// top-level decision reads "allow" — the errors check must still deny.
+		expect(rule.verify(attrsWith())).toBe(false);
+		expect(error).toHaveBeenCalledOnce();
+	});
+
+	it("denies on a missing principal id", async () => {
+		const { logger, error } = fakeLogger();
+		const rule = await collectRule({ policies: "permit(principal, action, resource);" }, logger);
+		const attrs = attrsWith();
+		attrs.delete("userId");
+		expect(rule.verify(attrs)).toBe(false);
+		expect(error).toHaveBeenCalledOnce();
+		expect(JSON.stringify(error.mock.calls[0])).toMatch(/principal id/);
+	});
+
+	it("denies on malformed parents rather than silently un-membering", async () => {
+		const { logger, error } = fakeLogger();
+		const rule = await collectRule(
+			{
+				policies: "permit(principal, action, resource);",
+				principal: { parents: { Group: "groups" } },
+			},
+			logger,
+		);
+		expect(rule.verify(attrsWith([["groups", [1, 2]]]))).toBe(false);
+		expect(error).toHaveBeenCalledOnce();
+		expect(JSON.stringify(error.mock.calls[0])).toMatch(/groups/);
+	});
+});
+
+describe("CedarPolicyRuleCollector — entity synthesis", () => {
+	it("supports group membership via parents", async () => {
+		// "deny" so that a non-matching permit is distinguishable from a match —
+		// under the default abstain both read as a pass.
+		const rule = await collectRule({
+			policies: `permit(principal in Group::"admins", action, resource);`,
+			onNoDeterminingPolicy: "deny",
+			principal: { parents: { Group: "groups" } },
+		});
+		expect(rule.verify(attrsWith([["groups", ["admins"]]]))).toBe(true);
+		expect(rule.verify(attrsWith([["groups", ["users"]]]))).toBe(false);
+		// Absent memberships are a legitimate state, not an error.
+		expect(rule.verify(attrsWith())).toBe(false);
+	});
+
+	it("supports entity-reference attributes (resource.owner == principal)", async () => {
+		const rule = await collectRule({
+			policies: `permit(principal, action == Action::"read", resource) when { resource.owner == principal };`,
+			onNoDeterminingPolicy: "deny",
+			resource: { attributes: { owner: { attribute: "resourceOwner", entityType: "User" } } },
+		});
+		expect(rule.verify(attrsWith([["resourceOwner", "alice"]]))).toBe(true);
+		expect(rule.verify(attrsWith([["resourceOwner", "bob"]]))).toBe(false);
+	});
+
+	it("supports context mapping", async () => {
+		const rule = await collectRule({
+			policies: "permit(principal, action, resource) when { context.mfa == true };",
+			context: { mfa: "mfaVerified" },
+		});
+		expect(rule.verify(attrsWith([["mfaVerified", true]]))).toBe(true);
+	});
+});
+
+describe("CedarPolicyRuleCollector — layered PDP through core evaluate", () => {
+	it("ANDs the cedar group with a TypeScript group", async () => {
+		const cedarRule = await collectRule({
+			policies: "permit(principal, action, resource);",
+		});
+		const tsRule = {
+			ruleType: "scope",
+			code: "invalid_scope",
+			message: "Insufficient scope",
+			verify: (attrs: Parameters<typeof cedarRule.verify>[0]) => attrs.get("scopeOk") === true,
+		};
+
+		const both = evaluate(attrsWith([["scopeOk", true]]), [cedarRule, tsRule]);
+		expect(both.decision).toBe("allow");
+
+		// Cedar permits, the TS group refuses: AND composes toward strictness.
+		const tsDenies = evaluate(attrsWith([["scopeOk", false]]), [cedarRule, tsRule]);
+		expect(tsDenies.decision).toBe("deny");
+	});
+});

--- a/packages/cedar/src/__tests__/RequestFactsCollector.test.mts
+++ b/packages/cedar/src/__tests__/RequestFactsCollector.test.mts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CollectorContext } from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import {
+	ATTR_REQUEST_ACTION,
+	ATTR_REQUEST_RESOURCE_ID,
+	ATTR_REQUEST_RESOURCE_RAW,
+	ATTR_REQUEST_RESOURCE_TYPE,
+} from "../keys.mjs";
+import { RequestFactsCollector } from "../RequestFactsCollector.mjs";
+
+function contextFor(resource: CollectorContext["resource"]): CollectorContext {
+	return {
+		subject: { sub: "user-1" },
+		resource,
+		action: "read",
+		signal: new AbortController().signal,
+	};
+}
+
+describe("RequestFactsCollector", () => {
+	it("promotes action and the parsed resource into attributes", async () => {
+		const attrs = await new RequestFactsCollector().collect(
+			contextFor({ raw: "document:42", resourceType: "document", resourceId: "42" }),
+		);
+		expect(attrs.get(ATTR_REQUEST_ACTION)).toBe("read");
+		expect(attrs.get(ATTR_REQUEST_RESOURCE_TYPE)).toBe("document");
+		expect(attrs.get(ATTR_REQUEST_RESOURCE_ID)).toBe("42");
+		expect(attrs.get(ATTR_REQUEST_RESOURCE_RAW)).toBe("document:42");
+	});
+
+	it("leaves requestResourceId absent when the parser produced none", async () => {
+		const attrs = await new RequestFactsCollector().collect(
+			contextFor({ raw: "document", resourceType: "document" }),
+		);
+		expect(attrs.has(ATTR_REQUEST_RESOURCE_ID)).toBe(false);
+	});
+});

--- a/packages/cedar/src/__tests__/module.test.mts
+++ b/packages/cedar/src/__tests__/module.test.mts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	type AttributeCollectorFactory,
+	Registry,
+	type ResourceParserFactory,
+	type RuleCollectorFactory,
+} from "@o3co/auth.policy-verifier.core";
+import { describe, expect, it } from "vitest";
+import { CedarPolicyRuleCollector } from "../CedarPolicyRuleCollector.mjs";
+import { cedarPolicyModule } from "../module.mjs";
+import { RequestFactsCollector } from "../RequestFactsCollector.mjs";
+
+describe("cedarPolicyModule", () => {
+	it("has name 'cedar-policy'", () => {
+		expect(cedarPolicyModule.name).toBe("cedar-policy");
+	});
+
+	it("registers both collector factories", async () => {
+		const attributeCollectorRegistry = new Registry<AttributeCollectorFactory>();
+		const ruleCollectorRegistry = new Registry<RuleCollectorFactory>();
+		const resourceParserRegistry = new Registry<ResourceParserFactory>();
+
+		await cedarPolicyModule.init({
+			pathResolver: (s: string) => s,
+			config: {},
+			attributeCollectorRegistry,
+			ruleCollectorRegistry,
+			resourceParserRegistry,
+		});
+
+		expect(attributeCollectorRegistry.get("RequestFactsCollector")({})).toBeInstanceOf(
+			RequestFactsCollector,
+		);
+		expect(
+			ruleCollectorRegistry.get("CedarPolicyRuleCollector")({
+				policies: "permit(principal, action, resource);",
+			}),
+		).toBeInstanceOf(CedarPolicyRuleCollector);
+	});
+});

--- a/packages/cedar/src/__tests__/policySource.test.mts
+++ b/packages/cedar/src/__tests__/policySource.test.mts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadPolicySource } from "../policySource.mjs";
+
+describe("loadPolicySource", () => {
+	it("concatenates *.cedar files in name order and ignores other files", () => {
+		const dir = mkdtempSync(join(tmpdir(), "cedar-policies-"));
+		writeFileSync(join(dir, "20-forbid.cedar"), "forbid(principal, action, resource);\n");
+		writeFileSync(join(dir, "10-permit.cedar"), "permit(principal, action, resource);\n");
+		writeFileSync(join(dir, "README.md"), "not a policy");
+
+		const source = loadPolicySource({ policyDir: dir });
+		expect(source.text.indexOf("permit")).toBeLessThan(source.text.indexOf("forbid"));
+		expect(source.text).not.toContain("not a policy");
+	});
+
+	it("names the offending file on a parse error", () => {
+		const dir = mkdtempSync(join(tmpdir(), "cedar-policies-"));
+		writeFileSync(join(dir, "ok.cedar"), "permit(principal, action, resource);\n");
+		writeFileSync(join(dir, "broken.cedar"), "permit(when;\n");
+
+		expect(() => loadPolicySource({ policyDir: dir })).toThrow(/broken\.cedar/);
+	});
+
+	it("allows a directory with zero policies — migration step one", () => {
+		const dir = mkdtempSync(join(tmpdir(), "cedar-policies-"));
+		expect(loadPolicySource({ policyDir: dir }).text).toBe("");
+	});
+
+	it("throws on an unreadable directory", () => {
+		expect(() => loadPolicySource({ policyDir: "/nonexistent/cedar-policies" })).toThrow(
+			/cannot read policyDir/,
+		);
+	});
+});

--- a/packages/cedar/src/index.mts
+++ b/packages/cedar/src/index.mts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+export type {
+	CedarPolicyRuleCollectorConfig,
+	CedarPolicyRuleCollectorOptions,
+	NoDeterminingPolicy,
+} from "./CedarPolicyRuleCollector.mjs";
+export { CedarPolicyRuleCollector } from "./CedarPolicyRuleCollector.mjs";
+export {
+	ATTR_REQUEST_ACTION,
+	ATTR_REQUEST_RESOURCE_ID,
+	ATTR_REQUEST_RESOURCE_RAW,
+	ATTR_REQUEST_RESOURCE_TYPE,
+} from "./keys.mjs";
+export type { AttributeMapping, EntityMappingConfig } from "./mapping.mjs";
+export { CedarInputError } from "./mapping.mjs";
+export { cedarPolicyModule } from "./module.mjs";
+export { RequestFactsCollector } from "./RequestFactsCollector.mjs";

--- a/packages/cedar/src/keys.mts
+++ b/packages/cedar/src/keys.mts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Attribute keys written by `RequestFactsCollector` and read (by default) by
+// `CedarPolicyRuleCollector`. They exist because the rule pipeline never sees
+// `CollectorContext`: a rule is a function of the merged attributes alone, so
+// the request facts a Cedar policy set decides over — action, resource type,
+// resource id — must be promoted into attributes by a collector first. These
+// are this package's vocabulary, not core's: core's `ATTR_*` constants are
+// reserved for OAuth/OIDC/RBAC concepts (AGENTS.md "Core Vocabulary Scope"),
+// and "the parsed request" is not one.
+
+export const ATTR_REQUEST_ACTION = "requestAction" as const;
+export const ATTR_REQUEST_RESOURCE_TYPE = "requestResourceType" as const;
+export const ATTR_REQUEST_RESOURCE_ID = "requestResourceId" as const;
+export const ATTR_REQUEST_RESOURCE_RAW = "requestResourceRaw" as const;

--- a/packages/cedar/src/mapping.mts
+++ b/packages/cedar/src/mapping.mts
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CedarValueJson, Context, Entities, EntityUid } from "@cedar-policy/cedar-wasm/nodejs";
+import type { ReadonlyAttributes } from "@o3co/auth.policy-verifier.core";
+import { ATTR_USER_ID } from "@o3co/auth.policy-verifier.core";
+import {
+	ATTR_REQUEST_ACTION,
+	ATTR_REQUEST_RESOURCE_ID,
+	ATTR_REQUEST_RESOURCE_TYPE,
+} from "./keys.mjs";
+
+/**
+ * Raised when the merged attributes cannot be shaped into a Cedar request —
+ * a required input is missing, or a value is present but malformed. The rule
+ * catches it and denies: an input the mapping cannot vouch for must never
+ * become an authorization the deployment did not write.
+ */
+export class CedarInputError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CedarInputError";
+	}
+}
+
+/**
+ * One synthesized entity attribute: either a plain value copied from an
+ * attribute, or an entity reference built from one (`resource.owner ==
+ * principal` needs `owner` to be an entity, not a string).
+ */
+export type AttributeMapping = string | { attribute: string; entityType: string };
+
+/** Declarative config for one synthesized entity (principal or resource). */
+export interface EntityMappingConfig {
+	attributes?: Record<string, AttributeMapping>;
+	parents?: Record<string, string>;
+}
+
+/** Validated mapping the collector resolves once at boot. */
+export interface ResolvedMapping {
+	principalType: string;
+	principalIdAttribute: string;
+	principal: EntityMappingConfig;
+	actionType: string;
+	actionIdAttribute: string;
+	resourceTypeAttribute: string;
+	resourceIdAttribute: string;
+	resourceIdWhenAbsent: string;
+	resource: EntityMappingConfig;
+	context: Record<string, string>;
+}
+
+/** The request shape `statefulIsAuthorized` accepts, minus the preparsed id. */
+export interface CedarRequest {
+	principal: EntityUid;
+	action: EntityUid;
+	resource: EntityUid;
+	context: Context;
+	entities: Entities;
+}
+
+/**
+ * Validates the mapping section of a `CedarPolicyRuleCollector` config entry
+ * and resolves defaults. Runs once at boot, inside the collector factory, so a
+ * shape mistake refuses to start rather than denying every request at runtime.
+ */
+export function resolveMapping(config: Record<string, unknown>): ResolvedMapping {
+	const principal = section(config, "principal");
+	const action = section(config, "action");
+	const resource = section(config, "resource");
+	const context = config.context;
+
+	const resolved: ResolvedMapping = {
+		principalType: optionalString(principal, "principal.type") ?? "User",
+		principalIdAttribute: optionalString(principal, "principal.idAttribute") ?? ATTR_USER_ID,
+		principal: entityMapping(principal, "principal"),
+		actionType: optionalString(action, "action.type") ?? "Action",
+		actionIdAttribute: optionalString(action, "action.idAttribute") ?? ATTR_REQUEST_ACTION,
+		resourceTypeAttribute:
+			optionalString(resource, "resource.typeAttribute") ?? ATTR_REQUEST_RESOURCE_TYPE,
+		resourceIdAttribute:
+			optionalString(resource, "resource.idAttribute") ?? ATTR_REQUEST_RESOURCE_ID,
+		resourceIdWhenAbsent: optionalString(resource, "resource.idWhenAbsent") ?? "",
+		resource: entityMapping(resource, "resource"),
+		context: stringRecord(context, "context"),
+	};
+	return resolved;
+}
+
+/**
+ * Builds the Cedar authorization request from the merged attributes.
+ *
+ * Pure: a deterministic function of `(mapping, attrs)`, no I/O, nothing read
+ * outside its arguments — it runs inside `Rule.verify` and is bound by the
+ * same contract. Throws {@link CedarInputError} when the attributes cannot
+ * supply the request; the caller turns that into a deny.
+ *
+ * Two deliberate asymmetries in how malformed input is treated:
+ *
+ * - A mapped **attribute** whose value is absent or unmappable is *omitted*
+ *   from the synthesized entity. That is fail-closed on its own: any policy
+ *   that reads the missing attribute raises a Cedar evaluation error, and the
+ *   rule denies on evaluation errors regardless of the abstain knob.
+ * - A mapped **parent** whose value is present but malformed *throws*. Parent
+ *   omission is not an error to Cedar — membership is simply absent — so a
+ *   typo'd `groups` attribute would silently un-member the principal, and a
+ *   `forbid (principal in Group::"banned")` policy would silently stop
+ *   forbidding. That is the one place omission fails open, so it is the one
+ *   place malformed input refuses instead. An *absent* parents attribute stays
+ *   legitimate (a principal in no groups).
+ */
+export function buildCedarRequest(
+	mapping: ResolvedMapping,
+	attrs: ReadonlyAttributes,
+): CedarRequest {
+	const principalId = requiredString(attrs, mapping.principalIdAttribute, "principal id");
+	const actionId = requiredString(attrs, mapping.actionIdAttribute, "action");
+	const resourceType = requiredString(attrs, mapping.resourceTypeAttribute, "resource type");
+	const resourceId =
+		optionalAttrString(attrs, mapping.resourceIdAttribute, "resource id") ??
+		mapping.resourceIdWhenAbsent;
+
+	const principal: EntityUid = { type: mapping.principalType, id: principalId };
+	const resource: EntityUid = { type: resourceType, id: resourceId };
+
+	return {
+		principal,
+		action: { type: mapping.actionType, id: actionId },
+		resource,
+		context: buildContext(mapping.context, attrs),
+		entities: [
+			{
+				uid: principal,
+				attrs: buildEntityAttrs(mapping.principal.attributes, attrs),
+				parents: buildParents(mapping.principal.parents, attrs),
+			},
+			{
+				uid: resource,
+				attrs: buildEntityAttrs(mapping.resource.attributes, attrs),
+				parents: buildParents(mapping.resource.parents, attrs),
+			},
+		],
+	};
+}
+
+/**
+ * Converts one attribute value to a Cedar value. `undefined` means "cannot be
+ * represented": non-integer numbers (Cedar `long` is integral), functions,
+ * objects, arrays with an unrepresentable element. Callers omit such values —
+ * see `buildCedarRequest` for why omission is the safe direction for
+ * attributes.
+ */
+function toCedarValue(value: unknown): CedarValueJson | undefined {
+	if (typeof value === "string" || typeof value === "boolean") return value;
+	if (typeof value === "number") return Number.isSafeInteger(value) ? value : undefined;
+	if (Array.isArray(value)) {
+		const out: CedarValueJson[] = [];
+		for (const item of value) {
+			const converted = toCedarValue(item);
+			if (converted === undefined) return undefined;
+			out.push(converted);
+		}
+		return out;
+	}
+	return undefined;
+}
+
+function buildEntityAttrs(
+	mappings: Record<string, AttributeMapping> | undefined,
+	attrs: ReadonlyAttributes,
+): Record<string, CedarValueJson> {
+	const out: Record<string, CedarValueJson> = {};
+	if (mappings === undefined) return out;
+	for (const [cedarName, mapping] of Object.entries(mappings)) {
+		if (typeof mapping === "string") {
+			const value = toCedarValue(attrs.get(mapping));
+			if (value !== undefined) out[cedarName] = value;
+			continue;
+		}
+		const raw = attrs.get(mapping.attribute);
+		if (typeof raw === "string" && raw.length > 0) {
+			out[cedarName] = { __entity: { type: mapping.entityType, id: raw } };
+		}
+	}
+	return out;
+}
+
+function buildParents(
+	mappings: Record<string, string> | undefined,
+	attrs: ReadonlyAttributes,
+): EntityUid[] {
+	const parents: EntityUid[] = [];
+	if (mappings === undefined) return parents;
+	for (const [entityType, attrKey] of Object.entries(mappings)) {
+		const raw = attrs.get(attrKey);
+		if (raw === undefined) continue; // no memberships is a legitimate state
+		const ids = typeof raw === "string" ? [raw] : raw;
+		if (!Array.isArray(ids) || !ids.every((id): id is string => typeof id === "string")) {
+			throw new CedarInputError(
+				`parents attribute "${attrKey}" must be a string or string[], got ${describe(raw)}`,
+			);
+		}
+		for (const id of ids) {
+			parents.push({ type: entityType, id });
+		}
+	}
+	return parents;
+}
+
+function buildContext(mappings: Record<string, string>, attrs: ReadonlyAttributes): Context {
+	const context: Context = {};
+	for (const [cedarKey, attrKey] of Object.entries(mappings)) {
+		const value = toCedarValue(attrs.get(attrKey));
+		if (value !== undefined) context[cedarKey] = value;
+	}
+	return context;
+}
+
+// --- boot-time config shape helpers -----------------------------------------
+
+function section(config: Record<string, unknown>, key: string): Record<string, unknown> {
+	const value = config[key];
+	if (value === undefined) return {};
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(
+			`CedarPolicyRuleCollector: ${key} must be a config object, got ${describe(value)}`,
+		);
+	}
+	return value as Record<string, unknown>;
+}
+
+function optionalString(section: Record<string, unknown>, path: string): string | undefined {
+	const key = path.split(".").pop() as string;
+	const value = section[key];
+	if (value === undefined) return undefined;
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(
+			`CedarPolicyRuleCollector: ${path} must be a non-empty string, got ${describe(value)}`,
+		);
+	}
+	return value;
+}
+
+function entityMapping(section: Record<string, unknown>, path: string): EntityMappingConfig {
+	const attributes = section.attributes;
+	const parents = section.parents;
+	const resolved: EntityMappingConfig = {};
+	if (attributes !== undefined) {
+		if (typeof attributes !== "object" || attributes === null || Array.isArray(attributes)) {
+			throw new Error(
+				`CedarPolicyRuleCollector: ${path}.attributes must be a config object, got ${describe(attributes)}`,
+			);
+		}
+		const out: Record<string, AttributeMapping> = {};
+		for (const [cedarName, mapping] of Object.entries(attributes)) {
+			if (typeof mapping === "string" && mapping.length > 0) {
+				out[cedarName] = mapping;
+				continue;
+			}
+			if (
+				typeof mapping === "object" &&
+				mapping !== null &&
+				!Array.isArray(mapping) &&
+				typeof (mapping as Record<string, unknown>).attribute === "string" &&
+				typeof (mapping as Record<string, unknown>).entityType === "string"
+			) {
+				const entry = mapping as { attribute: string; entityType: string };
+				out[cedarName] = { attribute: entry.attribute, entityType: entry.entityType };
+				continue;
+			}
+			throw new Error(
+				`CedarPolicyRuleCollector: ${path}.attributes.${cedarName} must be an attribute key or { attribute, entityType }, got ${describe(mapping)}`,
+			);
+		}
+		resolved.attributes = out;
+	}
+	if (parents !== undefined) {
+		resolved.parents = stringRecord(parents, `${path}.parents`);
+	}
+	return resolved;
+}
+
+function stringRecord(value: unknown, path: string): Record<string, string> {
+	if (value === undefined) return {};
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(
+			`CedarPolicyRuleCollector: ${path} must be a config object, got ${describe(value)}`,
+		);
+	}
+	const out: Record<string, string> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (typeof entry !== "string" || entry.length === 0) {
+			throw new Error(
+				`CedarPolicyRuleCollector: ${path}.${key} must be a non-empty attribute key, got ${describe(entry)}`,
+			);
+		}
+		out[key] = entry;
+	}
+	return out;
+}
+
+function requiredString(attrs: ReadonlyAttributes, key: string, role: string): string {
+	const value = attrs.get(key);
+	if (typeof value !== "string" || value.length === 0) {
+		throw new CedarInputError(
+			`${role} attribute "${key}" must be a non-empty string, got ${describe(value)}`,
+		);
+	}
+	return value;
+}
+
+function optionalAttrString(
+	attrs: ReadonlyAttributes,
+	key: string,
+	role: string,
+): string | undefined {
+	const value = attrs.get(key);
+	if (value === undefined) return undefined;
+	if (typeof value !== "string") {
+		throw new CedarInputError(
+			`${role} attribute "${key}" must be a string, got ${describe(value)}`,
+		);
+	}
+	return value;
+}
+
+function describe(value: unknown): string {
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "array";
+	return typeof value;
+}

--- a/packages/cedar/src/module.mts
+++ b/packages/cedar/src/module.mts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Module } from "@o3co/auth.policy-verifier.core";
+import { CedarPolicyRuleCollector } from "./CedarPolicyRuleCollector.mjs";
+import { RequestFactsCollector } from "./RequestFactsCollector.mjs";
+
+/**
+ * `Module` that registers the Cedar policy rule collector and the request-facts
+ * attribute collector that feeds it. Import and pass to
+ * `createApp({ modules: [builtinCollectorsModule, cedarPolicyModule, ...] })`,
+ * then reference both in config:
+ *
+ * ```hocon
+ * attribute.collectors = [
+ *   { collector = "RequestFactsCollector" }
+ * ]
+ * rule.collectors = [
+ *   { collector = "CedarPolicyRuleCollector", policyDir = "config/policies" }
+ * ]
+ * ```
+ *
+ * Nothing loads unless this module is imported: the WASM evaluator is a
+ * dependency of this package, not of core or the server.
+ */
+export const cedarPolicyModule: Module = {
+	name: "cedar-policy",
+	async init(context) {
+		context.attributeCollectorRegistry.register(
+			"RequestFactsCollector",
+			() => new RequestFactsCollector(),
+		);
+		context.ruleCollectorRegistry.register(
+			"CedarPolicyRuleCollector",
+			(config) => new CedarPolicyRuleCollector(config),
+		);
+	},
+};

--- a/packages/cedar/src/policySource.mts
+++ b/packages/cedar/src/policySource.mts
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { checkParsePolicySet } from "@cedar-policy/cedar-wasm/nodejs";
+
+/** Where a policy set came from, for boot-time error messages. */
+export interface PolicySource {
+	/** Concatenated Cedar policy text, ready for `preparsePolicySet`. */
+	text: string;
+	/** Human description of the source (`inline` or the resolved directory). */
+	description: string;
+}
+
+/**
+ * Loads the Cedar policy text a `CedarPolicyRuleCollector` evaluates.
+ *
+ * Exactly one of `policyDir` / `policies` must be set. `policyDir` is the
+ * intended shape: the `*.cedar` files in that directory (sorted by name,
+ * concatenated) are byte-identical to what a Cedar agent would load, so the
+ * corpus stays lift-and-shift portable and the official `cedar` CLI can
+ * validate the same files in CI. `policies` inlines a small set directly in
+ * config.
+ *
+ * Every file is parse-checked individually before the set is accepted, so a
+ * syntax error is reported against the file that contains it rather than
+ * against an offset into an invisible concatenation. All of this runs at boot,
+ * inside the collector factory: a broken policy set refuses to start, it does
+ * not serve denials (two-boundary validation — config is checked before the
+ * first request, here because file contents cannot be checked by the config
+ * schema).
+ *
+ * A directory with zero `.cedar` files is allowed and yields the empty policy
+ * set: that is migration step one — the collector mounted, abstaining on every
+ * request, behavior unchanged until the first policy lands.
+ *
+ * Relative paths resolve against the working directory, matching how the
+ * standalone template addresses its `config/` tree.
+ */
+export function loadPolicySource(config: {
+	policyDir?: unknown;
+	policies?: unknown;
+}): PolicySource {
+	const { policyDir, policies } = config;
+	if (policyDir !== undefined && policies !== undefined) {
+		throw new Error(
+			"CedarPolicyRuleCollector: policyDir and policies are mutually exclusive — configure one",
+		);
+	}
+
+	if (policies !== undefined) {
+		if (typeof policies !== "string") {
+			throw new Error(
+				`CedarPolicyRuleCollector: policies must be a string, got ${typeof policies}`,
+			);
+		}
+		assertParses(policies, "policies (inline)");
+		return { text: policies, description: "inline policies" };
+	}
+
+	if (policyDir === undefined) {
+		throw new Error("CedarPolicyRuleCollector: one of policyDir or policies is required");
+	}
+	if (typeof policyDir !== "string" || policyDir.length === 0) {
+		throw new Error(
+			`CedarPolicyRuleCollector: policyDir must be a non-empty string, got ${typeof policyDir}`,
+		);
+	}
+
+	const dir = resolve(policyDir);
+	let names: string[];
+	try {
+		names = readdirSync(dir);
+	} catch (cause) {
+		throw new Error(`CedarPolicyRuleCollector: cannot read policyDir "${dir}": ${message(cause)}`);
+	}
+
+	const files = names.filter((name) => name.endsWith(".cedar")).sort();
+	const parts: string[] = [];
+	for (const name of files) {
+		const path = resolve(dir, name);
+		let text: string;
+		try {
+			text = readFileSync(path, "utf8");
+		} catch (cause) {
+			throw new Error(`CedarPolicyRuleCollector: cannot read "${path}": ${message(cause)}`);
+		}
+		assertParses(text, path);
+		parts.push(text);
+	}
+
+	return { text: parts.join("\n"), description: dir };
+}
+
+/** Parse-checks one policy text, naming its source on failure. */
+function assertParses(text: string, source: string): void {
+	const answer = checkParsePolicySet({ staticPolicies: text });
+	if (answer.type === "failure") {
+		const details = answer.errors.map((error) => error.message).join("; ");
+		throw new Error(`CedarPolicyRuleCollector: ${source} failed to parse: ${details}`);
+	}
+}
+
+function message(cause: unknown): string {
+	return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/cedar/tsconfig.json
+++ b/packages/cedar/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}

--- a/packages/cedar/tsconfig.typecheck.json
+++ b/packages/cedar/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,25 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@26.4.0)(esbuild@0.27.4)(tsx@4.23.12)(yaml@2.9.0))
 
+  packages/cedar:
+    dependencies:
+      '@cedar-policy/cedar-wasm':
+        specifier: 4.12.0
+        version: 4.12.0
+      '@o3co/auth.policy-verifier.core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.4.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.11(vitest@4.1.11)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@26.4.0)(esbuild@0.27.4)(tsx@4.23.12)(yaml@2.9.0))
+
   packages/core:
     devDependencies:
       '@types/node':
@@ -156,6 +175,9 @@ importers:
       '@o3co/auth.policy-verifier.builtins':
         specifier: workspace:*
         version: link:../../packages/builtins
+      '@o3co/auth.policy-verifier.cedar':
+        specifier: workspace:*
+        version: link:../../packages/cedar
       '@o3co/auth.policy-verifier.core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -264,6 +286,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@cedar-policy/cedar-wasm@4.12.0':
+    resolution: {integrity: sha512-tCSj92hh4fnmas4ojO4tjx8wAAW3mKVgQ7M388NsSpXp64FVeYY6xwhKtJRaaYGK0qLiN2jnq8/SNIU2r5fdPw==}
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -1716,6 +1741,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.5.11':
     optional: true
+
+  '@cedar-policy/cedar-wasm@4.12.0': {}
 
   '@emnapi/core@1.9.1':
     dependencies:

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -12,6 +12,7 @@
 	},
 	"dependencies": {
 		"@o3co/auth.policy-verifier.builtins": "workspace:*",
+		"@o3co/auth.policy-verifier.cedar": "workspace:*",
 		"@o3co/auth.policy-verifier.core": "workspace:*",
 		"@o3co/auth.policy-verifier.server": "workspace:*"
 	},

--- a/tests/integration/src/rule-purity-conformance.test.mts
+++ b/tests/integration/src/rule-purity-conformance.test.mts
@@ -5,6 +5,7 @@ import {
 	ResourceActionPermissionRuleCollector,
 	ResourceActionScopeRuleCollector,
 } from "@o3co/auth.policy-verifier.builtins";
+import { CedarPolicyRuleCollector } from "@o3co/auth.policy-verifier.cedar";
 import type {
 	Attributes,
 	CollectorContext,
@@ -339,4 +340,60 @@ describe("rule purity conformance — the check itself", () => {
 			/not a deterministic function/,
 		);
 	});
+});
+
+// CedarPolicyRuleCollector (packages/cedar): the policy set is compiled at
+// boot and the rule builds its Cedar request from `attrs` inside `verify`, so
+// the suite proves exactly the property #185 claims — discard the request,
+// the answer stands. The mapping reads `department` / `suspended` out of the
+// attribute map, never out of the context.
+const cedarContext: CollectorRequest = {
+	subject: { sub: "user-1" },
+	resource: { raw: "document:42", resourceType: "document", resourceId: "42" },
+	action: "read",
+};
+
+const cedarCollector = new CedarPolicyRuleCollector({
+	policies: `
+		permit(principal, action == Action::"read", resource) when { principal.dept == "eng" };
+		forbid(principal, action, resource) when { context.suspended == true };
+	`,
+	onNoDeterminingPolicy: "deny",
+	principal: { attributes: { dept: "department" } },
+	context: { suspended: "suspended" },
+	logEvaluationErrors: false,
+});
+
+const cedarFacts: ReadonlyArray<[string, unknown]> = [
+	["userId", "user-1"],
+	["requestAction", "read"],
+	["requestResourceType", "Document"],
+	["requestResourceId", "42"],
+];
+
+describeRulePurityConformance({
+	name: "CedarPolicyRuleCollector",
+	collect: (context) => cedarCollector.collect(context),
+	cases: [
+		{
+			name: "a request a permit determines",
+			context: cedarContext,
+			attrs: new Map<string, unknown>([...cedarFacts, ["department", "eng"]]),
+		},
+		{
+			name: "a request a forbid determines",
+			context: cedarContext,
+			attrs: new Map<string, unknown>([...cedarFacts, ["department", "eng"], ["suspended", true]]),
+		},
+		{
+			name: "a request no policy determines",
+			context: cedarContext,
+			attrs: new Map<string, unknown>([...cedarFacts, ["department", "sales"]]),
+		},
+		{
+			name: "attributes that cannot supply the request at all",
+			context: cedarContext,
+			attrs: new Map<string, unknown>(),
+		},
+	],
 });


### PR DESCRIPTION
Closes #186. Implements #185 (shape A — coarse `cedar_deny`; the structured deny-detail contract change stays #185's follow-up item 4).

## What

- New optional workspace package **`packages/cedar` → `@o3co/auth.policy-verifier.cedar`**. Core / builtins / server unchanged; the WASM evaluator loads only if `cedarPolicyModule` is imported.
- `CedarPolicyRuleCollector`: boot-time load (`policyDir` of `*.cedar` files XOR inline `policies`) → per-file parse check → `preparsePolicySet`; per decision, one Rule in a dedicated group whose `verify(attrs)` builds the Cedar request from the merged attributes and calls `statefulIsAuthorized` — synchronous, deterministic, nothing of `CollectorContext` retained.
- `RequestFactsCollector`: promotes `action` / `resourceType` / `resourceId` / `raw` into attributes.
- Entity synthesis (one declarative hop): entity attributes, group membership via `parents`, entity references (`resource.owner == principal`). Malformed parents **throw → deny** (omission would silently un-member and let `forbid (principal in Group::"…")` stop firing); absent membership stays legitimate.
- Answer interpretation with the fail-open guard: `diagnostics.errors` is checked **before** the decision — an erroring `forbid` stops forbidding, so Cedar's top-level `allow` is least trustworthy exactly when errors exist. Errors always deny + log (`logEvaluationErrors`, default on), regardless of `onNoDeterminingPolicy` (`abstain` default / `deny`).

## Tests

- 27 unit tests (config validation, all interpretation branches incl. both fail-open traps, entity synthesis, layered AND through core `evaluate`).
- `describeRulePurityConformance` registered for the collector in the integration suite (4 cases) — the CI textual backstop also passes.
- Full gates green locally: `pnpm run lint` / `typecheck` / `test` (all workspaces), CI coverage step added for the new package.

## Review notes

1. **One deliberate softening of the purity letter**: on the *error branch only*, `verify` emits a log line through a logger fixed at boot. The decision stays a pure function of `attrs`; silence there would make a typo'd mapping indistinguishable from a policy deny (#185 "fail-open trap"). Flagging explicitly for review — `logEvaluationErrors = false` removes it entirely.
2. `@cedar-policy/cedar-wasm` is **exact-pinned** (4.12.0): Cedar minors can carry language changes; upgrades should be deliberate.
3. Request-context values reach Cedar as attributes via the builtins' `RequestContextAttributeCollector` (the #123 allowlist), not via a separate config path in this package — one trust discipline, not two.

## Merge / release plan

**Do not merge before the next minor ships.** Per the release discussion this lands alone as its own version after that, so the changelog entry sits under `[Unreleased]` and this PR stays draft until then.

Follow-ups (per #185): CLI equivalence conformance suite, structured deny detail (`[contract]`), README positioning line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)