### PR TITLE
revert: bump node from 24-alpine to 26-alpine in /templates/standalone (#151)

### DIFF
--- a/templates/standalone/Dockerfile
+++ b/templates/standalone/Dockerfile
@@ -3,7 +3,7 @@
 # rebuild. The digest is the multi-arch index, so amd64 and arm64 both resolve
 # from it. Dependabot's `docker` ecosystem keeps the pair in step — bump the
 # tag and the digest together, never the tag alone.
-FROM node:26-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019 AS node-base
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS node-base
 
 ENV HOME=/home/node
 


### PR DESCRIPTION
Reverts the #151 merge, restoring `node:24-alpine`.

#151 carried an explicit hold comment that was overlooked when it was merged today:

- `node:26` is still a **Current** release; it enters LTS in October 2026, and the Dockerfile deliberately pinned the LTS line.
- CI does not build this image, so the green checks validated nothing about the runtime jump.
- The Dependabot path exists for CVE-rebuild freshness, which keeps working on `24-alpine`.

Per that comment, the bump should land once 26.x is LTS (Dependabot will re-open it), or be declined entirely — either way `develop` should stay on 24-alpine for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)