### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and version sections follow the release labeling policy in
 [`docs/release-policy.md`](docs/release-policy.md).
 
+## [0.7.0] - 2026-09-04
+
+### Changed
+
+- **Liveness is served at `GET /_healthcheck`, with `GET /healthcheck` kept as
+  an alias** ([o3co/auth.provider#293](https://github.com/o3co/auth.provider/issues/293)
+  item 14). `auth.provider` and `auth.proxy` answer liveness on `/_healthcheck`
+  while this server answered on `/healthcheck` (the `@o3co/auth.utils`
+  default), so a probe configuration had to know which component it was pointed
+  at. `createApp` now mounts the healthcheck router on both paths:
+  `/_healthcheck` is the canonical spelling across the stack, and `/healthcheck`
+  stays as a compatibility alias so an orchestrator probe that was not updated
+  does not start failing on upgrade. Both answer identically, and neither is
+  gated by `http.callerAuth`.
+
+  The standalone image's `HEALTHCHECK` and every README name `/_healthcheck` as
+  the primary path and note the alias once.
+
 ## [0.6.0] - 2026-09-03
 
 ### Added


### PR DESCRIPTION
develop の v0.6.0 以降 1 commit ぶんの CHANGELOG セクションを cut 時点で stamp する (docs/release-policy.md R2/R6)。コード変更なし。

`release.yml` は publish の前に `## [0.7.0]` 見出しの存在を検証するので、この commit が無いと tag が落ちる。

- o3co/auth.provider#293 item 14 — liveness を stack 共通の `/_healthcheck` に統一、`/healthcheck` は互換 alias として維持

内部利用に向けた凍結の一環。マージ後 `v0.7.0` を tag する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)