### PR TITLE
fix(core,server): cap the timer knobs, and bound the batch fan-out (#181, #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,40 @@ and version sections follow the release labeling policy in
   a store-backed role collector threw inside `verify` and surfaced as a 500
   deny.
 
+- `POST /verify/batch` decides its entries in bounded lanes, at most
+  `verify.batchConcurrency` at a time (default 8, new knob)
+  ([#183](https://github.com/o3co/auth.policy-verifier/issues/183)).
+
+  The collector concurrency cap (#115) is per pipeline, **per decision** — it
+  never bounded the batch. The batch route started every entry under a bare
+  `Promise.all`, so one request at the default `maxBatchSize` of 50 could hold
+  50 × 8 collectors in flight per pipeline: for a store-backed collector
+  deployment, ~800 simultaneous outbound calls from a single authenticated
+  HTTP request, past any per-request rate limit in front of `/verify`. The
+  per-request ceiling is now the stated product of the two caps — 8 × 8, not
+  50 × 8 — and answers still come back in request order. The knob is read
+  through `resolveBound` at both config boundaries like every other numeric
+  knob, and the comment on `DEFAULT_COLLECTOR_CONCURRENCY` no longer claims
+  the per-decision cap protects the batch.
+
+### Fixed
+
+- The millisecond knobs are bounded above by what a timer can hold
+  ([#181](https://github.com/o3co/auth.policy-verifier/issues/181)).
+
+  `verify.collectorTimeoutMs`, `verify.collectorDeadlineMs` and
+  `oauth.jwt.jwksTimeoutMs` had a floor and no ceiling. Node stores a
+  `setTimeout` delay in a signed 32-bit integer and silently clamps anything
+  above 2 147 483 647 to ~1 ms — so a validated value became a ~1 ms budget,
+  and every decision denied with `collector_timeout` (or every JWKS fetch
+  aborted). Fail-closed, so availability rather than an authorization hole,
+  but exactly the failure the two-boundary doctrine exists to prevent: *"a
+  value must be refused rather than passed to a library that quietly applies
+  its own default."* All three now carry `maximum: MAX_TIMER_MS` (exported
+  from core) at both config boundaries, and core's own
+  `resolveCollectorLimits` refuses the same ceiling for a hand-built pipeline
+  that never met a config boundary.
+
 ## [0.4.0] - 2026-08-29
 
 ### Security

--- a/docs/extending.ja.md
+++ b/docs/extending.ja.md
@@ -121,7 +121,7 @@ unwrap した後の指針:
 
 ## デッドラインとキャンセル
 
-各コレクターには `CollectorContext.signal` で `AbortSignal` が渡され、そのコレクターが属する fan-out には 3 つの上限が掛かります: コレクター単位のタイムアウト（既定 2 秒）、fan-out 全体のデッドライン（5 秒）、同時実行数の上限（8）。運用側は `verify.collectorTimeoutMs` / `verify.collectorDeadlineMs` / `verify.collectorConcurrency` で調整します。
+各コレクターには `CollectorContext.signal` で `AbortSignal` が渡され、そのコレクターが属する fan-out には 3 つの上限が掛かります: コレクター単位のタイムアウト（既定 2 秒）、fan-out 全体のデッドライン（5 秒）、同時実行数の上限（8）。運用側は `verify.collectorTimeoutMs` / `verify.collectorDeadlineMs` / `verify.collectorConcurrency` で調整します。この 3 つはいずれも decision 単位です。`POST /verify/batch` は一度に最大 `verify.batchConcurrency` 件（既定 8）ずつ決定するので、バッチ全体の fan-out は「バッチサイズ × コレクター上限」ではなく 2 つの上限の積に収まります。
 
 **待つ相手には signal をそのまま渡してください。** キャンセルが名目でなく実効になるのはそれによってです:
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -121,7 +121,7 @@ A transport that builds a `CollectorContext` by hand — your own interceptor, o
 
 ## Deadlines and cancellation
 
-Every collector is handed an `AbortSignal` on `CollectorContext.signal`, and the fan-out it runs in is bounded three ways: a per-collector timeout (2s by default), an end-to-end deadline for the whole wave (5s), and a cap on how many collectors run at once (8). Operators tune all three through `verify.collectorTimeoutMs`, `verify.collectorDeadlineMs` and `verify.collectorConcurrency`.
+Every collector is handed an `AbortSignal` on `CollectorContext.signal`, and the fan-out it runs in is bounded three ways: a per-collector timeout (2s by default), an end-to-end deadline for the whole wave (5s), and a cap on how many collectors run at once (8). Operators tune all three through `verify.collectorTimeoutMs`, `verify.collectorDeadlineMs` and `verify.collectorConcurrency`. All three are per decision; `POST /verify/batch` decides at most `verify.batchConcurrency` entries at a time (8 by default), so a batch's fan-out is the product of the two caps rather than the batch size times one of them.
 
 **Pass the signal to whatever you wait on.** That is what makes cancellation real rather than nominal:
 

--- a/packages/core/src/__tests__/collectorLimits.test.mts
+++ b/packages/core/src/__tests__/collectorLimits.test.mts
@@ -566,3 +566,26 @@ describe("RulePipeline — collector deadlines (#115)", () => {
 		expect(peak).toBe(2);
 	});
 });
+
+describe("pipeline limits — timer knobs are bounded above (#181)", () => {
+	// Node clamps a `setTimeout` delay above 2^31 - 1 to ~1 ms, so a huge
+	// budget would cancel every collector almost on arrival — a verifier that
+	// denies everything, produced by a value that looked valid. Refused at
+	// construction, like every other unusable bound.
+	it("accepts the largest delay a timer can represent", () => {
+		expect(
+			() =>
+				new AttributePipeline([], {
+					collectorTimeoutMs: 2_147_483_647,
+					deadlineMs: 2_147_483_647,
+				}),
+		).not.toThrow();
+	});
+
+	it.each([
+		["collectorTimeoutMs", { collectorTimeoutMs: 2_147_483_648 }],
+		["deadlineMs", { deadlineMs: 2_147_483_648 }],
+	])("refuses a %s above the timer ceiling, naming the field", (field, limits) => {
+		expect(() => new AttributePipeline([], limits)).toThrow(field);
+	});
+});

--- a/packages/core/src/collectorLimits.mts
+++ b/packages/core/src/collectorLimits.mts
@@ -64,12 +64,27 @@ export const DEFAULT_COLLECT_DEADLINE_MS = 5_000;
  * Eight: more than the collector set of any deployment this project has seen,
  * so a normal configuration still fans out in a single wave and nothing about
  * its latency changes. What the cap removes is the tail — a config with dozens
- * of collectors, or a `POST /verify/batch` of 50 entries, multiplying into
- * simultaneous outbound calls against a dependency that has just started to
- * slow down. That is the amplification the bound exists for; the number is a
- * ceiling on pathology, not a tuning parameter.
+ * of collectors multiplying into simultaneous outbound calls against a
+ * dependency that has just started to slow down. That is the amplification the
+ * bound exists for; the number is a ceiling on pathology, not a tuning
+ * parameter.
+ *
+ * Per **decision**, which is worth saying twice: the cap does not bound a
+ * request that carries many decisions. A `POST /verify/batch` multiplies it by
+ * however many entries are decided at once — bounding that product is the
+ * batch route's own job (`verify.batchConcurrency`, #183), not this cap's.
  */
 export const DEFAULT_COLLECTOR_CONCURRENCY = 8;
+
+/**
+ * The largest delay a timer can actually hold: 2^31 - 1 milliseconds, about
+ * 24.8 days. Node stores a `setTimeout` delay in a signed 32-bit integer and
+ * silently clamps anything above to ~1 ms — so a bigger "budget" is not a
+ * generous bound but a timer that fires almost immediately, cancelling every
+ * collector and denying every decision (#181). A millisecond knob above this
+ * is refused wherever one is read.
+ */
+export const MAX_TIMER_MS = 2_147_483_647;
 
 /** Which fan-out a bound was tripped in. Carried into the failure message. */
 export type CollectorPipeline = "attribute" | "rule";
@@ -103,28 +118,32 @@ export interface ResolvedCollectorLimits {
 
 /**
  * Fills in the defaults and refuses a limit that is not a positive whole
- * number, naming the field.
+ * number — or a millisecond budget above what a timer can hold (#181) —
+ * naming the field.
  *
  * Refused rather than repaired, and refused at construction rather than at the
  * first request: `concurrency: 0` would otherwise start no collector at all and
  * resolve with an empty result — an empty attribute map and an empty rule set,
  * which is precisely the fail-open this module exists to close. A silently
- * ignored bound is the failure mode #157 catalogued for the config knobs.
+ * ignored bound is the failure mode #157 catalogued for the config knobs, and
+ * a timeout past {@link MAX_TIMER_MS} is its twin: `setTimeout` quietly clamps
+ * it to ~1 ms, a bound nobody wrote that denies everything.
  *
  * This check is deliberately *weaker* than the config layer's `resolveBound`
  * rather than a second opinion on the same values: every number `resolveBound`
- * produces for these knobs is a positive integer, so anything accepted there is
- * accepted here. The two cannot reach different verdicts on a configured value
- * — this only catches a hand-written call that never met a config boundary.
+ * produces for these knobs is a positive integer within the timer ceiling, so
+ * anything accepted there is accepted here. The two cannot reach different
+ * verdicts on a configured value — this only catches a hand-written call that
+ * never met a config boundary.
  */
 export function resolveCollectorLimits(limits?: CollectorLimits): ResolvedCollectorLimits {
 	return {
-		collectorTimeoutMs: positive(
+		collectorTimeoutMs: timer(
 			limits?.collectorTimeoutMs,
 			DEFAULT_COLLECTOR_TIMEOUT_MS,
 			"collectorTimeoutMs",
 		),
-		deadlineMs: positive(limits?.deadlineMs, DEFAULT_COLLECT_DEADLINE_MS, "deadlineMs"),
+		deadlineMs: timer(limits?.deadlineMs, DEFAULT_COLLECT_DEADLINE_MS, "deadlineMs"),
 		concurrency: positive(limits?.concurrency, DEFAULT_COLLECTOR_CONCURRENCY, "concurrency"),
 	};
 }
@@ -138,6 +157,17 @@ function positive(value: number | undefined, fallback: number, field: string): n
 		throw new RangeError(`${field} must be a positive integer, got ${String(value)}`);
 	}
 	return value;
+}
+
+/** A millisecond budget: positive, and small enough for a timer to hold (#181). */
+function timer(value: number | undefined, fallback: number, field: string): number {
+	const resolved = positive(value, fallback, field);
+	if (resolved > MAX_TIMER_MS) {
+		throw new RangeError(
+			`${field} must be at most ${MAX_TIMER_MS} milliseconds, got ${String(value)}`,
+		);
+	}
+	return resolved;
 }
 
 /** The half of a collector this runner uses — either kind produces some `T`. */

--- a/packages/core/src/index.mts
+++ b/packages/core/src/index.mts
@@ -11,6 +11,7 @@ export {
 	DEFAULT_COLLECT_DEADLINE_MS,
 	DEFAULT_COLLECTOR_CONCURRENCY,
 	DEFAULT_COLLECTOR_TIMEOUT_MS,
+	MAX_TIMER_MS,
 	resolveCollectorLimits,
 } from "./collectorLimits.mjs";
 export type { CollectorTimeoutDetail, CollectorTimeoutLimit } from "./errors.mjs";

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -47,6 +47,8 @@ interface VerifyRouterConfig {
   evaluateOptions?: EvaluateOptions;
   /** Most entries POST /verify/batch will decide in one request. Defaults to 50. */
   maxBatchSize?: number;
+  /** How many of a batch's entries are decided at once (#183). Defaults to 8. */
+  batchConcurrency?: number;
 }
 
 // Discriminated on `validate`: verification parameters exist only when verifying.
@@ -132,6 +134,9 @@ const AppConfigSchema = z.object({
     collectorDeadlineMs: boundedNumber(NUMERIC_BOUNDS.collectorDeadlineMs, "verify"), // default 5000
     collectorConcurrency:
       boundedNumber(NUMERIC_BOUNDS.collectorConcurrency, "verify"),               // default 8
+    // How many of a batch's entries are decided at once (#183). The collector
+    // bounds are per decision; this bounds their product with the batch.
+    batchConcurrency: boundedNumber(NUMERIC_BOUNDS.batchConcurrency, "verify"),   // default 8
   }),
 });
 
@@ -278,7 +283,7 @@ HTTP/1.1 200 OK
 { "decisions": [ { ... }, { ... } ] }
 ```
 
-Entries come back in request order, each the same object `POST /verify` would have answered for it. The status reports whether the batch was **decided**, not what it decided — a batch of denials is still `200`, and the caller reads each entry. `400 invalid_request` when `decisions` is absent, empty, over `verify.maxBatchSize`, or carries a malformed entry — including one whose `resource` the parser refuses — with the message naming the index; `401` rejects the whole batch when the token does not verify. The whole batch is validated before any of it is decided, so one bad entry refuses the request rather than yielding a partial answer.
+Entries come back in request order, each the same object `POST /verify` would have answered for it. The status reports whether the batch was **decided**, not what it decided — a batch of denials is still `200`, and the caller reads each entry. Entries are decided at most `verify.batchConcurrency` (default 8) at a time (#183): the collector bounds are per decision, so this is what keeps one batch from holding `maxBatchSize × collectorConcurrency` collectors in flight per pipeline. `400 invalid_request` when `decisions` is absent, empty, over `verify.maxBatchSize`, or carries a malformed entry — including one whose `resource` the parser refuses — with the message naming the index; `401` rejects the whole batch when the token does not verify. The whole batch is validated before any of it is decided, so one bad entry refuses the request rather than yielding a partial answer.
 
 ## Usage Example
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -46,9 +46,9 @@ interface VerifyRouterConfig {
   /** Evaluator semantics overrides; omitted means deny on an empty rule set. */
   evaluateOptions?: EvaluateOptions;
   /** Most entries POST /verify/batch will decide in one request. Defaults to 50. */
-  maxBatchSize?: number;
+  maxBatchSize?: number | string;
   /** How many of a batch's entries are decided at once (#183). Defaults to 8. */
-  batchConcurrency?: number;
+  batchConcurrency?: number | string;
 }
 
 // Discriminated on `validate`: verification parameters exist only when verifying.

--- a/packages/server/src/__tests__/application.schema.test.mts
+++ b/packages/server/src/__tests__/application.schema.test.mts
@@ -8,6 +8,7 @@ import {
 	JWT_MODE_REMOVED_KEYS,
 } from "#/config/application.schema.mjs";
 import {
+	DEFAULT_BATCH_CONCURRENCY,
 	DEFAULT_COLLECT_DEADLINE_MS,
 	DEFAULT_COLLECTOR_CONCURRENCY,
 	DEFAULT_COLLECTOR_TIMEOUT_MS,
@@ -608,7 +609,7 @@ describe("AppConfigSchema — one numeric reader at both boundaries (#157)", () 
 
 	it("refuses jwksTimeoutMs = true, which used to become a 1 ms timeout", () => {
 		expect(schemaRefusal({ jwksTimeoutMs: true }, "jwksTimeoutMs")).toBe(
-			"oauth.jwt.jwksTimeoutMs must be a positive integer number of milliseconds, got true",
+			"oauth.jwt.jwksTimeoutMs must be an integer between 1 and 2147483647 milliseconds, got true",
 		);
 	});
 
@@ -1213,6 +1214,7 @@ describe("AppConfigSchema — the verify block's default names every knob", () =
 			collectorTimeoutMs: DEFAULT_COLLECTOR_TIMEOUT_MS,
 			collectorDeadlineMs: DEFAULT_COLLECT_DEADLINE_MS,
 			collectorConcurrency: DEFAULT_COLLECTOR_CONCURRENCY,
+			batchConcurrency: DEFAULT_BATCH_CONCURRENCY,
 			credentialToCollectors: "never",
 		});
 	});
@@ -1237,5 +1239,77 @@ describe("AppConfigSchema — the verify block's default names every knob", () =
 				`verify.${key} is missing from the block's .default() literal`,
 			).toBeDefined();
 		}
+	});
+});
+
+describe("AppConfigSchema — millisecond knobs are bounded above (#181)", () => {
+	// Node clamps a `setTimeout` delay above 2^31 - 1 to ~1 ms. Before the
+	// ceiling, a collectorTimeoutMs of 3_000_000_000 passed validation and
+	// became a ~1 ms timer: every decision denied with collector_timeout, and
+	// every JWKS fetch aborted — a validated configuration producing a total
+	// outage, the failure class this module's own header forbids.
+	const MAX_TIMER = 2_147_483_647;
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
+	const rs256 = {
+		algorithm: "RS256",
+		mode: "verify",
+		jwksUri: "https://issuer.test/jwks.json",
+		...rfc9068,
+	};
+
+	it("accepts each millisecond knob at the timer ceiling", () => {
+		const result = AppConfigSchema.safeParse({
+			oauth: { jwt: { ...rs256, jwksTimeoutMs: MAX_TIMER } },
+			...baseBody,
+			verify: { collectorTimeoutMs: MAX_TIMER, collectorDeadlineMs: MAX_TIMER },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it.each([
+		[
+			"oauth.jwt.jwksTimeoutMs",
+			{ oauth: { jwt: { ...rs256, jwksTimeoutMs: MAX_TIMER + 1 } }, ...baseBody },
+		],
+		[
+			"verify.collectorTimeoutMs",
+			{ oauth: { jwt: validJwt }, ...baseBody, verify: { collectorTimeoutMs: MAX_TIMER + 1 } },
+		],
+		[
+			"verify.collectorDeadlineMs",
+			{ oauth: { jwt: validJwt }, ...baseBody, verify: { collectorDeadlineMs: MAX_TIMER + 1 } },
+		],
+	])("rejects %s above the timer ceiling", (_label, body) => {
+		expect(AppConfigSchema.safeParse(body).success).toBe(false);
+	});
+});
+
+describe("AppConfigSchema — batch decision concurrency (#183)", () => {
+	const validJwt = { algorithm: "HS256", secret: SECRET, mode: "verify", ...rfc9068 };
+
+	const parseVerify = (verify: Record<string, unknown>) =>
+		AppConfigSchema.safeParse({ oauth: { jwt: validJwt }, ...baseBody, verify });
+
+	it("defaults to the shipped bound", () => {
+		const result = AppConfigSchema.parse({ oauth: { jwt: validJwt }, ...baseBody });
+		expect(result.verify.batchConcurrency).toBe(DEFAULT_BATCH_CONCURRENCY);
+	});
+
+	it("takes an operator-set bound, coercing the string a HOCON env substitution produces", () => {
+		const result = parseVerify({ batchConcurrency: "4" });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.verify.batchConcurrency).toBe(4);
+		}
+	});
+
+	it.each([
+		["zero — a batch that decides nothing", 0],
+		["a negative bound", -1],
+		["a fractional bound", 1.5],
+		["a non-numeric bound", "abc"],
+		["an empty string — `VAR=` substituted", ""],
+	])("rejects %s", (_label, batchConcurrency) => {
+		expect(parseVerify({ batchConcurrency }).success).toBe(false);
 	});
 });

--- a/packages/server/src/__tests__/jwks.test.mts
+++ b/packages/server/src/__tests__/jwks.test.mts
@@ -130,7 +130,7 @@ describe("resolveJwksFetchBounds — bounded fetches on the decision path (#109)
 
 	it.each(["soon", "", "  ", "5s", "1_000"])("rejects the unparsable string %o", (value) => {
 		expect(() => resolveJwksFetchBounds({ jwksTimeoutMs: value })).toThrow(
-			/oauth\.jwt\.jwksTimeoutMs must be a positive integer/,
+			/oauth\.jwt\.jwksTimeoutMs must be an integer between 1 and 2147483647 milliseconds/,
 		);
 	});
 
@@ -138,7 +138,7 @@ describe("resolveJwksFetchBounds — bounded fetches on the decision path (#109)
 		"rejects %o as a timeout — an unbounded or nonsensical fetch is the bug",
 		(value) => {
 			expect(() => resolveJwksFetchBounds({ jwksTimeoutMs: value })).toThrow(
-				/oauth\.jwt\.jwksTimeoutMs must be a positive integer/,
+				/oauth\.jwt\.jwksTimeoutMs must be an integer between 1 and 2147483647 milliseconds/,
 			);
 		},
 	);
@@ -162,17 +162,17 @@ describe("resolveJwksFetchBounds — bounded fetches on the decision path (#109)
 			// Number(true) is 1 and Number(null) is 0: coercing anything that is not
 			// a number or a string would invent a bound the operator never wrote.
 			expect(() => resolveJwksFetchBounds({ jwksTimeoutMs: value as unknown as number })).toThrow(
-				/oauth\.jwt\.jwksTimeoutMs must be a positive integer/,
+				/oauth\.jwt\.jwksTimeoutMs must be an integer between 1 and 2147483647 milliseconds/,
 			);
 		},
 	);
 
 	it("names the config path the operator wrote, and takes an override", () => {
 		expect(() => resolveJwksFetchBounds({ jwksTimeoutMs: "soon" })).toThrow(
-			'oauth.jwt.jwksTimeoutMs must be a positive integer number of milliseconds, got "soon"',
+			'oauth.jwt.jwksTimeoutMs must be an integer between 1 and 2147483647 milliseconds, got "soon"',
 		);
 		expect(() => resolveJwksFetchBounds({ jwksTimeoutMs: "soon" }, "jwt")).toThrow(
-			"jwt.jwksTimeoutMs must be a positive integer number of milliseconds",
+			"jwt.jwksTimeoutMs must be an integer between 1 and 2147483647 milliseconds",
 		);
 	});
 

--- a/packages/server/src/__tests__/verify.test.mts
+++ b/packages/server/src/__tests__/verify.test.mts
@@ -1470,3 +1470,112 @@ describe("createVerifyRouter — a collector that runs out of time denies (#115)
 		expect(res.body.decisions[1].code).toBe("collector_timeout");
 	});
 });
+
+describe("POST /verify/batch — decisions in flight are bounded (#183)", () => {
+	// The collector concurrency cap is per pipeline, per decision. Before this
+	// bound the batch route started every entry's decision at once under a bare
+	// `Promise.all`, so one request at the default maxBatchSize of 50 could
+	// hold 50 × collectorConcurrency collectors in flight per pipeline —
+	// amplification a store-backed collector deployment feels as ~800
+	// simultaneous outbound calls from a single HTTP request. Entries are now
+	// decided in lanes, `verify.batchConcurrency` wide.
+	const gaugedApp = (batchConcurrency: number | string, gauge: AttributeCollector) => {
+		const app = express();
+		app.use(
+			createVerifyRouter({
+				jwt: {
+					validate: true,
+					key: hs256Key.key,
+					algorithms: hs256Key.algorithms,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					tokenType: "at+jwt",
+				},
+				resourceParser: new DotNotationResourceParser(),
+				attributePipeline: new AttributePipeline([gauge]),
+				rulePipeline: new RulePipeline([new ResourceActionScopeRuleCollector()]),
+				batchConcurrency,
+			}),
+		);
+		return app;
+	};
+
+	it("never has more than batchConcurrency decisions in flight, and preserves entry order", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		// One gauged collector per decision, so attribute collectors in flight
+		// equals decisions in flight.
+		const gauge: AttributeCollector = {
+			collect: async () => {
+				inFlight += 1;
+				peak = Math.max(peak, inFlight);
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				inFlight -= 1;
+				return new Map<string, unknown>([["scopes", ["read:project"]]]);
+			},
+		};
+		const token = await signHS256Token({ sub: "user-1", scope: "read:project" });
+		const resources = Array.from({ length: 8 }, (_, i) => `project:${i}`);
+
+		const res = await request(gaugedApp(2, gauge))
+			.post("/verify/batch")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ decisions: resources.map((resource) => ({ resource, action: "read" })) });
+
+		expect(res.status).toBe(200);
+		expect(peak).toBe(2);
+		// The lanes write into the entry's own slot, so the answer order is the
+		// request order however the lanes interleave.
+		expect(res.body.decisions.map((d: { resource: string }) => d.resource)).toEqual(resources);
+		expect(res.body.decisions.every((d: { decision: string }) => d.decision === "allow")).toBe(
+			true,
+		);
+	});
+
+	it("takes the string a hand-built env config carries", async () => {
+		const gauge: AttributeCollector = {
+			collect: async () => new Map<string, unknown>([["scopes", ["read:project"]]]),
+		};
+		const token = await signHS256Token({ sub: "user-1", scope: "read:project" });
+
+		const res = await request(gaugedApp("2", gauge))
+			.post("/verify/batch")
+			.set("Authorization", `Bearer ${token}`)
+			.send({ decisions: [{ resource: "project:1", action: "read" }] });
+
+		expect(res.status).toBe(200);
+	});
+
+	it("refuses zero at router construction, in the schema's wording (#157)", () => {
+		// Zero lanes is a batch that decides nothing — the same shape as the
+		// `0` cap maxBatchSize refuses, and one reader at both boundaries.
+		const fromRouter = (() => {
+			try {
+				gaugedApp(0, { collect: async () => new Map() });
+				return undefined;
+			} catch (cause) {
+				return (cause as Error).message;
+			}
+		})();
+		expect(fromRouter).toBeDefined();
+
+		const result = AppConfigSchema.safeParse({
+			oauth: {
+				jwt: {
+					algorithm: "HS256",
+					secret: JWT_SECRET,
+					mode: "verify",
+					issuer: ISSUER,
+					audience: AUDIENCE,
+				},
+			},
+			attribute: { collectors: [] },
+			rule: { collectors: [] },
+			verify: { batchConcurrency: 0 },
+		});
+		const fromSchema = result.success
+			? undefined
+			: result.error.issues.find((issue) => issue.path.at(-1) === "batchConcurrency")?.message;
+		expect(fromSchema).toBe(fromRouter);
+	});
+});

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -292,6 +292,7 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 			rulePipeline: new RulePipeline(ruleCollectors, collectorLimits),
 			evaluateOptions: { onEmptyRuleSet: config.rule.onEmptyRuleSet },
 			maxBatchSize: config.verify.maxBatchSize,
+			batchConcurrency: config.verify.batchConcurrency,
 			// Forwarded rather than defaulted here (#118): the router resolves each
 			// through the same `resolveBound` the schema used, so a hand-built config
 			// reaching `createApp` gets the schema's verdict either way.

--- a/packages/server/src/config/application.schema.mts
+++ b/packages/server/src/config/application.schema.mts
@@ -6,6 +6,7 @@ import { checkHs256Rotation } from "../jwt/hs256Rotation.mjs";
 import { checkJwksUri } from "../jwt/jwks.mjs";
 import { type BoundSpec, NUMERIC_BOUNDS, resolveBound } from "./bounds.mjs";
 import {
+	DEFAULT_BATCH_CONCURRENCY,
 	DEFAULT_CALLER_AUTH_HEADER,
 	DEFAULT_COLLECT_DEADLINE_MS,
 	DEFAULT_COLLECTOR_CONCURRENCY,
@@ -464,6 +465,12 @@ export const AppConfigSchema = z.object({
 			collectorDeadlineMs: boundedNumber(NUMERIC_BOUNDS.collectorDeadlineMs, "verify"),
 			collectorConcurrency: boundedNumber(NUMERIC_BOUNDS.collectorConcurrency, "verify"),
 			/**
+			 * How many of a batch's entries are decided at once (#183). The
+			 * three collector bounds above are per decision; this is what keeps
+			 * one `POST /verify/batch` from multiplying them by `maxBatchSize`.
+			 */
+			batchConcurrency: boundedNumber(NUMERIC_BOUNDS.batchConcurrency, "verify"),
+			/**
 			 * Whether collectors receive the raw credential as
 			 * `CollectorContext.credential` (#175). `"never"` (default): verified
 			 * claims only — the credential is replayable and a collector that
@@ -503,6 +510,7 @@ export const AppConfigSchema = z.object({
 			collectorTimeoutMs: DEFAULT_COLLECTOR_TIMEOUT_MS,
 			collectorDeadlineMs: DEFAULT_COLLECT_DEADLINE_MS,
 			collectorConcurrency: DEFAULT_COLLECTOR_CONCURRENCY,
+			batchConcurrency: DEFAULT_BATCH_CONCURRENCY,
 			credentialToCollectors: "never" as const,
 		})),
 	// Defaulted (not shape-only): deployments mount an overlay config OVER the

--- a/packages/server/src/config/bounds.mts
+++ b/packages/server/src/config/bounds.mts
@@ -34,6 +34,7 @@
  */
 
 import {
+	DEFAULT_BATCH_CONCURRENCY,
 	DEFAULT_CLOCK_TOLERANCE_SECONDS,
 	DEFAULT_COLLECT_DEADLINE_MS,
 	DEFAULT_COLLECTOR_CONCURRENCY,
@@ -51,6 +52,7 @@ import {
 	DEFAULT_MAX_TOKEN_AGE_SECONDS,
 	MAX_CLOCK_TOLERANCE_SECONDS,
 	MAX_TCP_PORT,
+	MAX_TIMER_MS,
 } from "./defaults.mjs";
 
 /** How one numeric knob is read: what it defaults to and what it admits. */
@@ -93,11 +95,16 @@ export const NUMERIC_BOUNDS = {
 		minimum: 1,
 		maximum: MAX_TCP_PORT,
 	},
-	/** Abort a JWKS fetch after this long. */
+	/**
+	 * Abort a JWKS fetch after this long. Bounded above by what a timer can
+	 * hold (#181): Node clamps a `setTimeout` delay past 2^31 - 1 to ~1 ms,
+	 * which would abort every fetch rather than none of them.
+	 */
 	jwksTimeoutMs: {
 		field: "jwksTimeoutMs",
 		fallback: DEFAULT_JWKS_TIMEOUT_MS,
 		minimum: 1,
+		maximum: MAX_TIMER_MS,
 		unit: "milliseconds",
 	},
 	/**
@@ -191,12 +198,15 @@ export const NUMERIC_BOUNDS = {
 	 * How long one collector may take before it is cancelled (#115). The floor
 	 * is 1: a zero budget cancels every collector before it can answer, which is
 	 * a verifier that denies everything — the same shape as the `0` cap
-	 * `maxBatchSize` refuses.
+	 * `maxBatchSize` refuses. The ceiling is the timer's own (#181): past
+	 * 2^31 - 1, Node clamps the delay to ~1 ms and the huge budget *is* the
+	 * zero budget, reached through validation instead of refused by it.
 	 */
 	collectorTimeoutMs: {
 		field: "collectorTimeoutMs",
 		fallback: DEFAULT_COLLECTOR_TIMEOUT_MS,
 		minimum: 1,
+		maximum: MAX_TIMER_MS,
 		unit: "milliseconds",
 	},
 	/**
@@ -206,12 +216,14 @@ export const NUMERIC_BOUNDS = {
 	 * as a deadline, which is a cruder message but a correct decision), and
 	 * cross-knob validation is not something one `BoundSpec` can express.
 	 * `Infinity` is refused like every other knob here — an unbounded deadline
-	 * is the state #115 found.
+	 * is the state #115 found. Bounded above by the timer ceiling (#181), like
+	 * `collectorTimeoutMs` and for the same reason.
 	 */
 	collectorDeadlineMs: {
 		field: "collectorDeadlineMs",
 		fallback: DEFAULT_COLLECT_DEADLINE_MS,
 		minimum: 1,
+		maximum: MAX_TIMER_MS,
 		unit: "milliseconds",
 	},
 	/**
@@ -225,6 +237,19 @@ export const NUMERIC_BOUNDS = {
 		fallback: DEFAULT_COLLECTOR_CONCURRENCY,
 		minimum: 1,
 		unit: "collectors",
+	},
+	/**
+	 * How many of a batch's entries are decided at once (#183). The three
+	 * collector bounds above are per decision, so without this one
+	 * `POST /verify/batch` multiplied them by up to `maxBatchSize`. The floor
+	 * is 1 for `collectorConcurrency`'s reason: `0` is not "no limit", it is a
+	 * batch that decides nothing.
+	 */
+	batchConcurrency: {
+		field: "batchConcurrency",
+		fallback: DEFAULT_BATCH_CONCURRENCY,
+		minimum: 1,
+		unit: "decisions",
 	},
 } satisfies Record<string, BoundSpec>;
 

--- a/packages/server/src/config/bounds.mts
+++ b/packages/server/src/config/bounds.mts
@@ -210,14 +210,14 @@ export const NUMERIC_BOUNDS = {
 		unit: "milliseconds",
 	},
 	/**
-	 * How long a whole collector fan-out may take. Not bounded above and not
-	 * bounded below by `collectorTimeoutMs`: a deployment may legitimately want
-	 * a deadline tighter than one collector's budget (every stall then reported
-	 * as a deadline, which is a cruder message but a correct decision), and
+	 * How long a whole collector fan-out may take. Not bounded below by
+	 * `collectorTimeoutMs`: a deployment may legitimately want a deadline
+	 * tighter than one collector's budget (every stall then reported as a
+	 * deadline, which is a cruder message but a correct decision), and
 	 * cross-knob validation is not something one `BoundSpec` can express.
 	 * `Infinity` is refused like every other knob here — an unbounded deadline
-	 * is the state #115 found. Bounded above by the timer ceiling (#181), like
-	 * `collectorTimeoutMs` and for the same reason.
+	 * is the state #115 found — and the ceiling is the timer's own (#181),
+	 * like `collectorTimeoutMs` and for the same reason.
 	 */
 	collectorDeadlineMs: {
 		field: "collectorDeadlineMs",

--- a/packages/server/src/config/defaults.mts
+++ b/packages/server/src/config/defaults.mts
@@ -16,6 +16,24 @@
  */
 export const DEFAULT_MAX_BATCH_SIZE = 50;
 
+/**
+ * How many of a batch's entries are decided at once (#183).
+ *
+ * The collector concurrency cap is per pipeline, **per decision** — it never
+ * bounded the batch. Before this knob the batch route started every entry
+ * under a bare `Promise.all`, so one request at `DEFAULT_MAX_BATCH_SIZE`
+ * could hold `50 × DEFAULT_COLLECTOR_CONCURRENCY` collectors in flight per
+ * pipeline: real amplification for a store-backed collector deployment, from
+ * a single HTTP request, past any per-request rate limit in front of
+ * `/verify`.
+ *
+ * Eight, the same number and the same reasoning as
+ * `DEFAULT_COLLECTOR_CONCURRENCY`: a small batch still decides in one wave,
+ * and the per-request ceiling is the stated product — 8 × 8 per pipeline,
+ * not 50 × 8.
+ */
+export const DEFAULT_BATCH_CONCURRENCY = 8;
+
 /*
  * Bounds on what one `/verify` request may carry (#118).
  *
@@ -105,11 +123,17 @@ export const DEFAULT_MAX_CONTEXT_VALUE_LENGTH = 1_024;
  * own, so a config-only consumer of `AppConfigSchema` still pulls in nothing but
  * the engine's own vocabulary — which is the property `config/bounds.mts`
  * guards, and the reason nothing heavier may ever be reached for from here.
+ *
+ * `MAX_TIMER_MS` rides along for the same reason (#181): it is a fact about
+ * `setTimeout`, defined once beside the engine's own timer use, and it is the
+ * ceiling every millisecond knob here is held to — the JWKS fetch timeout
+ * included, not just the collector bounds.
  */
 export {
 	DEFAULT_COLLECT_DEADLINE_MS,
 	DEFAULT_COLLECTOR_CONCURRENCY,
 	DEFAULT_COLLECTOR_TIMEOUT_MS,
+	MAX_TIMER_MS,
 } from "@o3co/auth.policy-verifier.core";
 
 /*

--- a/packages/server/src/routes/verify.mts
+++ b/packages/server/src/routes/verify.mts
@@ -46,6 +46,14 @@ export interface VerifyRouterConfig {
 	 */
 	maxBatchSize?: number | string;
 	/**
+	 * How many of a batch's entries are decided at once (#183). Defaults to 8
+	 * (`DEFAULT_BATCH_CONCURRENCY`), and admits the string form for the reason
+	 * `maxBatchSize` does. The collector concurrency cap is per decision, so
+	 * this is the other factor in what one `POST /verify/batch` may hold in
+	 * flight — see the lane loop in the batch route.
+	 */
+	batchConcurrency?: number | string;
+	/**
 	 * Ceiling on the JSON body, in bytes — the `limit` handed to
 	 * `express.json()`. Defaults to 64 KiB (`DEFAULT_MAX_BODY_BYTES`), below
 	 * Express's unstated 100 KB default, and is the outer envelope: it is what
@@ -456,6 +464,11 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 	// the schema refused to boot — and let a `0` through as a cap that rejects
 	// every batch there is.
 	const maxBatchSize = resolveBound(config.maxBatchSize, NUMERIC_BOUNDS.maxBatchSize, "verify");
+	const batchConcurrency = resolveBound(
+		config.batchConcurrency,
+		NUMERIC_BOUNDS.batchConcurrency,
+		"verify",
+	);
 	// The request limits (#118), read the same way and at the same boundary.
 	const maxBodyBytes = resolveBound(config.maxBodyBytes, NUMERIC_BOUNDS.maxBodyBytes, "verify");
 	const limits: RequestLimits = {
@@ -677,7 +690,37 @@ export function createVerifyRouter(config: VerifyRouterConfig): express.Router {
 				return;
 			}
 
-			const decisions = await Promise.all(entries.map((entry) => decide(req, auth, entry)));
+			// Decided in lanes, batchConcurrency wide, not under a bare
+			// `Promise.all` (#183): the collector concurrency cap is per
+			// decision, so starting every entry at once multiplied it by the
+			// batch size — one request at the default caps could hold
+			// 50 × 8 collectors in flight per pipeline against a dependency
+			// that had just started to slow down. The same shared-cursor shape
+			// as core's runCollectors; each lane writes into the entry's own
+			// slot, so the answer order is the request order however the lanes
+			// interleave.
+			const decisions = new Array<DecisionResponse>(entries.length);
+			let next = 0;
+			let abandoned = false;
+			const lane = async (): Promise<void> => {
+				while (!abandoned && next < entries.length) {
+					const index = next++;
+					decisions[index] = await decide(req, auth, entries[index]);
+				}
+			};
+			try {
+				await Promise.all(
+					Array.from({ length: Math.min(batchConcurrency, entries.length) }, () => lane()),
+				);
+			} catch (cause) {
+				// A decide that throws is a genuine fault — denials are answered
+				// inside it — and the 500 below speaks for the whole batch, so
+				// the lanes stop pulling entries nobody will read. What is
+				// already in flight settles on its own, exactly as it did under
+				// Promise.all.
+				abandoned = true;
+				throw cause;
+			}
 			res.status(200).json({ decisions });
 		} catch (cause) {
 			logger.error({ err: cause, endpoint: "/verify/batch" }, "verify_internal_error");

--- a/templates/standalone/config/application.conf
+++ b/templates/standalone/config/application.conf
@@ -314,11 +314,18 @@ verify {
 
   # `collectorConcurrency` is how many run at once, per pipeline, per decision.
   # Higher than any realistic collector set, so an ordinary configuration still
-  # fans out in one wave; what it removes is the tail, where a wide config or a
-  # full batch multiplies into simultaneous calls against a dependency that has
-  # just started to slow down.
+  # fans out in one wave; what it removes is the tail, where a wide config
+  # multiplies into simultaneous calls against a dependency that has just
+  # started to slow down.
   collectorConcurrency = 8
   collectorConcurrency = ${?VERIFY_COLLECTOR_CONCURRENCY}
+
+  # `batchConcurrency` is how many of a batch's entries are decided at once.
+  # The three collector bounds above are per decision — this is what keeps one
+  # `POST /verify/batch` from multiplying them by `maxBatchSize` (50 x 8
+  # collectors in flight per pipeline, from a single request).
+  batchConcurrency = 8
+  batchConcurrency = ${?VERIFY_BATCH_CONCURRENCY}
 
   # Whether collectors receive the raw credential as `context.credential`
   # (#175). "never" (the default): collectors get verified claims only — the

--- a/templates/standalone/src/__tests__/loadConfig.test.mts
+++ b/templates/standalone/src/__tests__/loadConfig.test.mts
@@ -381,7 +381,7 @@ rule { collectors = [ { collector = ResourceActionScopeRuleCollector } ] }
 
 		const config = loadAppConfig(withoutVerify(), "development");
 
-		// All ten, spelled out. A knob that reached the shape but not the
+		// All eleven, spelled out. A knob that reached the shape but not the
 		// block's `.default()` literal is `undefined` here, and `toEqual` says
 		// which one.
 		expect(config.verify).toEqual({
@@ -394,6 +394,7 @@ rule { collectors = [ { collector = ResourceActionScopeRuleCollector } ] }
 			collectorTimeoutMs: 2_000,
 			collectorDeadlineMs: 5_000,
 			collectorConcurrency: 8,
+			batchConcurrency: 8,
 			credentialToCollectors: "never",
 		});
 	});


### PR DESCRIPTION
## Summary

Two findings from the v0.4.0 release-cut audit, both about bounds that oversold themselves. Closes #181, closes #183.

**#181 — millisecond knobs bounded above by what a timer can hold.** `verify.collectorTimeoutMs`, `verify.collectorDeadlineMs` and `oauth.jwt.jwksTimeoutMs` had a floor and no ceiling; Node clamps a `setTimeout` delay past 2^31 − 1 to ~1 ms, so a *validated* value produced a verifier that denies everything (or aborts every JWKS fetch). All three specs now carry `maximum: MAX_TIMER_MS` — a fact about `setTimeout` defined once in core and re-exported through `config/defaults.mts` like the other fan-out constants — and core's `resolveCollectorLimits` refuses the same ceiling for a hand-built pipeline that never met a config boundary (its check stays strictly weaker than `resolveBound`, so the two-boundary invariant is unchanged).

**#183 — `POST /verify/batch` decides entries in bounded lanes.** The collector concurrency cap is per pipeline **per decision**; the batch route ran every entry under a bare `Promise.all`, so one request at the default caps could hold 50 × 8 collectors in flight per pipeline (~800 outbound calls from one authenticated request, past any per-request rate limit). New knob `verify.batchConcurrency` (default 8, floor 1, read through `resolveBound` at both boundaries, wired through `createApp`, the schema `.default()` literal, the standalone template conf and the docs). Answers still come back in request order; the `DEFAULT_COLLECTOR_CONCURRENCY` comment no longer claims the per-decision cap protects the batch.

Refusal wording for the three ms knobs changes from "a positive integer number of milliseconds" to "an integer between 1 and 2147483647 milliseconds" — test pins updated.

## Test plan

- TDD: 13 RED cases first — timer-ceiling accepts/refusals at the schema and at pipeline construction, `batchConcurrency` schema defaults/refusals, a gauge-collector batch proving peak decisions in flight = 2 under `batchConcurrency: 2` (was 8), and the #157-style router/schema parity wording check.
- `pnpm run test` (full workspace, 1,602 tests), `pnpm run typecheck`, `pnpm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)