### PR TITLE
fix(builtins): HasPermission wildcard halves must not overlap (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@ and version sections follow the release labeling policy in
   toward at most one half, while the wildcard itself may still match the empty
   string.
 
-  From the same audit: malformed role data never matches and never throws — the
-  discipline `HasScope` already applies to non-string scope values. A role
-  whose `permissions` is missing or not an array is ignored rather than
-  half-honoured, and non-string entries in a permissions list are skipped.
-  Before, one bad row from a store-backed role collector threw inside `verify`
-  and surfaced as a 500 deny.
+  From the same audit: malformed permission and role data never matches and
+  never throws — the discipline `HasScope` already applies to non-string scope
+  values. A non-array value under either attribute key, a role whose
+  `permissions` is missing or not an array, and non-string entries are all
+  ignored rather than half-honoured — notably, a bare string under
+  `permissions` is no longer spread into characters. Before, one bad row from
+  a store-backed role collector threw inside `verify` and surfaced as a 500
+  deny.
 
 ## [0.4.0] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and version sections follow the release labeling policy in
 [`docs/release-policy.md`](docs/release-policy.md).
 
+## [Unreleased]
+
+### Security
+
+- `HasPermission` no longer lets the two halves of a single-wildcard grant
+  overlap in the required permission
+  ([#180](https://github.com/o3co/auth.policy-verifier/issues/180)).
+
+  `required.startsWith(prefix) && required.endsWith(suffix)` had nothing
+  stopping the halves from sharing characters, so a grant of `posts.*.read`
+  matched a required permission of `posts.read` — the single `.` satisfied both
+  checks at once. That is an over-grant, and it contradicted the rule's own
+  contract ("the literal halves around the `*` still compare exactly"). The
+  guard is one length check: each character of the required permission counts
+  toward at most one half, while the wildcard itself may still match the empty
+  string.
+
+  From the same audit: malformed role data never matches and never throws — the
+  discipline `HasScope` already applies to non-string scope values. A role
+  whose `permissions` is missing or not an array is ignored rather than
+  half-honoured, and non-string entries in a permissions list are skipped.
+  Before, one bad row from a store-backed role collector threw inside `verify`
+  and surfaced as a 500 deny.
+
 ## [0.4.0] - 2026-08-29
 
 ### Security

--- a/packages/builtins/src/__tests__/rules/HasPermission.test.mts
+++ b/packages/builtins/src/__tests__/rules/HasPermission.test.mts
@@ -119,4 +119,72 @@ describe("HasPermission", () => {
 			expect(rule.verify(attrs)).toBe(false);
 		});
 	});
+
+	// #180: the halves around the wildcard must not overlap in the required
+	// permission. `startsWith(prefix) && endsWith(suffix)` alone lets one
+	// character satisfy both halves — "posts.*.read" matched "posts.read",
+	// where the single "." was counted as the prefix's trailing "." and the
+	// suffix's leading "." at once. An over-grant, the failure direction that
+	// matters in an authorization service.
+	describe("wildcard halves must not overlap (#180)", () => {
+		it("does NOT match when one character would satisfy both halves: posts.*.read vs posts.read", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([["permissions", ["posts.*.read"]]]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
+
+		it("does NOT match when the required permission is shorter than the two halves: a*a vs a", () => {
+			const rule = new HasPermission("a");
+			const attrs: Attributes = new Map([["permissions", ["a*a"]]]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
+
+		it("still matches a real middle segment: posts.*.read vs posts.123.read", () => {
+			const rule = new HasPermission("posts.123.read");
+			const attrs: Attributes = new Map([["permissions", ["posts.*.read"]]]);
+			expect(rule.verify(attrs)).toBe(true);
+		});
+
+		it("matches when the halves touch without sharing: a*a vs aa — the wildcard may match empty", () => {
+			// The guard refuses shared characters, not an empty middle: each
+			// character of the required permission counts toward at most one half.
+			const rule = new HasPermission("aa");
+			const attrs: Attributes = new Map([["permissions", ["a*a"]]]);
+			expect(rule.verify(attrs)).toBe(true);
+		});
+	});
+
+	// #180 (related): roles reach this rule from collectors, so a store-backed
+	// role collector can hand back shapes the operator-config
+	// StaticRoleCollector never produces. Malformed entries never match and
+	// never throw — the discipline HasScope already applies to non-string
+	// scope values. Before the guard, an undefined `permissions` reached
+	// `match` and threw, turning one bad row in a role store into a 500 deny.
+	describe("malformed role data never matches and never throws (#180)", () => {
+		it("ignores a role whose permissions is missing", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([["roles", [{ name: "broken" }]]]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
+
+		it("ignores a role whose permissions is not an array — malformed shapes are not half-honoured", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([
+				["roles", [{ name: "broken", permissions: "posts.read" }]],
+			]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
+
+		it("ignores a null role entry", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([["roles", [null]]]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
+
+		it("ignores non-string entries among granted permissions and still finds a string match", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([["permissions", [42, null, "posts.read"]]]);
+			expect(rule.verify(attrs)).toBe(true);
+		});
+	});
 });

--- a/packages/builtins/src/__tests__/rules/HasPermission.test.mts
+++ b/packages/builtins/src/__tests__/rules/HasPermission.test.mts
@@ -186,5 +186,29 @@ describe("HasPermission", () => {
 			const attrs: Attributes = new Map([["permissions", [42, null, "posts.read"]]]);
 			expect(rule.verify(attrs)).toBe(true);
 		});
+
+		// The CONTAINERS get the same treatment as their entries: the values
+		// under ATTR_PERMISSIONS / ATTR_ROLES arrive from collectors through an
+		// unchecked cast, so "an array or ignored" has to be decided here, not
+		// assumed. A string under `permissions` is the sharp case — spreading it
+		// would splay it into characters, and a one-character requirement could
+		// then match a character of a value that was never a grant.
+		it("ignores a roles value that is not an array", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([["roles", "admin"]]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
+
+		it("ignores a permissions value that is a bare string, not one entry of it", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([["permissions", "posts.read"]]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
+
+		it("ignores a permissions value that is not iterable at all", () => {
+			const rule = new HasPermission("posts.read");
+			const attrs: Attributes = new Map([["permissions", 42]]);
+			expect(rule.verify(attrs)).toBe(false);
+		});
 	});
 });

--- a/packages/builtins/src/rules/HasPermission.mts
+++ b/packages/builtins/src/rules/HasPermission.mts
@@ -48,17 +48,20 @@ export class HasPermission implements Rule {
 	}
 
 	verify(attrs: ReadonlyAttributes): boolean {
-		const direct = (attrs.get(ATTR_PERMISSIONS) as string[] | undefined) ?? [];
-		// The casts above are not trusted (#180): roles arrive from collectors,
-		// and a store-backed one can hand back a role whose `permissions` is
-		// missing or not an array. `flatMap` would smuggle the raw value (or
-		// `undefined`) into the list, and `match` would throw — one bad row in a
-		// role store turned into a 500 deny. A malformed shape is ignored, not
-		// half-honoured.
-		const fromRoles = ((attrs.get(ATTR_ROLES) as Role[] | undefined) ?? []).flatMap((role) =>
+		// Nothing about these values is taken on the cast's word (#180): both
+		// arrive from collectors, and a store-backed one can hand back anything
+		// — a non-array under either key, a role whose `permissions` is missing
+		// or not an array, non-string entries. Every malformed shape is ignored
+		// rather than half-honoured: an entry-level guard alone still throws on
+		// a non-array container, and spreading a bare string under
+		// `permissions` would splay it into characters, letting a
+		// one-character requirement match a value that was never a grant.
+		const direct = attrs.get(ATTR_PERMISSIONS);
+		const roles = attrs.get(ATTR_ROLES);
+		const fromRoles = (Array.isArray(roles) ? (roles as Role[]) : []).flatMap((role) =>
 			Array.isArray(role?.permissions) ? role.permissions : [],
 		);
-		const all = [...direct, ...fromRoles];
+		const all = [...(Array.isArray(direct) ? direct : []), ...fromRoles];
 
 		// Non-string entries never match and never throw, as in HasScope (#116).
 		return all.some((p) => typeof p === "string" && this.match(p, this.permission));

--- a/packages/builtins/src/rules/HasPermission.mts
+++ b/packages/builtins/src/rules/HasPermission.mts
@@ -31,6 +31,12 @@ import { ATTR_PERMISSIONS, ATTR_ROLES } from "@o3co/auth.policy-verifier.core";
  * literal halves around the `*` still compare exactly and case-sensitively.
  * Multiple wildcards are rejected outright because the two-part split would
  * silently drop segments and over-grant.
+ *
+ * The two halves must not overlap in the required permission (#180): a grant
+ * of `"posts.*.read"` does not match `"posts.read"`, where the single `.`
+ * would satisfy `startsWith` and `endsWith` at once. The wildcard may match
+ * the empty string, but each character of the required permission counts
+ * toward at most one half.
  */
 export class HasPermission implements Rule {
 	readonly ruleType = "permission";
@@ -43,12 +49,19 @@ export class HasPermission implements Rule {
 
 	verify(attrs: ReadonlyAttributes): boolean {
 		const direct = (attrs.get(ATTR_PERMISSIONS) as string[] | undefined) ?? [];
-		const fromRoles = ((attrs.get(ATTR_ROLES) as Role[] | undefined) ?? []).flatMap(
-			(role) => role.permissions,
+		// The casts above are not trusted (#180): roles arrive from collectors,
+		// and a store-backed one can hand back a role whose `permissions` is
+		// missing or not an array. `flatMap` would smuggle the raw value (or
+		// `undefined`) into the list, and `match` would throw — one bad row in a
+		// role store turned into a 500 deny. A malformed shape is ignored, not
+		// half-honoured.
+		const fromRoles = ((attrs.get(ATTR_ROLES) as Role[] | undefined) ?? []).flatMap((role) =>
+			Array.isArray(role?.permissions) ? role.permissions : [],
 		);
 		const all = [...direct, ...fromRoles];
 
-		return all.some((p) => this.match(p, this.permission));
+		// Non-string entries never match and never throw, as in HasScope (#116).
+		return all.some((p) => typeof p === "string" && this.match(p, this.permission));
 	}
 
 	private match(permission: string, required: string): boolean {
@@ -66,6 +79,12 @@ export class HasPermission implements Rule {
 			if ((permission.match(/\*/g) ?? []).length > 1) return false;
 
 			const [prefix, suffix] = permission.split("*");
+			// The halves must not overlap in `required` (#180): "posts.*.read"
+			// must not match "posts.read", where the single "." satisfies both
+			// startsWith and endsWith. Length is the whole check — the wildcard
+			// may match the empty string, but a character may only count toward
+			// one half.
+			if (required.length < prefix.length + suffix.length) return false;
 			return (!prefix || required.startsWith(prefix)) && (!suffix || required.endsWith(suffix));
 		}
 


### PR DESCRIPTION
## Summary

Closes #180 — found by the v0.4.0 release-cut audit, pre-existing since v0.3.1.

- `HasPermission.match` let the two halves of a single-wildcard grant **overlap** in the required permission: `posts.*.read` matched `posts.read`, the single `.` satisfying `startsWith` and `endsWith` at once. An **over-grant**, contradicting the rule's own v0.4.0 contract ("the literal halves around the `*` still compare exactly"). The guard is the issue's proposed one-length check: each character of the required permission counts toward at most one half; the wildcard may still match the empty string (`a*a` still matches `aa`, pinned).
- From the same audit note: **malformed role data never matches and never throws** — a role whose `permissions` is missing or not an array is ignored rather than half-honoured, and non-string entries are skipped, mirroring `HasScope`'s non-string discipline (#116). Before, one bad row from a store-backed role collector threw inside `verify` and surfaced as a 500 deny.

## Test plan

- TDD: 8 new cases written first (6 RED), covering the overlap deny, the empty-middle boundary, and each malformed-role shape.
- `pnpm run test` (full workspace, 1,595 tests), `pnpm run typecheck`, `pnpm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)