### PR TITLE
docs(changelog): record the release-workflow and audit-job changes under 0.7.0 (#203, #204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ and version sections follow the release labeling policy in
   The standalone image's `HEALTHCHECK` and every README name `/_healthcheck` as
   the primary path and note the alias once.
 
+- **A prerelease tag publishes under npm dist-tag `next` and as a GitHub prerelease** (#203). `release.yml`
+  published every `v*` tag under npm's default `latest` and as a full GitHub
+  Release, so pushing a prerelease tag (`vX.Y.Z-rc.1`) would have made the
+  release candidate what `npm install @o3co/auth.policy-verifier.core` resolves
+  to for every consumer. The step that already validates the tag now also
+  classifies it, and the publish and both release steps read that
+  classification. A final release moves `latest` forward as before.
+
+### Documentation
+
+- **`pnpm audit` runs in its own CI job, on every push and pull request and daily
+  on the default branch** (#204). It was a step of `build-and-test`, the one
+  required status check, so an outage of the npm audit endpoint blocked every
+  merge — three consecutive failures on `ERR_SOCKET_TIMEOUT` while cutting this
+  release, with no change in the pull requests themselves. A finding is still a
+  red check the reviewer sees; it is no longer a merge held hostage to a
+  third-party endpoint. `--prod` and the deliberate `--audit-level=low` floor
+  are unchanged.
+
 ## [0.6.0] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ and version sections follow the release labeling policy in
   classifies it, and the publish and both release steps read that
   classification. A final release moves `latest` forward as before.
 
-### Documentation
-
 - **`pnpm audit` runs in its own CI job, on every push and pull request and daily
   on the default branch** (#204). It was a step of `build-and-test`, the one
   required status check, so an outage of the npm audit endpoint blocked every


### PR DESCRIPTION
CHANGELOG only.

The `## [0.7.0]` section was stamped in #202 before #205 merged, so it covers only the liveness-path change and not the two operator-visible changes that landed after it:

- **#203** — a prerelease tag now publishes under npm dist-tag `next` and as a GitHub prerelease. This decides what `npm install @o3co/auth.policy-verifier.core` resolves to when a release candidate is tagged, so it belongs in the notes for the release that introduces it.
- **#204** — `pnpm audit` moved out of the required `build-and-test` check into its own job. It changes what blocks a merge.

The `v0.7.0` tag is not cut yet, so the section is extended rather than deferred. Matches what o3co/auth.proxy did for the same pair of changes in its `0.4.0` section, and what o3co/auth.provider#466 does for `0.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)