### PR TITLE
test(integration): the wire-contract table names every code the server answers (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,21 @@ and version sections follow the release labeling policy in
   `resolveCollectorLimits` refuses the same ceiling for a hand-built pipeline
   that never met a config boundary.
 
+- The wire-contract fixture names every code a deployed instance can answer
+  ([#182](https://github.com/o3co/auth.policy-verifier/issues/182)).
+
+  `responseEnvelopes.json` documents its key lists as EXHAUSTIVE — it is the
+  table [o3co/protobuf.interceptors](https://github.com/o3co/protobuf.interceptors)
+  implements against — but three answers a deployed instance can legally give
+  were missing: `attribute_conflict` (a 403 deny code shipped in v0.4.0),
+  `caller_unauthenticated` (the optional #108 caller-auth gate's 401) and
+  `internal_error` / 500. The `codes` and `status` maps now carry all three,
+  the conformance suite exercises the first two on the wire against the
+  reference deployment (new optional `conflicting` / `failing` adapter
+  fixtures), and the table notes that the caller-auth gate answers ahead of
+  the pinned surface — which is why it appears in the vocabulary but never as
+  a request case.
+
 ## [0.4.0] - 2026-08-29
 
 ### Security

--- a/tests/integration/src/conformance/fixtures/wireContract/responseEnvelopes.json
+++ b/tests/integration/src/conformance/fixtures/wireContract/responseEnvelopes.json
@@ -9,7 +9,15 @@
 		"Key lists are EXHAUSTIVE. A response carrying a key not named here is drift, and",
 		"the suite fails on the extra key as readily as on a missing one — an enforcement",
 		"layer that switched on a field this contract never promised is exactly the coupling",
-		"#125 exists to prevent."
+		"#125 exists to prevent.",
+		"Three vocabulary notes (#182). `attribute_conflict` is a deny code and arrives",
+		"with `status.deny`, wearing the decision envelope like `collector_timeout`.",
+		"`internal_error` is the terminal envelope — the one 5xx in this table, still",
+		"shaped like `error` so a client parsing only decision JSON reads it as a deny.",
+		"`caller_unauthenticated` is the optional `http.callerAuth` gate's refusal (#108):",
+		"the gate sits IN FRONT of this surface and answers before the body is parsed, so",
+		"it appears in `codes`/`status` but never as a request case — where a deployment",
+		"sets the gate, every refusal below is reachable only through it."
 	],
 	"error": {
 		"keys": ["decision", "code", "message"],
@@ -38,8 +46,10 @@
 		"batchDecided": 200,
 		"invalidRequest": 400,
 		"unauthenticated": 401,
+		"callerUnauthenticated": 401,
 		"payloadTooLarge": 413,
-		"unsupportedMediaType": 415
+		"unsupportedMediaType": 415,
+		"internalError": 500
 	},
 	"codes": {
 		"invalidRequest": "invalid_request",
@@ -48,6 +58,9 @@
 		"unsupportedScheme": "unsupported_scheme",
 		"payloadTooLarge": "payload_too_large",
 		"unsupportedMediaType": "unsupported_media_type",
-		"collectorTimeout": "collector_timeout"
+		"collectorTimeout": "collector_timeout",
+		"attributeConflict": "attribute_conflict",
+		"callerUnauthenticated": "caller_unauthenticated",
+		"internalError": "internal_error"
 	}
 }

--- a/tests/integration/src/conformance/wireContract.mts
+++ b/tests/integration/src/conformance/wireContract.mts
@@ -142,6 +142,19 @@ export interface WireFixtures {
 	 * omits it and the two cases that need it do not run.
 	 */
 	stalling?: WireDecisionRequest;
+	/**
+	 * Optional: a request two attribute collectors answer with different scalar
+	 * values for one key, for the `attribute_conflict` deny (#174, shipped in
+	 * v0.4.0 and missing from this table until #182). Omitted by a deployment
+	 * that cannot stage a conflict.
+	 */
+	conflicting?: WireDecisionRequest;
+	/**
+	 * Optional: a request whose collector fails outright — not a timeout — for
+	 * the terminal `internal_error` envelope (#182). Omitted by a deployment
+	 * with no failable collector.
+	 */
+	failing?: WireDecisionRequest;
 }
 
 /** Hooks a decision endpoint must provide to be checked against the wire contract. */
@@ -466,6 +479,62 @@ export function describeWireContractConformance(adapter: WireContractAdapter): v
 					expect(body.decisions[1].code).toBe(codes.collectorTimeout);
 				},
 			);
+		});
+
+		// #182: three codes a deployed instance can legally answer were missing
+		// from the table, so the contract an enforcement layer reads was narrower
+		// than the surface it meets. Two are exercised on the wire below; the
+		// third — the optional caller-auth gate's — cannot be, and the case says
+		// why.
+		describe("a scalar attribute conflict (#174, table row #182)", () => {
+			it.runIf(adapter.fixtures.conflicting)("denies with 403 and an empty reason", async () => {
+				const conflicting = adapter.fixtures.conflicting;
+				if (!conflicting) return;
+				const res = await post("/verify", conflicting);
+
+				// The same rendering as collector_timeout, for the same reason:
+				// two collectors disagreeing about one attribute means the
+				// decision's inputs are not established, and the safe answer is a
+				// deny an enforcement layer will not retry around.
+				expect(res.status).toBe(status.deny);
+				const body = expectDecisionEnvelope(res.body);
+				expect(body.decision).toBe("deny");
+				expect(body.code).toBe(codes.attributeConflict);
+				// No rule group was evaluated, and the reason says so.
+				expect(body.reason).toEqual({ groups: [] });
+			});
+		});
+
+		describe("a collector failure that is not a timeout (table row #182)", () => {
+			it.runIf(adapter.fixtures.failing)("answers the terminal 500 envelope", async () => {
+				const failing = adapter.fixtures.failing;
+				if (!failing) return;
+				const res = await post("/verify", failing);
+
+				// A genuine fault, not a refusal the verifier can stand behind —
+				// the one answer in this table that IS a 5xx, and it still wears
+				// the deny envelope so a client that parses only decision JSON
+				// reads it as the deny it must treat it as.
+				expect(res.status).toBe(status.internalError);
+				expect(keysOf(res.body)).toEqual([...error.keys].sort());
+				const body = res.body as { decision: string; code: string };
+				expect(body.decision).toBe(error.decision);
+				expect(body.code).toBe(codes.internalError);
+			});
+		});
+
+		describe("the code the table names without a request case (#182)", () => {
+			it("names the caller-auth gate's refusal, which answers ahead of this surface (#108)", () => {
+				// The optional `http.callerAuth` gate sits IN FRONT of the pinned
+				// surface — it answers before the body is parsed, so it is not one
+				// of the per-request refusals the request cases enumerate, and this
+				// reference deployment does not mount it. The table still names it:
+				// an enforcement layer switching on `code` meets it wherever a
+				// deployment sets the gate, and a vocabulary documented as
+				// exhaustive must not be narrower than the wire.
+				expect(codes.callerUnauthenticated).toBe("caller_unauthenticated");
+				expect(status.callerUnauthenticated).toBe(401);
+			});
 		});
 	});
 }

--- a/tests/integration/src/wire-contract-conformance.test.mts
+++ b/tests/integration/src/wire-contract-conformance.test.mts
@@ -48,6 +48,12 @@ const secret = new TextEncoder().encode("wire-contract-conformance-secret");
 /** The action the stalling collector below never answers for. */
 const STALLING_ACTION = "stall";
 
+/** The action that makes two collectors disagree about `tenantId` (#174). */
+const CONFLICTING_ACTION = "conflict";
+
+/** The action the failing collector below throws on — a fault, not a timeout. */
+const FAILING_ACTION = "explode";
+
 /**
  * Small enough that a case can exceed them cheaply, and stated here rather than
  * defaulted so the 413 and the batch-cap cases do not depend on this package's
@@ -66,6 +72,33 @@ const stallableCollector: AttributeCollector = {
 	collect: (collectorContext: CollectorContext) =>
 		collectorContext.action === STALLING_ACTION
 			? new Promise<Attributes>(() => {})
+			: Promise.resolve(new Map<string, unknown>()),
+};
+
+/**
+ * For `CONFLICTING_ACTION`, answers `tenantId` with a value the request's own
+ * `tenant_id` context never carries — so it and
+ * `RequestContextAttributeCollector` disagree about one scalar, which is the
+ * `attribute_conflict` deny (#174). Inert for every other action.
+ */
+const conflictableCollector: AttributeCollector = {
+	collect: (collectorContext: CollectorContext) =>
+		Promise.resolve(
+			collectorContext.action === CONFLICTING_ACTION
+				? new Map<string, unknown>([["tenantId", "a-tenant-no-request-names"]])
+				: new Map<string, unknown>(),
+		),
+};
+
+/**
+ * For `FAILING_ACTION`, rejects with a plain error — the store-outage shape,
+ * which is a genuine fault and must surface as the terminal `internal_error`
+ * envelope rather than as any refusal (#182). Inert for every other action.
+ */
+const failableCollector: AttributeCollector = {
+	collect: (collectorContext: CollectorContext) =>
+		collectorContext.action === FAILING_ACTION
+			? Promise.reject(new Error("wire-contract synthetic collector fault"))
 			: Promise.resolve(new Map<string, unknown>()),
 };
 
@@ -105,6 +138,8 @@ app.use(
 					attributes: [{ from: "tenant_id", to: "tenantId" }],
 				}),
 				stallableCollector,
+				conflictableCollector,
+				failableCollector,
 			],
 			// Bounds low enough that the stall is answered well inside vitest's own
 			// timeout, and high enough that the in-memory collectors beside it are
@@ -199,6 +234,13 @@ const adapter: WireContractAdapter = {
 		// so one response carries a `satisfiedBy` and an absence of one.
 		partiallySatisfied: { resource: "project:1", action: "read", context: { tenant_id: "other" } },
 		stalling: { resource: "project:1", action: STALLING_ACTION, context: { tenant_id: "acme" } },
+		// `tenant_id` here and the collector's own answer disagree on `tenantId`.
+		conflicting: {
+			resource: "project:1",
+			action: CONFLICTING_ACTION,
+			context: { tenant_id: "acme" },
+		},
+		failing: { resource: "project:1", action: FAILING_ACTION, context: { tenant_id: "acme" } },
 	},
 };
 


### PR DESCRIPTION
## Summary

Closes #182 — found by the v0.4.0 release-cut audit.

`responseEnvelopes.json` documents its key lists as EXHAUSTIVE — it is the table o3co/protobuf.interceptors implements against — but three answers a deployed instance can legally give were missing. The `codes` / `status` maps now carry:

- `attribute_conflict` — the 403 deny code v0.4.0 shipped, pinned on the wire: the reference deployment gains a conflictable collector (optional `conflicting` adapter fixture, the shape `stalling` set) and the suite asserts the deny envelope, code and empty reason.
- `internal_error` / 500 — pinned on the wire via a failable collector (`failing` fixture): the one 5xx in the table, still wearing the deny envelope so a client parsing only decision JSON reads it as the deny it must treat it as.
- `caller_unauthenticated` — the optional #108 caller-auth gate's 401, asserted as vocabulary only. The gate answers before the body is parsed, ahead of the pinned surface, so it appears in `codes`/`status` but never as a request case; the fixture's `about` block and the test say so.

## Test plan

- TDD: 3 RED cases first (missing table entries), GREEN by the fixture edit.
- `pnpm run test` (full workspace, 1,588 tests incl. 124 integration), `pnpm run typecheck`, `pnpm run lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)