### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and version sections follow the release labeling policy in
 [`docs/release-policy.md`](docs/release-policy.md).
 
-## [Unreleased]
+## [0.5.0] - 2026-09-03
 
 ### Security
 


### PR DESCRIPTION
## Summary

Release-cut PR per `docs/release-policy.md` R2/R6: `## [Unreleased]` → `## [0.5.0] - 2026-09-03`. No other change.

R6 audit for this cut:
- step 1 grep (forward-version references outside CHANGELOG): no hits
- step 3 (forward phrases inside the section): none
- one heading per type, no repeated entries
- no new packages; all four publishable packages exist on npm at 0.4.0

After merge: `v0.5.0` tag on the merge commit → `release.yml` publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
