### PR TITLE
docs(readme): Cedar positioning — optional co-resident language, topology unbound (#185)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -67,7 +67,7 @@ POST /verify/batch — 同じ契約で、1 往復に N 件の decision
 - **JWKS サポート** — `jwksUri` を auth.provider の `https://.../.well-known/jwks.json` に向ければ鍵ローテーションに自動対応。エンドポイントは TLS 必須（ローカル開発向けにループバックのみ例外）。取得はタイムアウト / クールダウン / キャッシュ期間で必ず上限が付き、プロバイダー障害が判定パスを止めない。
 - **本番で答えられる** — 判定 1 件ごとに構造化された `decision` イベント（subject / resource / action / 決め手になったルール / request id / レイテンシ）を出力し、allow/deny カウンタを持つ Prometheus `/metrics` を提供する。メトリクスのラベルはすべて有界であり、bearer トークン・`sub` を超えるクレーム集合・呼び出し元の `context` はログに載らない。[可観測性](#可観測性)を参照。
 - **プラグイン可能なアーキテクチャ** — Module システムでカスタム Collector、ルール、リソースパーサーをファクトリ経由で登録。
-- **DSL ロックインなし** — 認可ロジックは TypeScript。DSL は一切必須ではない。Cedar は*オプションの同居言語*として利用できる（[`packages/cedar`](packages/cedar/)）: 本物の Cedar evaluator が in-process で 1 ルールグループとして動き、Collector が集めた事実を entity store の構築・同期なしで判定する。どちらの言語を選んでも topology には縛られない — 同じ `.cedar` ファイルは後から埋め込み evaluator にも Cedar Agent にも無変更でロードでき、[protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) 経由で共通 `VerifierEndpoint` の背後をまるごと OPA / Cedar に差し替える道も残る。
+- **DSL ロックインなし** — 認可ロジックは TypeScript。DSL は一切必須ではない。Cedar は「オプションの同居言語」として利用できる（[`packages/cedar`](packages/cedar/)）: 本物の Cedar evaluator が in-process で 1 ルールグループとして動き、Collector が集めた事実を entity store の構築・同期なしで判定する。どちらの言語を選んでも topology には縛られない — 同じ `.cedar` ファイルは後から埋め込み evaluator にも Cedar Agent にも無変更でロードでき、[protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) 経由で共通 `VerifierEndpoint` の背後をまるごと OPA / Cedar に差し替える道も残る。
 
 ## いつ選ぶか
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,12 +67,13 @@ POST /verify/batch — 同じ契約で、1 往復に N 件の decision
 - **JWKS サポート** — `jwksUri` を auth.provider の `https://.../.well-known/jwks.json` に向ければ鍵ローテーションに自動対応。エンドポイントは TLS 必須（ローカル開発向けにループバックのみ例外）。取得はタイムアウト / クールダウン / キャッシュ期間で必ず上限が付き、プロバイダー障害が判定パスを止めない。
 - **本番で答えられる** — 判定 1 件ごとに構造化された `decision` イベント（subject / resource / action / 決め手になったルール / request id / レイテンシ）を出力し、allow/deny カウンタを持つ Prometheus `/metrics` を提供する。メトリクスのラベルはすべて有界であり、bearer トークン・`sub` を超えるクレーム集合・呼び出し元の `context` はログに載らない。[可観測性](#可観測性)を参照。
 - **プラグイン可能なアーキテクチャ** — Module システムでカスタム Collector、ルール、リソースパーサーをファクトリ経由で登録。
-- **DSL ロックインなし** — 認可ロジックは TypeScript。Rego も Cedar ポリシー言語も不要。スケールアウトが必要になれば [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) 経由で OPA や Cedar に差し替え可能 — interceptor がバックエンドを抽象化する。
+- **DSL ロックインなし** — 認可ロジックは TypeScript。DSL は一切必須ではない。Cedar は*オプションの同居言語*として利用できる（[`packages/cedar`](packages/cedar/)）: 本物の Cedar evaluator が in-process で 1 ルールグループとして動き、Collector が集めた事実を entity store の構築・同期なしで判定する。どちらの言語を選んでも topology には縛られない — 同じ `.cedar` ファイルは後から埋め込み evaluator にも Cedar Agent にも無変更でロードでき、[protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) 経由で共通 `VerifierEndpoint` の背後をまるごと OPA / Cedar に差し替える道も残る。
 
 ## いつ選ぶか
 
 - ポリシーを書くのは開発者で、DSL を学習したくない → **これ**
-- ポリシーを非開発者が編集する、または形式検証が必要 → **[Cedar](https://www.cedarpolicy.com/)**
+- Cedar の言語は使いたいが entity store を構築・同期したくない → **これ + [`packages/cedar`](packages/cedar/)**。規模が超えたら（階層探索・entity store が必要になったら）同じ `.cedar` ファイルを無変更でフル Cedar 構成へ移せる
+- ポリシーを非開発者が編集する、またはポリシー全面の形式検証が必要 → **[Cedar](https://www.cedarpolicy.com/)**
 - 組織全体のポリシー基盤として広範な built-in operator 群が必要 → **[OPA](https://www.openpolicyagent.org/)**
 
 ## Quick Start
@@ -149,6 +150,7 @@ standalone → server   → core
 | --- | --- | --- |
 | [`packages/core`](packages/core/) | `@o3co/auth.policy-verifier.core` | 型定義、evaluate、パイプライン、Module 基盤 |
 | [`packages/builtins`](packages/builtins/) | `@o3co/auth.policy-verifier.builtins` | 組み込み Collector、ルール、リソースパーサー |
+| [`packages/cedar`](packages/cedar/) | `@o3co/auth.policy-verifier.cedar` | オプションの同居 Cedar ポリシー評価（policy set ごとに 1 ルールグループ） |
 | [`packages/server`](packages/server/) | `@o3co/auth.policy-verifier.server` | Express サーバー、`createApp`、`POST /verify`、JWT 鍵リゾルバ |
 | [`templates/standalone`](templates/standalone/) | — | デプロイ可能なサーバーテンプレート (コンポジションルート) |
 | [`create-app`](create-app/) | `@o3co/create-auth-policy-verifier` | CLI スキャフォルダー |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > This repository handles **authorization decision** in the three-layer separation of concerns ([authentication & token issuance](https://github.com/o3co/auth.provider) / authorization decision / [authorization enforcement](https://github.com/o3co/protobuf.interceptors)) of the [auth](https://github.com/o3co/auth) stack.
 
-Attribute-based access control (ABAC) engine for microservice authorization. Receives a JWT + resource + action, evaluates collector-driven rules, and returns allow/deny. No policy DSL — authorization logic is composed in TypeScript.
+Attribute-based access control (ABAC) engine for microservice authorization. Receives a JWT + resource + action, evaluates collector-driven rules, and returns allow/deny. No policy DSL required — authorization logic is composed in TypeScript.
 
 - Drop-in replaceable with OPA or Cedar — [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) can route to this service, OPA, or Cedar Agent via a common `VerifierEndpoint` interface
 - Runs as an HTTP sidecar — swapping engines is a config change, not a code change
@@ -67,12 +67,13 @@ so the enforcement layer can implement against the same table.
 - **JWKS support** — Point `jwksUri` at auth.provider's `https://.../.well-known/jwks.json` for automatic key rotation. The endpoint must be TLS-protected (loopback hosts excepted for local development), and the fetch is bounded by an operator-set timeout, cooldown and cache age so a provider outage cannot stall the decision path.
 - **Answerable in production** — one structured `decision` event per decision (subject, resource, action, the rule that decided, request id, latency) and a Prometheus `/metrics` endpoint with allow/deny counters. Every metric label is bounded; the bearer token, the claim set beyond `sub`, and the caller's `context` never reach the log. See [Observability](#observability).
 - **Pluggable architecture** — Module system for registering custom collectors, rules, and resource parsers via factories.
-- **No DSL lock-in** — Authorization logic is TypeScript. No Rego, no Cedar policy language. If you outgrow this, swap to OPA or Cedar via [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) — the interceptor abstracts over the backend.
+- **No DSL lock-in** — Authorization logic is TypeScript; no DSL is ever required. Cedar is available as an *optional co-resident language* ([`packages/cedar`](packages/cedar/)): the real Cedar evaluator runs in-process as one rule group beside your TypeScript rules, deciding over collector-gathered facts with no entity store to build or sync. Whichever language you choose, the topology doesn't bind you — the same `.cedar` files later load unchanged into an embedded evaluator or a Cedar Agent, and [protobuf.interceptors](https://github.com/o3co/protobuf.interceptors) can still swap the whole backend for OPA or Cedar behind the common `VerifierEndpoint`.
 
 ## When to choose this
 
 - Policy authors are developers, and you don't want to learn a DSL → **this**
-- Policies are edited by non-developers, or you need formal verification → **[Cedar](https://www.cedarpolicy.com/)**
+- You want Cedar's policy language without building and syncing an entity store → **this, with [`packages/cedar`](packages/cedar/)**; when you outgrow it (hierarchy traversal, an entity store), the same `.cedar` files move to a full Cedar deployment unchanged
+- Policies are edited by non-developers, or you need formal verification over the whole policy surface → **[Cedar](https://www.cedarpolicy.com/)**
 - You need org-wide policy infrastructure with a large built-in operator surface → **[OPA](https://www.openpolicyagent.org/)**
 
 ## Quick Start
@@ -149,6 +150,7 @@ standalone → server   → core
 | --- | --- | --- |
 | [`packages/core`](packages/core/) | `@o3co/auth.policy-verifier.core` | Types, evaluate, pipelines, Module infrastructure |
 | [`packages/builtins`](packages/builtins/) | `@o3co/auth.policy-verifier.builtins` | Built-in collectors, rules, resource parser |
+| [`packages/cedar`](packages/cedar/) | `@o3co/auth.policy-verifier.cedar` | Optional co-resident Cedar policy evaluation, one rule group per policy set |
 | [`packages/server`](packages/server/) | `@o3co/auth.policy-verifier.server` | Express server, `createApp`, `POST /verify`, JWT key resolver |
 | [`templates/standalone`](templates/standalone/) | — | Deployable server template (composition root) |
 | [`create-app`](create-app/) | `@o3co/create-auth-policy-verifier` | CLI scaffolder |


### PR DESCRIPTION
Docs-only. Completes the README follow-up from #185 / #187 so v0.6.0 ships coherent with its own announcement: the root READMEs still described Cedar only as an external swap target, which `packages/cedar` now contradicts.

Three positioning sites updated in both languages, identity intact:

- **"No DSL lock-in" stays**, sharpened — no DSL is ever required; Cedar is an *optional co-resident language*; whichever language you choose, the topology doesn't bind you (same `.cedar` files load unchanged into an embedded evaluator or Cedar Agent later).
- **"When to choose this"** gains the middle row — Cedar's language without an entity store to build/sync → this + `packages/cedar`; the entity-store/hierarchy line is the stated criterion for moving to full Cedar (the line doubles as the migration signal).
- **Packages table** lists `packages/cedar`.

Intro line tightened one word: "No policy DSL" → "No policy DSL required" (the ja intro already said 不要).

🤖 Generated with [Claude Code](https://claude.com/claude-code)