### PR TITLE
fix(server): serve the liveness probe at /_healthcheck like the rest of the stack, keep /healthcheck as an alias

### DIFF
--- a/packages/server/README.ja.md
+++ b/packages/server/README.ja.md
@@ -30,7 +30,7 @@ function createApp(options: CreateAppOptions): Promise<express.Express>
 2. `modules` の各モジュールに対して `mod.init(context)` を順に呼び出し、各モジュールがファクトリ関数を登録できるようにする。
 3. `config.attribute.collectors` と `config.rule.collectors` の各エントリについて、`collector` 名で登録済みファクトリを検索して AttributeCollector と RuleCollector を生成する。
 4. `config.resource.parser` から ResourceParser を生成する。
-5. `config.http.pathPrefix` 以下に `GET /healthcheck`・任意の caller 認証ゲート・`POST /verify` をこの順にマウントする。
+5. `config.http.pathPrefix` 以下に liveness probe（`GET /_healthcheck` — スタックの全コンポーネントが応答するパス。`GET /healthcheck` は互換 alias として残す）・任意の caller 認証ゲート・`POST /verify` をこの順にマウントする。
 6. 設定済みの `express.Express` インスタンスを返す。
 
 `pathResolver` には、コンポジションルート側の `import.meta.resolve`（または互換リゾルバー）を渡します。モジュール相対パスの解決が必要なモジュールに渡されます。
@@ -163,7 +163,7 @@ HOCON の `${?VAR}` 置換が渡す文字列のいずれかで到着し、その
 これを抑えるのが次の 2 つの設定です。
 
 - **`http.hostname` の既定値は `127.0.0.1`。** 本プロジェクトが想定するのはサイドカー構成 — enforcement 層が verifier と同居し、ループバック経由で到達する形です。全インターフェースへの bind は明示的なオプトイン（`http.hostname = "0.0.0.0"`）であり、コンテナデプロイではこれを設定しない限り到達できません。
-- **`http.callerAuth.token` は呼び出し元サービスを認証します。** 設定すると、`/verify` と `/verify/batch` への全リクエストがその値を `http.callerAuth.header`（既定 `x-caller-token`。`Authorization` を避けているのは意図的）にそのまま載せる必要があります。比較は定数時間で、body のパースより前・パイプライン処理より前に走るため、未認証のピアはプロセスの処理時間を消費できません。資格情報の欠落と誤りは同一の `401 { decision: "deny", code: "caller_unauthenticated", message: "Caller authentication failed" }` を返します — 推測した値が正しい形だったかを探索者に教えてはならないからです。`GET /healthcheck` は常に非ゲートで、オーケストレーターの probe はそのまま動作します。
+- **`http.callerAuth.token` は呼び出し元サービスを認証します。** 設定すると、`/verify` と `/verify/batch` への全リクエストがその値を `http.callerAuth.header`（既定 `x-caller-token`。`Authorization` を避けているのは意図的）にそのまま載せる必要があります。比較は定数時間で、body のパースより前・パイプライン処理より前に走るため、未認証のピアはプロセスの処理時間を消費できません。資格情報の欠落と誤りは同一の `401 { decision: "deny", code: "caller_unauthenticated", message: "Caller authentication failed" }` を返します — 推測した値が正しい形だったかを探索者に教えてはならないからです。`GET /_healthcheck` は常に非ゲートで、オーケストレーターの probe はそのまま動作します。
 
 caller 認証は**本リリースでは任意**です。未設定かつ bind がループバックでない場合、`createApp` は `unauthenticated_non_loopback_bind` を warn で記録します — 本当に危険な組み合わせを、塞ぐのではなく名指しします。必須化は `config/defaults` の `CALLER_AUTH_REQUIRED` の 1 行変更で行えます（同定数の doc コメント参照）。
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -30,7 +30,7 @@ Steps performed:
 2. Calls `mod.init(context)` for each module in order, allowing each to register factory functions.
 3. Instantiates attribute collectors and rule collectors from `config.attribute.collectors` and `config.rule.collectors` by looking up the registered factory for each `collector` name.
 4. Instantiates the resource parser from `config.resource.parser`.
-5. Mounts `GET /healthcheck`, the optional caller-authentication gate, then `POST /verify` and `POST /verify/batch` under `config.http.pathPrefix`.
+5. Mounts the liveness probe (`GET /_healthcheck`, the path every component of the stack answers on, with `GET /healthcheck` kept as a compatibility alias), the optional caller-authentication gate, then `POST /verify` and `POST /verify/batch` under `config.http.pathPrefix`.
 6. Returns the configured `express.Express` instance.
 
 `pathResolver` must be `import.meta.resolve` (or a compatible resolver) from the composition root. It is passed to modules that need to resolve module-relative paths.
@@ -164,7 +164,7 @@ The bearer token on `/verify` establishes the **subject** a decision is about. I
 Two settings bound that exposure:
 
 - **`http.hostname` defaults to `127.0.0.1`.** The deployment this project targets is a sidecar — the enforcement layer runs alongside the verifier and reaches it over loopback. Binding all interfaces is an explicit opt-in (`http.hostname = "0.0.0.0"`), which a containerised deployment must set to be reachable at all.
-- **`http.callerAuth.token` authenticates the calling service.** When set, every request to `/verify` and `/verify/batch` must carry that credential verbatim in `http.callerAuth.header` (default `x-caller-token`, deliberately not `Authorization`). The comparison is constant-time, and it runs before the body is parsed and before any pipeline work, so an unauthenticated peer costs the process nothing. A missing credential and a wrong one get the same `401 { decision: "deny", code: "caller_unauthenticated", message: "Caller authentication failed" }` — the rejection must not tell a prober whether their guess had the right shape. `GET /healthcheck` is never gated, so orchestrator probes keep working.
+- **`http.callerAuth.token` authenticates the calling service.** When set, every request to `/verify` and `/verify/batch` must carry that credential verbatim in `http.callerAuth.header` (default `x-caller-token`, deliberately not `Authorization`). The comparison is constant-time, and it runs before the body is parsed and before any pipeline work, so an unauthenticated peer costs the process nothing. A missing credential and a wrong one get the same `401 { decision: "deny", code: "caller_unauthenticated", message: "Caller authentication failed" }` — the rejection must not tell a prober whether their guess had the right shape. `GET /_healthcheck` is never gated, so orchestrator probes keep working.
 
 Caller authentication is **optional in this release**. When it is not configured and the bind is not loopback, `createApp` logs `unauthenticated_non_loopback_bind` at warn — the genuinely dangerous combination, named rather than blocked. Making it mandatory is a one-line change to `CALLER_AUTH_REQUIRED` in `config/defaults`; see that constant's doc comment.
 

--- a/packages/server/src/__tests__/app.test.mts
+++ b/packages/server/src/__tests__/app.test.mts
@@ -270,15 +270,33 @@ describe("createApp", () => {
 		expect(res.body.code).toBe("invalid_token");
 	});
 
-	it("includes healthcheck endpoint", async () => {
+	it("serves the liveness probe at /_healthcheck", async () => {
+		// The path every component of the stack answers on (o3co/auth.provider#293).
 		const app = await createApp({
 			pathResolver: (s: string) => s,
 			config: testConfig,
 			modules: [testModule, builtinKeyResolversModule],
 		});
 
-		const res = await request(app).get("/healthcheck");
+		const res = await request(app).get("/_healthcheck");
 		expect(res.status).toBe(200);
+		expect(res.body).toEqual({ status: "ok" });
+	});
+
+	it("keeps /healthcheck answering identically as a compatibility alias", async () => {
+		// The path this server answered on before the stack settled on
+		// `/_healthcheck`. An orchestrator probe config that was not updated must
+		// not start failing on upgrade, so the alias gives the canonical answer.
+		const app = await createApp({
+			pathResolver: (s: string) => s,
+			config: testConfig,
+			modules: [testModule, builtinKeyResolversModule],
+		});
+
+		const canonical = await request(app).get("/_healthcheck");
+		const alias = await request(app).get("/healthcheck");
+		expect(alias.status).toBe(200);
+		expect(alias.body).toEqual(canonical.body);
 	});
 
 	it("starts successfully and decodes tokens in insecure-decode mode with no key material", async () => {
@@ -753,18 +771,23 @@ describe("createApp caller authentication (#108)", () => {
 		expect(res.body.code).toBe("caller_unauthenticated");
 	});
 
-	it("leaves the healthcheck reachable without a credential", async () => {
-		// The container healthcheck (and every orchestrator probe) has no
-		// credential to present; gating liveness would make the service unschedulable.
-		const app = await createApp({
-			pathResolver: (s: string) => s,
-			config: guardedConfig,
-			modules: [testModule, builtinKeyResolversModule],
-		});
+	it.each(["/_healthcheck", "/healthcheck"])(
+		"leaves the liveness probe at %s reachable without a credential",
+		async (path) => {
+			// The container healthcheck (and every orchestrator probe) has no
+			// credential to present; gating liveness would make the service
+			// unschedulable. The compatibility alias is covered too: a probe config
+			// that still names it must not start being rejected on upgrade.
+			const app = await createApp({
+				pathResolver: (s: string) => s,
+				config: guardedConfig,
+				modules: [testModule, builtinKeyResolversModule],
+			});
 
-		const res = await request(app).get("/healthcheck");
-		expect(res.status).toBe(200);
-	});
+			const res = await request(app).get(path);
+			expect(res.status).toBe(200);
+		},
+	);
 
 	it("serves decisions with no caller credential configured — the gate is opt-in", async () => {
 		// Deliberately optional in this pass: container deployments and the

--- a/packages/server/src/app.mts
+++ b/packages/server/src/app.mts
@@ -71,18 +71,30 @@ function assertConfigObject(value: unknown, path: string): asserts value is obje
 }
 
 /**
+ * Where the liveness probe answers, under `config.http.pathPrefix`.
+ *
+ * `/_healthcheck` is the canonical path: the one every component of the stack
+ * serves (auth.provider and auth.proxy already did — o3co/auth.provider#293
+ * item 14) and the one the standalone image's `HEALTHCHECK` probes. This server
+ * answered on `/healthcheck` before the stack settled on one spelling; it is
+ * kept as a compatibility alias so an orchestrator probe config that was not
+ * updated does not start failing on upgrade. Both paths give the same answer.
+ */
+const LIVENESS_PATHS = ["/_healthcheck", "/healthcheck"] as const;
+
+/**
  * Builds the Express app with registries initialized by the supplied modules.
  *
  * Flow: (1) create registries, (2) run `mod.init` sequentially so later modules
  * can see earlier ones' registrations, (3) resolve concrete collectors /
- * resource parser / key resolver from config, (4) mount the healthcheck, the
- * optional caller-auth gate and the `/verify` router under the configured path
- * prefix.
+ * resource parser / key resolver from config, (4) mount the liveness probe
+ * (`LIVENESS_PATHS`), the optional caller-auth gate and the `/verify` router
+ * under the configured path prefix.
  *
  * `config.http.callerAuth.token` authenticates the *calling service* before any
- * decision work runs (#108). It is optional in this release; the healthcheck is
- * never gated. See `CALLER_AUTH_REQUIRED` in `config/defaults` for the one-line
- * change that makes it mandatory.
+ * decision work runs (#108). It is optional in this release; the liveness probe
+ * is never gated. See `CALLER_AUTH_REQUIRED` in `config/defaults` for the
+ * one-line change that makes it mandatory.
  *
  * `config.oauth.jwt.mode = "insecure-decode"` disables signature verification
  * and only decodes the token (the time claims are still enforced in full —
@@ -263,9 +275,12 @@ export async function createApp(options: CreateAppOptions): Promise<express.Expr
 	// including the responses produced before any route runs, such as the
 	// caller-auth gate's 401s. A surge of those is exactly what it exists to show.
 	app.use(metrics.middleware);
-	// Healthcheck stays open: an orchestrator probe has no credential to present,
-	// and it reveals nothing a decision does.
-	app.use(prefix, createHealthcheckRouter());
+	// The liveness probe stays open on both its canonical path and its alias:
+	// an orchestrator probe has no credential to present, and it reveals nothing
+	// a decision does.
+	for (const path of LIVENESS_PATHS) {
+		app.use(prefix, createHealthcheckRouter(path));
+	}
 	// `/metrics` is ungated for the same reason, and one more (#111). Prometheus
 	// scrape configs carry `authorization`, `basic_auth` and `oauth2` — not an
 	// arbitrary header — so gating it behind `http.callerAuth`'s `x-caller-token`

--- a/templates/standalone/Dockerfile
+++ b/templates/standalone/Dockerfile
@@ -91,8 +91,10 @@ EXPOSE ${HTTP_PORT}
 # operator's port — the config reads `${?HTTP_PORT}`, so app.listen() and the
 # probe stay in sync. Shell form, so both expand at probe time.
 #
-# `GET /healthcheck` is never gated by `http.callerAuth`, so setting
-# HTTP_CALLER_AUTH_TOKEN does not require a credential here.
+# `GET /_healthcheck` is the liveness path every component of the stack answers
+# on (`/healthcheck` stays as a compatibility alias). It is never gated by
+# `http.callerAuth`, so setting HTTP_CALLER_AUTH_TOKEN does not require a
+# credential here.
 #
 # The deployment where loopback is genuinely correct — a sidecar sharing a
 # network namespace with its caller — is the one shape this check is wrong for.
@@ -101,7 +103,7 @@ EXPOSE ${HTTP_PORT}
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD addr="$(hostname -i | cut -d' ' -f1)"; \
       case "$addr" in *:*) addr="[$addr]" ;; esac; \
-      wget -q -O /dev/null "http://${addr}:${HTTP_PORT}${HTTP_PATH_PREFIX%/}/healthcheck" || exit 1
+      wget -q -O /dev/null "http://${addr}:${HTTP_PORT}${HTTP_PATH_PREFIX%/}/_healthcheck" || exit 1
 
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "dist/main.mjs"]

--- a/templates/standalone/README.ja.md
+++ b/templates/standalone/README.ja.md
@@ -93,7 +93,7 @@ x-caller-token: <secret>
 Authorization: Bearer <jwt>
 ```
 
-それ以外は body のパースより前に `401 { "decision": "deny", "code": "caller_unauthenticated", "message": "Caller authentication failed" }` を返します。`GET /healthcheck` は常に非ゲートなので、コンテナの healthcheck はそのまま動作します。
+それ以外は body のパースより前に `401 { "decision": "deny", "code": "caller_unauthenticated", "message": "Caller authentication failed" }` を返します。`GET /_healthcheck` は常に非ゲートなので、コンテナの healthcheck はそのまま動作します。
 
 資格情報を未設定のままにする運用もサポートされており、ループバックであれば問題ありません。ループバック以外に bind した場合は起動時に `unauthenticated_non_loopback_bind` が warn で記録されます — 修正する価値があるのはこの組み合わせです。
 
@@ -303,8 +303,11 @@ tag と digest を意図的に一緒に上げます。
 アドレスを叩けば呼び出し元と同じ問いになるため、`HTTP_HOSTNAME=0.0.0.0` の
 付け忘れは隠れずに `unhealthy` として現れます。
 
-`GET /healthcheck` は `http.callerAuth` で決してゲートされないので、probe に
-資格情報は不要です。`HTTP_PATH_PREFIX` と `HTTP_PORT` には追従します。
+probe が叩くのは `GET /_healthcheck` で、スタックの全コンポーネントが応答する
+liveness パスです。以前このイメージが probe していた `GET /healthcheck` は互換
+alias として残しているので、そのパスのままの probe 設定でも動き続けます。
+どちらも `http.callerAuth` でゲートされないので、probe に資格情報は不要です。
+`HTTP_PATH_PREFIX` と `HTTP_PORT` には追従します。
 
 例外は 1 つ、呼び出し元と network namespace を共有する sidecar 構成です。
 そこでは loopback bind が正しく、到達可能アドレスでは何も listen していま

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -94,7 +94,7 @@ x-caller-token: <secret>
 Authorization: Bearer <jwt>
 ```
 
-Anything else gets `401 { "decision": "deny", "code": "caller_unauthenticated", "message": "Caller authentication failed" }`, decided before the body is parsed. `GET /healthcheck` is never gated, so the container healthcheck keeps working.
+Anything else gets `401 { "decision": "deny", "code": "caller_unauthenticated", "message": "Caller authentication failed" }`, decided before the body is parsed. `GET /_healthcheck` is never gated, so the container healthcheck keeps working.
 
 Leaving the credential unset is supported and is fine on loopback. On a non-loopback bind the server logs `unauthenticated_non_loopback_bind` at warn on boot — that combination is the one worth fixing.
 
@@ -306,7 +306,10 @@ server is bound to loopback and no caller can reach it — it would report
 container is actually reachable at asks the same question a caller does, so
 forgetting `HTTP_HOSTNAME=0.0.0.0` shows up as `unhealthy` instead of hiding.
 
-`GET /healthcheck` is never gated by `http.callerAuth`, so the probe needs no
+The probe hits `GET /_healthcheck`, the liveness path every component of the
+stack answers on. `GET /healthcheck` — the path this image probed before — is
+kept as a compatibility alias, so a probe config that still names it keeps
+working. Neither is gated by `http.callerAuth`, so the probe needs no
 credential. It follows `HTTP_PATH_PREFIX` and `HTTP_PORT`.
 
 One deployment shape is the exception: a sidecar sharing a network namespace

--- a/templates/standalone/src/__tests__/smoke.test.mts
+++ b/templates/standalone/src/__tests__/smoke.test.mts
@@ -101,7 +101,18 @@ function createShippedApp(config: AppConfig = shippedConfig) {
 }
 
 describe("standalone smoke", () => {
-	it("GET /healthcheck returns 200", async () => {
+	it("GET /_healthcheck returns 200", async () => {
+		// The liveness path the Dockerfile's HEALTHCHECK probes, and the one every
+		// component of the stack answers on (o3co/auth.provider#293).
+		const app = await createShippedApp();
+
+		const res = await request(app).get("/_healthcheck");
+		expect(res.status).toBe(200);
+	});
+
+	it("GET /healthcheck returns 200 as a compatibility alias", async () => {
+		// The path this image probed before; a probe config that still names it
+		// must keep working.
 		const app = await createShippedApp();
 
 		const res = await request(app).get("/healthcheck");


### PR DESCRIPTION
## What

- `createApp` mounts the `@o3co/auth.utils` healthcheck router on two paths under `config.http.pathPrefix`: `GET /_healthcheck` (canonical) and `GET /healthcheck` (compatibility alias). Both answer identically (`200 {"status":"ok"}`) and neither is gated by `http.callerAuth`.
- The standalone image's `HEALTHCHECK` probes `/_healthcheck`.
- `packages/server/README.md` / `README.ja.md`, `templates/standalone/README.md` / `README.ja.md` and the Dockerfile comment name `/_healthcheck` as the primary spelling and note the alias once.
- `CHANGELOG.md` deliberately untouched.

## Why

Cross-stack probe consistency — o3co/auth.provider#293 item 14. auth.provider and auth.proxy already answer liveness on `/_healthcheck`; this server was the odd one out on `/healthcheck` (the `@o3co/auth.utils` default), so a probe config had to know which component it pointed at. The alias means an orchestrator probe config that is not updated does not start failing on upgrade; it is documented as the compatibility spelling, with no removal schedule (per the stack's release policy).

The umbrella side (E2E probe path + a stack-level "Probes" section in `docs/architecture.md`) is o3co/auth#18 (https://github.com/o3co/auth/pull/18), a draft that depends on this one being merged first, because the umbrella E2E clones each sibling from its default branch.

## Tests

TDD — the `/_healthcheck` tests were written first and failed (404 on the new path; 401 behind the caller-auth gate), then the mount was changed:

- `packages/server/src/__tests__/app.test.mts`: `serves the liveness probe at /_healthcheck`, `keeps /healthcheck answering identically as a compatibility alias`, and the caller-auth case `leaves the liveness probe at %s reachable without a credential` over both paths.
- `templates/standalone/src/__tests__/smoke.test.mts`: `GET /_healthcheck returns 200` plus the alias case.
- `pnpm run lint` / `pnpm -r run typecheck` / `pnpm run test` all exit 0 (749 server tests, 63 template tests).

Refs o3co/auth.provider#293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
