### PR TITLE
ci: run pnpm audit in its own daily job, and publish prerelease tags under dist-tag next as GitHub prereleases (#203, #204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
-  # Daily audit of develop (see the `audit` job). Nothing else runs on this
-  # trigger: build-and-test is gated on the event below.
+  # Daily audit (see the `audit` job). A `schedule` event runs on the
+  # repository's default branch — `develop` here — so this is a daily audit of
+  # develop only as long as develop stays the default branch. Nothing else runs
+  # on this trigger: build-and-test is gated on the event below.
   schedule:
     - cron: '23 3 * * *'
 
@@ -181,8 +183,9 @@ jobs:
   # It used to be a step of build-and-test — the one required status check — so
   # an outage of registry.npmjs.org's audit endpoint blocked every merge (three
   # consecutive release-PR failures on ERR_SOCKET_TIMEOUT, 2026-09-04). It now
-  # runs on every push and pull request (visible on the PR) and daily on develop
-  # so an advisory published between pushes is caught. Deliberately not a
+  # runs on every push and pull request (visible on the PR) and daily on the
+  # default branch (`develop`; `schedule` events always run there) so an
+  # advisory published between pushes is caught. Deliberately not a
   # required check: a finding on a PR is a red check the reviewer sees, not a
   # merge held hostage to a third-party endpoint.
   audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,14 @@ on:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
+  # Daily audit of develop (see the `audit` job). Nothing else runs on this
+  # trigger: build-and-test is gated on the event below.
+  schedule:
+    - cron: '23 3 * * *'
 
 jobs:
   build-and-test:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,16 +34,6 @@ jobs:
           restore-keys: pnpm-store-
 
       - run: pnpm install --frozen-lockfile
-
-      # `pnpm audit --prod --audit-level=low`. Runs before lint/build so a known
-      # advisory in a shipped dependency fails fast and is not buried under a
-      # test log. `--prod` scopes it to what consumers actually install; the
-      # `--audit-level=low` floor is deliberate — this is an authorization
-      # service, and a "low" DoS in the request-parsing path is not cosmetic.
-      #
-      # Same entry point as `make audit`, so a contributor reproduces this
-      # locally with one command instead of re-deriving the flags.
-      - run: pnpm run audit
 
       - run: pnpm run lint
 
@@ -178,6 +173,42 @@ jobs:
   # build resolves. Catches the class of defect where the template references a
   # symbol that is not in the published tarball — invisible in the workspace,
   # where `src/` is right there, and only observable after the tag is pushed.
+  # `pnpm audit --prod --audit-level=low` in its own job (#204). `--prod`
+  # scopes it to what consumers actually install; the `--audit-level=low` floor
+  # is deliberate — this is an authorization service, and a "low" DoS in the
+  # request-parsing path is not cosmetic. Same entry point as `make audit`.
+  #
+  # It used to be a step of build-and-test — the one required status check — so
+  # an outage of registry.npmjs.org's audit endpoint blocked every merge (three
+  # consecutive release-PR failures on ERR_SOCKET_TIMEOUT, 2026-09-04). It now
+  # runs on every push and pull request (visible on the PR) and daily on develop
+  # so an advisory published between pushes is caught. Deliberately not a
+  # required check: a finding on a PR is a red check the reviewer sees, not a
+  # merge held hostage to a third-party endpoint.
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run audit
+
   publish-readiness:
     runs-on: ubuntu-latest
     needs: build-and-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,22 @@ jobs:
             exit 1
           fi
 
-          # The one place the tag is parsed. Later steps read this output
-          # instead of re-deriving the version from GITHUB_REF, so the tag
+          # The one place the tag is parsed. Later steps read these outputs
+          # instead of re-deriving anything from GITHUB_REF, so the tag
           # grammar cannot drift between two copies of the same expression.
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          # A prerelease identifier (v1.0.0-rc1, v2.0.0-beta.2) must neither
+          # move npm's `latest` dist-tag nor be listed as a full GitHub Release
+          # (#203). PRERELEASE above already validated the shape; here it only
+          # has to be present.
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Get pnpm store path
         id: pnpm-store
@@ -101,6 +113,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           draft: true
+          prerelease: ${{ steps.release.outputs.prerelease == 'true' }}
           generate_release_notes: true
 
       # `pnpm -r publish` decides package by package: it asks the registry about
@@ -123,11 +136,17 @@ jobs:
       #
       # templates/standalone and tests/integration are `private: true`, so pnpm
       # never offers them to the registry.
+      # `--tag` is the npm dist-tag: `latest` for a final release, `next` for a
+      # prerelease, so `npm install @o3co/<pkg>` never resolves to an RC. A final
+      # release after an RC moves `latest` forward as before.
       - name: Publish packages
-        run: pnpm -r publish --access public --no-git-checks --provenance
+        env:
+          NPM_TAG: ${{ steps.release.outputs.npm_tag }}
+        run: pnpm -r publish --access public --no-git-checks --provenance --tag "$NPM_TAG"
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           draft: false
+          prerelease: ${{ steps.release.outputs.prerelease == 'true' }}
           generate_release_notes: true


### PR DESCRIPTION
Workflow-only changes; no package code. Mirrors o3co/auth.provider's change for #476/#477.

## Audit as its own job (#204)

`pnpm run audit` moves out of `build-and-test` (the required status check) into an `audit` job that runs on every push / PR and daily on `develop`; `build-and-test` is gated off the `schedule` event. Three consecutive release-PR failures on `ERR_SOCKET_TIMEOUT` against the npm audit endpoint on 2026-09-04 (#202) blocked merges with no change in the PR. Findings still show as a red check on the PR; `--prod` and `--audit-level=low` unchanged.

## Prerelease tags (#203)

The existing `Verify tag and CHANGELOG` step now also emits `prerelease` / `npm_tag`. `pnpm -r publish … --tag next` for a prerelease identifier, `--tag latest` otherwise; both `softprops/action-gh-release` steps get `prerelease:` from the same output. Verified locally as YAML only (the workflow runs on the next tag).

Closes #203
Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)